### PR TITLE
fix(Windows MSI): Don't remove config on upgrade

### DIFF
--- a/windows/wix.json
+++ b/windows/wix.json
@@ -18,7 +18,8 @@
       }
     },
     {
-      "path": "config.yaml"
+      "path": "config.yaml",
+      "never_overwrite": true
     },
     {
       "path": "opentelemetry-java-contrib-jmx-metrics.jar"


### PR DESCRIPTION
### Proposed Change
* set ""never_overwrite": true" for the config file

I tested this before, and thought this is what was being done already, but I must have somehow reverted that change in https://github.com/observIQ/observiq-otel-collector/pull/263 before it was merged. Without this, config files are overwritten on upgrade (we really don't want that to happen).
##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
