### PR TITLE
logsreceiver transforms

### DIFF
--- a/pkg/receiver/logsreceiver/converter_test.go
+++ b/pkg/receiver/logsreceiver/converter_test.go
@@ -34,7 +34,7 @@ func BenchmarkConvertSimple(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		convert(ent)
+		convert(ent, nil)
 	}
 }
 
@@ -44,7 +44,7 @@ func BenchmarkConvertComplex(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		convert(ent)
+		convert(ent, nil)
 	}
 }
 
@@ -403,7 +403,7 @@ func TestConverterCancelledContextCancellsTheFlush(t *testing.T) {
 		pLogs := pdata.NewLogs()
 		ills := pLogs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty()
 
-		lr := convert(complexEntry())
+		lr := convert(complexEntry(), nil)
 		lr.CopyTo(ills.Logs().AppendEmpty())
 
 		assert.Error(t, converter.flush(ctx, pLogs))
@@ -421,7 +421,7 @@ func TestConvertMetadata(t *testing.T) {
 	e.AddAttribute("one", "two")
 	e.Body = true
 
-	result := convert(e)
+	result := convert(e, nil)
 
 	atts := result.Attributes()
 	require.Equal(t, 1, atts.Len(), "expected 1 attribute")
@@ -591,7 +591,7 @@ func anyToBody(body interface{}) pdata.AttributeValue {
 }
 
 func convertAndDrill(entry *entry.Entry) pdata.LogRecord {
-	return convert(entry)
+	return convert(entry, nil)
 }
 
 func TestConvertSeverity(t *testing.T) {

--- a/pkg/receiver/logsreceiver/factory.go
+++ b/pkg/receiver/logsreceiver/factory.go
@@ -80,8 +80,18 @@ func createLogsReceiver(
 		return nil, err
 	}
 
+	pluginIdToConfig := map[string]map[string]interface{}{}
+	for _, conf := range stanzaCfg.Pipeline {
+		if id, ok := conf["id"]; ok {
+			if idStr, ok := id.(string); ok {
+				pluginIdToConfig[idStr] = conf
+			}
+		}
+	}
+
 	opts := []ConverterOption{
 		WithLogger(params.Logger),
+		WithIdToPipelineConfigMap(pluginIdToConfig),
 	}
 	if stanzaCfg.Converter.MaxFlushCount > 0 {
 		opts = append(opts, WithMaxFlushCount(stanzaCfg.Converter.MaxFlushCount))

--- a/pkg/receiver/logsreceiver/receiver_test.go
+++ b/pkg/receiver/logsreceiver/receiver_test.go
@@ -204,7 +204,7 @@ func BenchmarkReadLine(b *testing.B) {
 	b.ResetTimer()
 	require.NoError(b, pl.Start(newMockPersister()))
 	for i := 0; i < b.N; i++ {
-		convert(<-emitter.logChan)
+		convert(<-emitter.logChan, nil)
 	}
 }
 
@@ -265,7 +265,7 @@ func BenchmarkParseAndMap(b *testing.B) {
 	b.ResetTimer()
 	require.NoError(b, pl.Start(newMockPersister()))
 	for i := 0; i < b.N; i++ {
-		convert(<-emitter.logChan)
+		convert(<-emitter.logChan, nil)
 	}
 }
 

--- a/pkg/receiver/logsreceiver/record_transform.go
+++ b/pkg/receiver/logsreceiver/record_transform.go
@@ -1,0 +1,269 @@
+package logsreceiver
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/observiq/observiq-collector/pkg/receiver/logsreceiver/severity"
+	"github.com/observiq/observiq-collector/pkg/receiver/logsreceiver/timestamp"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+// Transform performs various transformations to the LogRecord to transform it into a friendlier representation
+func Transform(le *pdata.LogRecord, idToPipelineConfig map[string]map[string]interface{}) {
+	promoteTimestamp(le)
+	promoteSeverity(le)
+	addPluginInfo(le, idToPipelineConfig)
+	convertClient(le)
+	convertStringArrays(le)
+	convertIntAndFloatFields(le)
+}
+
+var timestampFields = []string{
+	"@timestamp",
+	"timestamp",
+	"time",
+}
+
+// promoteTimestamp promotes one of the fields from timestampFields to the top-level timestamp, if one is found
+func promoteTimestamp(le *pdata.LogRecord) {
+	if le.Body().Type() != pdata.AttributeValueTypeMap {
+		return
+	}
+
+	bodyMap := le.Body().MapVal()
+
+	for _, tsField := range timestampFields {
+		if val, ok := bodyMap.Get(tsField); ok {
+			if ts, ok := timestamp.CoerceValToTimestamp(val); ok {
+				le.SetTimestamp(ts)
+				bodyMap.Delete(tsField)
+				return
+			}
+		}
+	}
+}
+
+// promoteSeverity looks for an integral "severity" field, and converts/promotes it to the top level of the record
+func promoteSeverity(le *pdata.LogRecord) {
+	if le.Body().Type() != pdata.AttributeValueTypeMap {
+		return
+	}
+
+	bodyMap := le.Body().MapVal()
+
+	if val, ok := bodyMap.Get("severity"); ok {
+		switch val.Type() {
+		case pdata.AttributeValueTypeInt:
+			v := val.IntVal()
+			le.SetSeverityNumber(severity.ConvertSeverity(v))
+			bodyMap.Delete("severity")
+		case pdata.AttributeValueTypeString:
+			v := val.StringVal()
+			if intVal, err := strconv.ParseInt(v, 10, 64); err == nil {
+				le.SetSeverityNumber(severity.ConvertSeverity(intVal))
+				bodyMap.Delete("severity")
+			}
+		}
+	}
+}
+
+// addPluginInfo adds extra information about the plugin that gathered the entry, if the 'plugin_id' is present on Attributes
+func addPluginInfo(le *pdata.LogRecord, idToPipelineConfig map[string]map[string]interface{}) {
+	if idToPipelineConfig == nil {
+		return
+	}
+
+	if pluginId, ok := le.Attributes().Get("plugin_id"); ok {
+		if pluginId.Type() == pdata.AttributeValueTypeString {
+			pluginIdStr := pluginId.StringVal()
+			pluginConf := idToPipelineConfig[pluginIdStr]
+
+			if pluginType, ok := pluginConf["type"]; ok {
+				if pluginTypeStr, ok := pluginType.(string); ok {
+					le.Attributes().Insert("plugin_type", pdata.NewAttributeValueString(pluginTypeStr))
+				}
+			}
+
+			if pluginName, ok := pluginConf["name"]; ok {
+				if pluginNameStr, ok := pluginName.(string); ok {
+					le.Attributes().Insert("plugin_name", pdata.NewAttributeValueString(pluginNameStr))
+				}
+			}
+
+			if pluginVersion, ok := pluginConf["version"]; ok {
+				if pluginVersionStr, ok := pluginVersion.(string); ok {
+					le.Attributes().Insert("plugin_version", pdata.NewAttributeValueString(pluginVersionStr))
+				}
+			}
+		}
+	}
+}
+
+// convertClient transforms the 'client' field on the body into its parts (ip (or address) and port)
+func convertClient(le *pdata.LogRecord) {
+	if le.Body().Type() != pdata.AttributeValueTypeMap {
+		return
+	}
+
+	bodyMap := le.Body().MapVal()
+
+	if clientData, ok := bodyMap.Get("client"); ok {
+		if clientData.Type() == pdata.AttributeValueTypeString {
+			clientDataStr := clientData.StringVal()
+			pdata.NewAttributeValueMap()
+
+			bodyMap.Delete("client")
+			bodyMap.Insert("client", parseIpPort(clientDataStr))
+		}
+	}
+}
+
+var arrayFields = []string{
+	"http_x_forwarded_for",
+	"remote",
+	"remote_addr",
+	"proxy_protocol_addr",
+	"proxy_add_x_forwarded_for",
+}
+
+// convertStringArrays converts known array fields that are encoded as strings into an array
+func convertStringArrays(le *pdata.LogRecord) {
+	if le.Body().Type() != pdata.AttributeValueTypeMap {
+		return
+	}
+
+	bodyMap := le.Body().MapVal()
+
+	for _, fieldName := range arrayFields {
+		if val, ok := bodyMap.Get(fieldName); ok {
+			if val.Type() != pdata.AttributeValueTypeString {
+				// Skip non-string values
+				continue
+			}
+
+			strVal := val.StringVal()
+
+			strVal = strings.TrimSpace(strVal)
+			if strVal[0] == '[' && strVal[len(strVal)-1] == ']' {
+				strVal = strVal[1 : len(strVal)-1]
+			}
+
+			strArr := strings.Split(strVal, ",")
+			arrAttrib := pdata.NewAttributeValueArray()
+			arrOut := arrAttrib.ArrayVal()
+			arrOut.EnsureCapacity(len(strArr))
+
+			for _, val := range strArr {
+				arrOut.AppendEmpty().SetStringVal(strings.TrimSpace(val))
+			}
+
+			bodyMap.Update(fieldName, arrAttrib)
+		}
+	}
+}
+
+var intFields = []string{
+	"bytes_sent",
+	"code",
+	"dbid",
+	"http_status",
+	"level",
+	"org_id",
+	"pid",
+	"process_id",
+	"process_log_line",
+	"rows_examined",
+	"rows_sent",
+	"sessionid",
+	"size",
+	"slow_query_timestamp",
+	"status",
+	"tid",
+}
+
+var floatFields = []string{
+	"query_time",
+	"lock_time",
+}
+
+// convertIntAndFloatFields converts known integer and float fields from strings, replacing the string field with their
+//  actual type (int or float)
+func convertIntAndFloatFields(le *pdata.LogRecord) {
+	if le.Body().Type() != pdata.AttributeValueTypeMap {
+		return
+	}
+
+	bodyMap := le.Body().MapVal()
+
+	for _, fieldName := range intFields {
+		if val, ok := bodyMap.Get(fieldName); ok {
+			if val.Type() == pdata.AttributeValueTypeString {
+				strVal := val.StringVal()
+				if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+					bodyMap.Delete(fieldName)
+					bodyMap.InsertInt(fieldName, intVal)
+				}
+			}
+		}
+	}
+
+	for _, fieldName := range floatFields {
+		if val, ok := bodyMap.Get(fieldName); ok {
+			if val.Type() == pdata.AttributeValueTypeString {
+				strVal := val.StringVal()
+				if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil {
+					bodyMap.Delete(fieldName)
+					bodyMap.InsertDouble(fieldName, floatVal)
+				}
+			}
+		}
+	}
+}
+
+var IPPortRegex = regexp.MustCompile(`^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)$`)
+var IPRegex = regexp.MustCompile(`^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$`)
+var PortRegex = regexp.MustCompile(`(.*):(\d+)$`)
+
+const ipField = "ip"
+const portField = "port"
+const addressField = "address"
+
+// parseIPPort parses the given string into its ipv4 and port components. If the ip or port cannot be parsed,
+//  the field "address" is filled with the unparsed string.
+func parseIpPort(s string) pdata.AttributeValue {
+	ipPortAttribVal := pdata.NewAttributeValueMap()
+	ipPortMap := ipPortAttribVal.MapVal()
+
+	if match := IPPortRegex.FindStringSubmatch(s); match != nil {
+		if port, err := strconv.ParseInt(match[2], 10, 64); err == nil {
+			ipPortMap.Insert(ipField, pdata.NewAttributeValueString(match[1]))
+			ipPortMap.Insert(portField, pdata.NewAttributeValueInt(port))
+		} else {
+			ipPortMap.Insert(addressField, pdata.NewAttributeValueString(s))
+		}
+		return ipPortAttribVal
+	}
+
+	if match := IPRegex.FindStringSubmatch(s); match != nil {
+		ipPortMap.Insert(ipField, pdata.NewAttributeValueString(match[1]))
+		return ipPortAttribVal
+	}
+
+	if match := PortRegex.FindStringSubmatch(s); match != nil {
+		if port, err := strconv.ParseInt(match[2], 10, 64); err == nil {
+			if len(match[1]) > 0 {
+				ipPortMap.Insert(addressField, pdata.NewAttributeValueString(match[1]))
+			}
+			ipPortMap.Insert(portField, pdata.NewAttributeValueInt(port))
+		} else {
+			ipPortMap.Insert(addressField, pdata.NewAttributeValueString(s))
+		}
+		return ipPortAttribVal
+	}
+
+	ipPortMap.Insert(addressField, pdata.NewAttributeValueString(s))
+
+	return ipPortAttribVal
+}

--- a/pkg/receiver/logsreceiver/record_transform_test.go
+++ b/pkg/receiver/logsreceiver/record_transform_test.go
@@ -1,0 +1,346 @@
+package logsreceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+type mockLogRecord struct {
+	Attributes   map[string]interface{}
+	Body         interface{}
+	Timestamp    pdata.Timestamp
+	Severity     pdata.SeverityNumber
+	SeverityText string
+}
+
+func (m mockLogRecord) LogRecord(t *testing.T) pdata.LogRecord {
+	lr := pdata.NewLogRecord()
+
+	attribMap := toAttributeMap(m.Attributes)
+	attribMap.MapVal().CopyTo(lr.Attributes())
+
+	if m.Body != nil {
+		switch v := m.Body.(type) {
+		case map[string]interface{}:
+			toAttributeMap(v).CopyTo(lr.Body())
+		default:
+			require.Fail(t, "Body type not implemented", m)
+		}
+	} else {
+		pdata.NewAttributeValueMap().CopyTo(lr.Body())
+	}
+
+	lr.SetTimestamp(m.Timestamp)
+	lr.SetSeverityNumber(m.Severity)
+	lr.SetSeverityText(m.SeverityText)
+
+	return lr
+}
+
+func TestTransform(t *testing.T) {
+	testDate := time.Date(2021, 6, 16, 13, 32, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name                string
+		lrIn                mockLogRecord
+		pluginIdToConfigMap map[string]map[string]interface{}
+		lrOut               mockLogRecord
+	}{
+		{
+			name: "Timestamp is promoted (@timestamp)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"@timestamp":   testDate.Format(time.RFC3339),
+					"anotherValue": "val",
+				},
+			},
+			lrOut: mockLogRecord{
+				Timestamp: pdata.TimestampFromTime(testDate),
+				Body: map[string]interface{}{
+					"anotherValue": "val",
+				},
+			},
+		},
+		{
+			name: "Timestamp is promoted (timestamp)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"timestamp":    testDate.Format(time.RFC3339),
+					"anotherValue": "val",
+				},
+			},
+			lrOut: mockLogRecord{
+				Timestamp: pdata.TimestampFromTime(testDate),
+				Body: map[string]interface{}{
+					"anotherValue": "val",
+				},
+			},
+		},
+		{
+			name: "Timestamp is promoted (time)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"time":         testDate.Format(time.RFC3339),
+					"anotherValue": "val",
+				},
+			},
+			lrOut: mockLogRecord{
+				Timestamp: pdata.TimestampFromTime(testDate),
+				Body: map[string]interface{}{
+					"anotherValue": "val",
+				},
+			},
+		},
+		{
+			name: "Severity is promoted (integral)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"severity":     10,
+					"anotherValue": "val",
+				},
+			},
+			lrOut: mockLogRecord{
+				Severity: pdata.SeverityNumberTRACE,
+				Body: map[string]interface{}{
+					"anotherValue": "val",
+				},
+			},
+		},
+		{
+			name: "Severity is promoted (string)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"severity":     "10",
+					"anotherValue": "val",
+				},
+			},
+			lrOut: mockLogRecord{
+				Severity: pdata.SeverityNumberTRACE,
+				Body: map[string]interface{}{
+					"anotherValue": "val",
+				},
+			},
+		},
+		{
+			name: "Adds plugin info",
+			lrIn: mockLogRecord{
+				Attributes: map[string]interface{}{
+					"plugin_id": "myid",
+				},
+			},
+			pluginIdToConfigMap: map[string]map[string]interface{}{
+				"myid": {
+					"id":      "myid",
+					"name":    "my_plugin_1",
+					"version": "0.0.10",
+					"type":    "my_plugin",
+				},
+			},
+			lrOut: mockLogRecord{
+				Attributes: map[string]interface{}{
+					"plugin_id":      "myid",
+					"plugin_name":    "my_plugin_1",
+					"plugin_version": "0.0.10",
+					"plugin_type":    "my_plugin",
+				},
+			},
+		},
+		{
+			name: "Skips plugin info if it doesn't exist",
+			lrIn: mockLogRecord{
+				Attributes: map[string]interface{}{
+					"plugin_id": "myid",
+				},
+			},
+			pluginIdToConfigMap: map[string]map[string]interface{}{},
+			lrOut: mockLogRecord{
+				Attributes: map[string]interface{}{
+					"plugin_id": "myid",
+				},
+			},
+		},
+		{
+			name: "Converts client ip:port",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": "192.168.1.1:9001",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": map[string]interface{}{
+						"ip":   "192.168.1.1",
+						"port": 9001,
+					},
+				},
+			},
+		},
+		{
+			name: "Converts client ip",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": "192.168.1.1",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": map[string]interface{}{
+						"ip": "192.168.1.1",
+					},
+				},
+			},
+		},
+		{
+			name: "Converts client port",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": "myhostname:9001",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": map[string]interface{}{
+						"address": "myhostname",
+						"port":    9001,
+					},
+				},
+			},
+		},
+		{
+			name: "Converts client just hostname",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": "myhostname",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"client": map[string]interface{}{
+						"address": "myhostname",
+					},
+				},
+			},
+		},
+		{
+			name: "Converts array of IPs to actual array (1)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": "[1.1.1.1, 2.2.2.2]",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": []interface{}{"1.1.1.1", "2.2.2.2"},
+				},
+			},
+		},
+		{
+			name: "Converts array of IPs to actual array (2)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": " [1.1.1.1, 2.2.2.2]",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": []interface{}{"1.1.1.1", "2.2.2.2"},
+				},
+			},
+		},
+		{
+			name: "Converts array of IPs to actual array (3)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": "[1.1.1.1 2.2.2.2]",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": []interface{}{"1.1.1.1 2.2.2.2"},
+				},
+			},
+		},
+		{
+			name: "Converts array of IPs to actual array (4)",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": "1.1.1.1, 2.2.2.2",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": []interface{}{"1.1.1.1", "2.2.2.2"},
+				},
+			},
+		},
+		{
+			name: "Converts known int fields",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"bytes_sent":    "1024",
+					"rows_examined": "455",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"bytes_sent":    1024,
+					"rows_examined": 455,
+				},
+			},
+		},
+		{
+			name: "Converts known float fields",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"query_time": "1.75",
+					"lock_time":  "3.5",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"query_time": 1.75,
+					"lock_time":  3.5,
+				},
+			},
+		},
+		{
+			name: "Doesn't convert int fields if not integral",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"bytes_sent":    "sent",
+					"rows_examined": "examined",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"bytes_sent":    "sent",
+					"rows_examined": "examined",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			lrIn := testCase.lrIn.LogRecord(t)
+			Transform(&lrIn, testCase.pluginIdToConfigMap)
+			lrOut := testCase.lrOut.LogRecord(t)
+
+			lrIn.Attributes().Sort()
+			lrOut.Attributes().Sort()
+
+			if lrIn.Body().Type() == pdata.AttributeValueTypeMap {
+				lrIn.Body().MapVal().Sort()
+			}
+
+			if lrOut.Body().Type() == pdata.AttributeValueTypeMap {
+				lrOut.Body().MapVal().Sort()
+			}
+
+			require.EqualValues(t, lrOut, lrIn)
+		})
+	}
+}

