### PR TITLE
fix: Set permissions of config.yaml and manager.yaml in macOS install script

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -521,6 +521,7 @@ install_package()
   if [ ! -f "$INSTALL_DIR/config.yaml" ]; then
     info "Copying default config.yaml..."
     cp "$TMP_DIR/artifacts/config.yaml" "$INSTALL_DIR/config.yaml" || error_exit "$LINENO" "Failed to copy default config.yaml to install dir"
+    chmod 0600 "$INSTALL_DIR/config.yaml" || error_exit "$LINENO" "Failed to change permissions of config.yaml"
     succeeded
   fi
 
@@ -571,6 +572,13 @@ create_manager_yml()
   manager_yml_path="$1"
   if [ ! -f "$manager_yml_path" ]; then
     info "Creating manager yaml..."
+
+    # Note here: We create the file and change permissions of the file here BEFORE writing info to it
+    # We do this because the file may contain a secret key, so we want 0 window when the
+    # file is readable by anyone other than root
+    command printf '' >> "$manager_yml_path"
+    chmod 0600 "$manager_yml_path"
+
     command printf 'endpoint: "%s"\n' "$OPAMP_ENDPOINT" > "$manager_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf 'labels: "%s"\n' "$OPAMP_LABELS" >> "$manager_yml_path"
     [ -n "$OPAMP_SECRET_KEY" ] && command printf 'secret_key: "%s"\n' "$OPAMP_SECRET_KEY" >> "$manager_yml_path"


### PR DESCRIPTION
### Proposed Change
* Explicitly set the permissions to 0600 for these files, as they should only be readable by admins of the system.

To test: 
Run the install script, e.g.:
```sh
sudo ./scripts/install/install_macos.sh
```

Note the permission of the config.yaml. You can also check the permissions of manager.yaml by specifying the `-e` flag with an opamp endpoint.

`ls -la /opt/observiq-otel-collector`
```
drwxr-xr-x@ 15 root  wheel        480 May 28 09:52 .
drwxr-xr-x   8 root  wheel        256 May 28 09:52 ..
-rw-r--r--@  1 root  wheel      11339 May 28 09:52 LICENSE
drwxr-xr-x@  3 root  wheel         96 May 28 09:52 Library
-rw-r--r--@  1 root  wheel          8 May 28 09:52 VERSION.txt
-rw-r--r--@  1 root  wheel       8900 May 28 09:51 config.bak.yaml
-rw-------   1 root  wheel       8900 May 28 09:52 config.yaml
drwxr-xr-x@  7 root  wheel        224 May 28 09:52 install
drwxr-xr-x@  3 root  wheel         96 May 28 09:52 log
-rw-r--r--@  1 root  wheel        230 May 28 09:52 logging.yaml
-rw-------   1 root  wheel        202 May 28 09:52 manager.yaml
-rwxr-xr-x@  1 root  wheel  268148226 May 28 09:52 observiq-otel-collector
drwxr-xr-x@ 55 root  wheel       1760 May 28 09:52 plugins
drwxr-xr-x@  2 root  wheel         64 May 28 09:52 storage
-rwxr-xr-x@  1 root  wheel    7460690 May 28 09:52 updater
```

note the restricted permissions of config.yaml and manager.yaml.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
