### PR TITLE
chore: Removed the disclaimer from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Disclaimer
-While the `main` branch is stable, it is still under development and documentation may not fully reflect the current feature set. Please refer to documentation for your specific release.
-
 # BindPlane Agent
 
 <center>


### PR DESCRIPTION
### Proposed Change
Removed the `Disclaimer` from the readme as it is no longer valid with the new release branching model we use.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
