### PR TITLE
fix: Fix malformed gosec yaml

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -25,16 +25,7 @@ jobs:
         with:
           go-version: "1.17"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Install Tools
-        run: make install-tools
+      - name: Install Goec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.10.0
       - name: Run Gosec Security Scanner
         run: make gosec


### PR DESCRIPTION
### Proposed Change
* Use make target to run gosec instead of docker file

Both "uses" and "working-directory" cannot be simultaneously be specified, so the action was not valid and does not run.

Unfortunately, gosec doesn't provide a way to tell it which module you want to use, it just assumes the module root is the CWD (which cannot be changed for "uses" job steps). If we want to get it to work, we need to use the make target instead of the action.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
