### PR TITLE
fix: Don't hijack signals from otel to allow interrupts to work

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -29,6 +29,10 @@ func main() {
 	_ = pflag.String("log-level", "", "not implemented") // TEMP(jsirianni): Required for OTEL k8s operator
 	pflag.Parse()
 
+	// TODO: Add this back in when https://github.com/open-telemetry/opentelemetry-collector/issues/4842 is resolved
+	// ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// defer cancel()
+
 	settings := collector.NewSettings(*configPaths, version.Version(), nil)
 	svc, err := service.New(settings)
 	if err != nil {


### PR DESCRIPTION
### Proposed Change
* Remove our custom interrupt handling from main

This ends up hurting us, since our hijacking of signal handling makes it so that sending SIGINT to the collector doesn't shut it down (which is extremely annoying).

We can add this back, if we need it, when something is done about this issue:
https://github.com/open-telemetry/opentelemetry-collector/issues/4842

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
