### PR TITLE
Fix out of bounds error in convertStringArrays

### DIFF
--- a/pkg/receiver/logsreceiver/record_transform.go
+++ b/pkg/receiver/logsreceiver/record_transform.go
@@ -141,8 +141,12 @@ func convertStringArrays(le *pdata.LogRecord) {
 			}
 
 			strVal := val.StringVal()
-
 			strVal = strings.TrimSpace(strVal)
+
+			if len(strVal) == 0 {
+				continue
+			}
+
 			if strVal[0] == '[' && strVal[len(strVal)-1] == ']' {
 				strVal = strVal[1 : len(strVal)-1]
 			}

--- a/pkg/receiver/logsreceiver/record_transform_test.go
+++ b/pkg/receiver/logsreceiver/record_transform_test.go
@@ -287,6 +287,19 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		{
+			name: "Doesn't panic if expected IP array field is empty",
+			lrIn: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": "",
+				},
+			},
+			lrOut: mockLogRecord{
+				Body: map[string]interface{}{
+					"remote": "",
+				},
+			},
+		},
+		{
 			name: "Converts known int fields",
 			lrIn: mockLogRecord{
 				Body: map[string]interface{}{


### PR DESCRIPTION
### Proposed Change
* Fix a possible out of bounds error when an empty string is in one of the fields checked by convertStringArrays.

##### Checklist
- [x] Changes are tested
- [x] Changes are documented
