### PR TITLE
fix: Error out of linux script if package install fails

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -576,10 +576,10 @@ unpack_package()
 {
   case "$package_type" in
     deb)
-      dpkg -i "$out_file_path" > /dev/null
+      dpkg -i "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
       ;;
     rpm)
-      rpm -U "$out_file_path" > /dev/null
+      rpm -U "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
       ;;
     *)
       error "Unrecognized package type"


### PR DESCRIPTION
### Proposed Change
* Add error_exit if the linux script fails to unpack the package

Tested this using the URL flag pointing to a local tarball instead of an actual package.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
