### PR TITLE
Added a config package for outside configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Config is the raw config of a collector.
+type Config struct {
+	Receivers  map[string]map[string]interface{} `yaml:"receivers" mapstructure:"receivers"`
+	Processors map[string]map[string]interface{} `yaml:"processors" mapstructure:"processors"`
+	Exporters  map[string]map[string]interface{} `yaml:"exporters" mapstructure:"exporters"`
+	Extensions map[string]map[string]interface{} `yaml:"extensions" mapstructure:"extensions"`
+	Service    Service                           `yaml:"service" mapstructure:"service"`
+}
+
+// Service is the raw service config of a collector.
+type Service struct {
+	Extensions []string            `yaml:"extensions" mapstructure:"extensions"`
+	Pipelines  map[string]Pipeline `yaml:"pipelines" mapstructure:"pipelines"`
+}
+
+// Pipeline is a raw pipeline config.
+type Pipeline struct {
+	Receivers  []string `yaml:"receivers" mapstructure:"receivers"`
+	Processors []string `yaml:"processors" mapstructure:"processors"`
+	Exporters  []string `yaml:"exporters" mapstructure:"exporters"`
+}
+
+// Read will read a config from the supplied file path.
+func Read(path string) (*Config, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	config := Config{}
+	if err = yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	return &config, nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMissingFile(t *testing.T) {
+	path := "/missing/file"
+	config, err := Read(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read file")
+	require.Nil(t, config)
+}
+
+func TestReadInvalidYAML(t *testing.T) {
+	file, err := ioutil.TempFile("", "config")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	_, err = file.WriteString("invalid yaml")
+	require.NoError(t, err)
+
+	config, err := Read(file.Name())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal")
+	require.Nil(t, config)
+}
+
+func TestReadValid(t *testing.T) {
+	file, err := ioutil.TempFile("", "config")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	contents := `
+receivers:
+  test_receiver:
+    key: value
+exporters:
+  test_exporter:
+    key: value
+service:
+  pipelines:
+    test_pipeline:
+      receivers: [test_receiver]
+      exporters: [test_exporter]`
+
+	_, err = file.WriteString(contents)
+	require.NoError(t, err)
+
+	config, err := Read(file.Name())
+	require.NoError(t, err)
+
+	_, ok := config.Receivers["test_receiver"]
+	require.True(t, ok)
+
+	_, ok = config.Exporters["test_exporter"]
+	require.True(t, ok)
+
+	_, ok = config.Service.Pipelines["test_pipeline"]
+	require.True(t, ok)
+}


### PR DESCRIPTION
### Proposed Change
- Adds a config package for outside parsing and config manipulation. These structs already exist in the open telemetry library, but they're unfortunately private and hidden behind an unmarshaler.

##### Checklist
- [x] Changes are tested
- [x] Changes are documented