--- a/pkg/receiver/logsreceiver/severity/severity.go
+++ b/pkg/receiver/logsreceiver/severity/severity.go
@@ -1,0 +1,31 @@
+package severity
+
+import "go.opentelemetry.io/collector/model/pdata"
+
+// mappings based on carbon severity parsing
+// NOTE: If adding a value to this slice, make sure to put them such that it's in descending order according to the MinIntVal!
+var severityInfos = []struct {
+	MinIntVal int64
+	Name      pdata.SeverityNumber
+}{
+	{100, pdata.SeverityNumberFATAL4}, // indicates that it is already too late (originally mapped to "catastrophe")
+	{90, pdata.SeverityNumberFATAL2},  // indicates that the application is unusable (originally mapped to "emergency")
+	{80, pdata.SeverityNumberERROR4},  // indicates that action must be taken immediately (originally mapped to "alert")
+	{70, pdata.SeverityNumberERROR3},  // indicates that a problem requires attention immediately (originally mapped to "critical")
+	{60, pdata.SeverityNumberERROR},   // indicates that something undesirable has actually happened (originally mapped to "error")
+	{50, pdata.SeverityNumberWARN4},   // indicates that someone should look into an issue (originally mapped to "warning")
+	{40, pdata.SeverityNumberWARN2},   // indicates that the log should be noticed (originally mapped to "notice")
+	{30, pdata.SeverityNumberINFO},    // indicates that the log may be useful for understanding high level details about an application (originally mapped to "info")
+	{20, pdata.SeverityNumberDEBUG},   // indicates that the log may be useful for debugging purposes (originally mapped to "debug")
+	{10, pdata.SeverityNumberTRACE},   // indicates that the log may be useful for detailed debugging (originally mapped to "trace")
+}
+
+// ConvertSeverity converts an integral severity from a stanza log (0 - 100) to otel severity
+func ConvertSeverity(severity int64) pdata.SeverityNumber {
+	for _, severityInfo := range severityInfos {
+		if severity >= severityInfo.MinIntVal {
+			return severityInfo.Name
+		}
+	}
+	return pdata.SeverityNumberUNDEFINED
+}

