### PR TITLE
Fix flaky websocket server test

### DIFF
--- a/extension/observiq/websocket/websocket_test.go
+++ b/extension/observiq/websocket/websocket_test.go
@@ -296,8 +296,16 @@ func (s *Server) Start() {
 	}
 	ready := make(chan struct{})
 	go func() {
+		addr := s.httpServer.Addr
+		if addr == "" {
+			addr = ":http"
+		}
+
+		ln, _ := net.Listen("tcp", addr)
+
 		ready <- struct{}{}
-		_ = s.httpServer.ListenAndServe()
+
+		_ = s.httpServer.Serve(ln)
 	}()
 	<-ready
 }


### PR DESCRIPTION
Wait to actually be listening to signal ready

### Proposed Change
* Listen on tcp before signaling ready to avoid race condition in tests

##### Checklist
- [x] Changes are tested
- [x] Changes are documented
