### PR TITLE
fix: Fix incorrect entrypoint in Dockerfile

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,5 @@
+tmp
+.vscode
+.vagrant
+dist
+release_deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,5 @@ COPY --from=build /collector/observiq-otel-collector /collector/
 COPY --from=build /opt/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap
-ENTRYPOINT [ "/collector" ]
+ENTRYPOINT [ "/collector/observiq-otel-collector" ]
 CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
### Proposed Change
* Fix incorrect entrypoint in dockerfile
* Add .Dockerignore so that build artifacts and some local stuff doesn't get transferred to docker's context when building locally

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
