### PR TITLE
deps: Fix google cloud replace pointing to non-existent commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -392,7 +392,7 @@ require (
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
@@ -417,4 +417,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.46.0 => github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220302140143-6186c5f3961e
+replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.46.0 => github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220304152956-bb36c08bd895

--- a/go.sum
+++ b/go.sum
@@ -1507,8 +1507,8 @@ github.com/observiq/go-syslog/v3 v3.0.2/go.mod h1:9abcumkQwDUY0VgWdH6CaaJ3Ks39A7
 github.com/observiq/goflow/v3 v3.4.4 h1:wobLnBqdKGQVdkBDymngcQgbg+9ZzUGEdljUnCS2XoA=
 github.com/observiq/goflow/v3 v3.4.4/go.mod h1:VVPbaBEcfR0r+VaYwg6iDXws68r68AsCwLFegONP4nM=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
-github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220302140143-6186c5f3961e h1:CcxA/cCVl1b+vW3w6r5N3BRnt1bQsyOPbSTWIbV9buw=
-github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220302140143-6186c5f3961e/go.mod h1:Hm0BYBpzZQnGmtdGGqjEqgNX7vOdm61KOv1q19VzrS0=
+github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220304152956-bb36c08bd895 h1:A1VpJlUjKeQpzf4Y7bo/5Np5U/3K62Z1q3aRyVcuLgA=
+github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.0.0-20220304152956-bb36c08bd895/go.mod h1:F8F4AFZw+bVR9gZf8pB6oFqqo6qs3BVi4OczfrkMMOI=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=


### PR DESCRIPTION
### Proposed Change
```
pkg/factories/exporters.go:29:2: github.com/observiq/opentelemetry-collector-contrib/exporter/googlecloudexporter@v0.0.0-20220302140143-6186c5f3961e: invalid version: unknown revision 6186c5f3961e
```

Got this when trying to build. Seems like the original branch was rebased, throwing away the commit we were pointing to.

This change points to a new branch, https://github.com/observIQ/opentelemetry-collector-contrib/tree/google-exporter-add-logging-dont-rebase, that won't be rebased.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