--- a/pkg/receiver/logsreceiver/severity/severity_test.go
+++ b/pkg/receiver/logsreceiver/severity/severity_test.go
@@ -1,0 +1,49 @@
+package severity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestConvertSeverity(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  int64
+		output pdata.SeverityNumber
+	}{
+		{
+			name:   "Default range",
+			input:  5,
+			output: pdata.SeverityNumberUNDEFINED,
+		},
+		{
+			name:   "Catastrophe range",
+			input:  106,
+			output: pdata.SeverityNumberFATAL4,
+		},
+		{
+			name:   "Notice range",
+			input:  42,
+			output: pdata.SeverityNumberWARN2,
+		},
+		{
+			name:   "Debug range",
+			input:  28,
+			output: pdata.SeverityNumberDEBUG,
+		},
+		{
+			name:   "Trace range",
+			input:  14,
+			output: pdata.SeverityNumberTRACE,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			out := ConvertSeverity(testCase.input)
+			require.Equal(t, testCase.output, out)
+		})
+	}
+}

--- a/pkg/receiver/logsreceiver/timestamp/timestamp.go
+++ b/pkg/receiver/logsreceiver/timestamp/timestamp.go
@@ -1,0 +1,73 @@
+package timestamp
+
+import (
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+const msToNs = int64(time.Millisecond / time.Nanosecond)
+const sToNs = int64(time.Second / time.Nanosecond)
+
+// UnixTimestampToOtelTimestamp converts an integer representing either seconds or milliseconds since the unix epoch to
+//  an pdata.Timestamp (time in nano-seconds since epoch).
+func UnixTimestampToOtelTimestamp(v int64) pdata.Timestamp {
+	// This is an assumption that if v <= 100 billion, that it's a timestamp in seconds.
+	if v <= 100_000_000_000 {
+		return pdata.Timestamp(v * sToNs)
+	}
+	return pdata.Timestamp(v * msToNs)
+}
+
+// See https://stackoverflow.com/questions/38596079/how-do-i-parse-an-iso-8601-timestamp-in-golang
+// Basically, RFC3339 can fail for some ISO8601 valid date strings.
+const iso8601TimestampLayout = "2006-01-02T15:04:05Z0700"
+
+var possibleTimestampFormats = []struct {
+	Layout     string
+	UsesAbbrev bool
+}{
+	{iso8601TimestampLayout, false},
+	{"2006-01-02T15:04:05.000Z07:00", false}, // RFC3339, but with micro-second precision
+	{time.RFC3339, false},
+	{time.RFC3339Nano, false},
+	{"2006-01-02 15:04:05.999 MST", true}, // Not sure what this format is called, but it's a possible input format.
+	{time.RFC822Z, false},
+	{time.RFC822, true},
+}
+
+// CoerceValToTimestamp attempts to coerce val into a opentelemetry timestamp.
+//  returns the coerced timestamp, and a bool indicating if it could be properly coerced or not.
+func CoerceValToTimestamp(val pdata.AttributeValue) (pdata.Timestamp, bool) {
+	switch val.Type() {
+	case pdata.AttributeValueTypeString:
+		// Check the timestamp against a few formats. If we don't get a match, we just drop it as
+		//  an invalid string.
+		v := val.StringVal()
+
+		// First check if it's a stringified unix timestamp
+		if val, err := strconv.ParseInt(v, 10, 64); err == nil {
+			// Call coerce timestamp for integer value
+			return UnixTimestampToOtelTimestamp(val), true
+		}
+
+		for _, format := range possibleTimestampFormats {
+			if date, err := time.Parse(format.Layout, v); err == nil {
+				if format.UsesAbbrev {
+					// Check that the abbreviation was actually found in time.Local
+					abbrev, offset := date.Zone()
+					if abbrev != "UTC" && abbrev != "GMT" && offset == 0 {
+						// Invalid timestamp (not UTC/GMT, but 0 offset.)
+						continue
+					}
+				}
+				return pdata.TimestampFromTime(date), true
+			}
+		}
+	case pdata.AttributeValueTypeInt:
+		return UnixTimestampToOtelTimestamp(val.IntVal()), true
+	}
+
+	return 0, false
+}

--- a/pkg/receiver/logsreceiver/timestamp/timestamp_test.go
+++ b/pkg/receiver/logsreceiver/timestamp/timestamp_test.go
@@ -1,0 +1,126 @@
+package timestamp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestUnixTimestampToOtelTimestamp(t *testing.T) {
+	// Test seconds (<= 100 billion)
+	out := UnixTimestampToOtelTimestamp(1000)
+	require.Equal(t, pdata.Timestamp(1_000_000_000_000), out)
+
+	// Test milliseconds (> 100 billion)
+	out = UnixTimestampToOtelTimestamp(1_000_000_000_000)
+	require.Equal(t, pdata.Timestamp(1_000_000_000_000_000_000), out)
+}
+
+func TestCoerceValToTimestamp(t *testing.T) {
+	testDate := time.Date(2021, 6, 16, 13, 32, 0, 0, time.UTC)
+	testDateTs := pdata.TimestampFromTime(testDate)
+	origLocal := time.Local
+
+	testCases := []struct {
+		name       string
+		val        pdata.AttributeValue
+		ts         pdata.Timestamp
+		beforeTest func()
+		afterTest  func()
+		ok         bool
+	}{
+		{
+			name: "Unix seconds",
+			val:  pdata.NewAttributeValueInt(1000),
+			ts:   pdata.Timestamp(1_000_000_000_000),
+			ok:   true,
+		},
+		{
+			name: "Unix ms",
+			val:  pdata.NewAttributeValueInt(1_000_000_000_000),
+			ts:   pdata.Timestamp(1_000_000_000_000_000_000),
+			ok:   true,
+		},
+		{
+			name: "ISO8601 timestamp",
+			val:  pdata.NewAttributeValueString(testDate.Format(iso8601TimestampLayout)),
+			ts:   testDateTs,
+			ok:   true,
+		},
+		{
+			name: "RFC3339 timestamp",
+			val:  pdata.NewAttributeValueString(testDate.Format(time.RFC3339)),
+			ts:   testDateTs,
+			ok:   true,
+		},
+		{
+			name: "RFC3339 Nano timestamp",
+			val:  pdata.NewAttributeValueString(testDate.Format(time.RFC3339Nano)),
+			ts:   testDateTs,
+			ok:   true,
+		},
+		{
+			name: "That one format that is ambiguous",
+			val:  pdata.NewAttributeValueString(testDate.Format("2006-01-02 15:04:05.999 MST")),
+			beforeTest: func() {
+				estContainingTz, err := time.LoadLocation("America/New_York")
+				require.NoError(t, err)
+				time.Local = estContainingTz
+			},
+			afterTest: func() {
+				time.Local = origLocal
+			},
+			ts: testDateTs,
+			ok: true,
+		}, {
+			name: "That one format that is ambiguous (ambiguous timezone)",
+			val:  pdata.NewAttributeValueString("2021-02-05 14:41:56.21 PST"),
+			beforeTest: func() {
+				estContainingTz, err := time.LoadLocation("America/New_York")
+				require.NoError(t, err)
+				time.Local = estContainingTz
+			},
+			afterTest: func() {
+				time.Local = origLocal
+			},
+			ok: false,
+		},
+		{
+			name: "That one format that is ambiguous (ambiguous timezone, valid for location)",
+			val:  pdata.NewAttributeValueString("2021-02-05 14:41:56.21 EST"),
+			ts:   pdata.Timestamp(1612554116210000000),
+			beforeTest: func() {
+				estContainingTz, err := time.LoadLocation("America/New_York")
+				require.NoError(t, err)
+				time.Local = estContainingTz
+			},
+			afterTest: func() {
+				time.Local = origLocal
+			},
+			ok: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.beforeTest != nil {
+				testCase.beforeTest()
+			}
+
+			out, ok := CoerceValToTimestamp(testCase.val)
+
+			if testCase.ok {
+				require.True(t, ok)
+				require.Equal(t, testCase.ts, out)
+			} else {
+				require.False(t, ok)
+			}
+
+			if testCase.afterTest != nil {
+				testCase.afterTest()
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Change
* Add some transforms into the logsreceiver in order to better match the intended format for observiq

We might want to pull (most) of this out into its own processor at some point, but this should work for now.

This is the majority of "data" transforms within the entry, some extra stuff is still going to be added to the exporter itself in order to handle hoisting to the top-level observiqLogEntry.


##### Checklist
- [x] Changes are tested
- [x] Changes are documented
