### PR TITLE
fix: Replace mutex with channel for TelemetryCounter

### DIFF
--- a/counter/counter.go
+++ b/counter/counter.go
@@ -20,33 +20,45 @@ import "encoding/json"
 // TelemetryCounter tracks the number of times a set of resource and attribute dimensions have been seen.
 type TelemetryCounter struct {
 	resources map[string]*ResourceCounter
+	commands  chan func()
 }
 
 // NewTelemetryCounter creates a new TelemetryCounter.
 func NewTelemetryCounter() *TelemetryCounter {
-	return &TelemetryCounter{
+	t := &TelemetryCounter{
 		resources: make(map[string]*ResourceCounter),
+		commands:  make(chan func()),
+	}
+	go t.run()
+	return t
+}
+
+// run listens for commands to modify or read the resources.
+func (t *TelemetryCounter) run() {
+	for cmd := range t.commands {
+		cmd()
 	}
 }
 
 // Add increments the counter with the supplied dimensions.
 func (t *TelemetryCounter) Add(resource, attributes map[string]any) {
-	key := getDimensionKey(resource)
-	if _, ok := t.resources[key]; !ok {
-		t.resources[key] = NewResourceCounter(resource)
+	t.commands <- func() {
+		key := getDimensionKey(resource)
+		if _, ok := t.resources[key]; !ok {
+			t.resources[key] = newResourceCounter(resource)
+		}
+		t.resources[key].add(attributes)
 	}
-
-	t.resources[key].Add(attributes)
 }
 
-// Resources returns a map of resource ID to a counter for that resource.
-func (t TelemetryCounter) Resources() map[string]*ResourceCounter {
-	return t.resources
-}
-
-// Reset resets the counter.
-func (t *TelemetryCounter) Reset() {
-	t.resources = make(map[string]*ResourceCounter)
+// Resources returns a map of resource ID to a counter for that resource and resets the counter.
+func (t *TelemetryCounter) Resources() map[string]*ResourceCounter {
+	result := make(chan map[string]*ResourceCounter)
+	t.commands <- func() {
+		result <- t.resources
+		t.resources = make(map[string]*ResourceCounter) // Reset the counter
+	}
+	return <-result
 }
 
 // ResourceCounter dimensions the counter by resource.
@@ -55,22 +67,22 @@ type ResourceCounter struct {
 	attributes map[string]*AttributeCounter
 }
 
-// NewResourceCounter creates a new ResourceCounter.
-func NewResourceCounter(values map[string]any) *ResourceCounter {
+// newResourceCounter creates a new ResourceCounter.
+func newResourceCounter(values map[string]any) *ResourceCounter {
 	return &ResourceCounter{
 		values:     values,
 		attributes: map[string]*AttributeCounter{},
 	}
 }
 
-// Add increments the counter with the supplied dimensions.
-func (r *ResourceCounter) Add(attributes map[string]any) {
+// add increments the counter with the supplied dimensions.
+func (r *ResourceCounter) add(attributes map[string]any) {
 	key := getDimensionKey(attributes)
 	if _, ok := r.attributes[key]; !ok {
-		r.attributes[key] = NewAttributeCounter(attributes)
+		r.attributes[key] = newAttributeCounter(attributes)
 	}
 
-	r.attributes[key].Add()
+	r.attributes[key].add()
 }
 
 // Attributes returns a map of attribute set ID to a counter for that attribute set.
@@ -89,15 +101,15 @@ type AttributeCounter struct {
 	count  int
 }
 
-// NewAttributeCounter creates a new AttributeCounter.
-func NewAttributeCounter(values map[string]any) *AttributeCounter {
+// newAttributeCounter creates a new AttributeCounter.
+func newAttributeCounter(values map[string]any) *AttributeCounter {
 	return &AttributeCounter{
 		values: values,
 	}
 }
 
-// Add increments the counter.
-func (a *AttributeCounter) Add() {
+// add increments the counter.
+func (a *AttributeCounter) add() {
 	a.count++
 }
 

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -42,10 +42,13 @@ func TestLogCounter(t *testing.T) {
 	attrKey1 := getDimensionKey(attrMap1)
 	attrKey2 := getDimensionKey(attrMap2)
 
-	require.Equal(t, 10, counter.resources[resourceKey1].attributes[attrKey1].count)
-	require.Equal(t, 5, counter.resources[resourceKey1].attributes[attrKey2].count)
-	require.Equal(t, 1, counter.resources[resourceKey2].attributes[attrKey1].count)
+	resources := counter.Resources()
 
-	counter.Reset()
-	require.Len(t, counter.resources, 0)
+	require.Equal(t, 10, resources[resourceKey1].attributes[attrKey1].count)
+	require.Equal(t, 5, resources[resourceKey1].attributes[attrKey2].count)
+	require.Equal(t, 1, resources[resourceKey2].attributes[attrKey1].count)
+
+	// Ensure that the counter has been reset
+	resources = counter.Resources()
+	require.Len(t, resources, 0)
 }

--- a/processor/datapointcountprocessor/processor.go
+++ b/processor/datapointcountprocessor/processor.go
@@ -42,7 +42,6 @@ type metricCountProcessor struct {
 	logger    *zap.Logger
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
-	mux       sync.Mutex
 }
 
 // newExprProcessor returns a new processor with expr expressions.
@@ -110,8 +109,6 @@ func (p *metricCountProcessor) Shutdown(_ context.Context) error {
 
 // ConsumeMetrics processes the metrics.
 func (p *metricCountProcessor) ConsumeMetrics(ctx context.Context, m pmetric.Metrics) error {
-	p.mux.Lock()
-	defer p.mux.Unlock()
 
 	if p.isOTTL() {
 		p.consumeMetricsOTTL(ctx, m)
@@ -202,9 +199,6 @@ func (p *metricCountProcessor) sendMetrics(ctx context.Context) {
 
 // createMetrics creates metrics from the counter. The counter is reset after the metrics are created.
 func (p *metricCountProcessor) createMetrics() pmetric.Metrics {
-	p.mux.Lock()
-	defer p.mux.Unlock()
-
 	metrics := pmetric.NewMetrics()
 	for _, resource := range p.counter.Resources() {
 		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
@@ -231,9 +225,6 @@ func (p *metricCountProcessor) createMetrics() pmetric.Metrics {
 
 		}
 	}
-
-	p.counter.Reset()
-
 	return metrics
 }
 

--- a/processor/datapointcountprocessor/processor.go
+++ b/processor/datapointcountprocessor/processor.go
@@ -104,6 +104,7 @@ func (p *metricCountProcessor) Shutdown(_ context.Context) error {
 		p.cancel()
 	}
 	p.wg.Wait()
+	p.counter.Stop()
 	return nil
 }
 

--- a/processor/logcountprocessor/processor.go
+++ b/processor/logcountprocessor/processor.go
@@ -99,6 +99,7 @@ func (p *logCountProcessor) Shutdown(_ context.Context) error {
 		p.cancel()
 	}
 	p.wg.Wait()
+	p.counter.Stop()
 	return nil
 }
 

--- a/processor/spancountprocessor/processor.go
+++ b/processor/spancountprocessor/processor.go
@@ -100,6 +100,7 @@ func (p *spanCountProcessor) Shutdown(_ context.Context) error {
 		p.cancel()
 	}
 	p.wg.Wait()
+	p.counter.Stop()
 	return nil
 }
 

--- a/processor/spancountprocessor/processor.go
+++ b/processor/spancountprocessor/processor.go
@@ -43,7 +43,6 @@ type spanCountProcessor struct {
 	logger    *zap.Logger
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
-	mux       sync.Mutex
 }
 
 // newProcessor returns a new processor.
@@ -106,8 +105,6 @@ func (p *spanCountProcessor) Shutdown(_ context.Context) error {
 
 // ConsumeMetrics processes the metrics.
 func (p *spanCountProcessor) ConsumeTraces(ctx context.Context, t ptrace.Traces) error {
-	p.mux.Lock()
-	defer p.mux.Unlock()
 
 	if p.isOTTL() {
 		p.consumeTracesOTTL(ctx, t)
@@ -184,15 +181,11 @@ func (p *spanCountProcessor) handleMetricInterval(ctx context.Context) {
 
 // sendMetrics sends metrics to the consumer.
 func (p *spanCountProcessor) sendMetrics(ctx context.Context) {
-	p.mux.Lock()
-	defer p.mux.Unlock()
 
 	metrics := p.createMetrics()
 	if metrics.ResourceMetrics().Len() == 0 {
 		return
 	}
-
-	p.counter.Reset()
 
 	if err := routereceiver.RouteMetrics(ctx, p.config.Route, metrics); err != nil {
 		p.logger.Error("Failed to send metrics", zap.Error(err))


### PR DESCRIPTION
### Proposed Change

Users are seeing agents stuck at restart after reconfiguring, and my working hypothesis is that the agent is having trouble with a pipeline that includes 16 count_telemetry processors, each of which uses a mutex. The obvious problem is that the agent defers unlocking the mutex until the next consumer in the ConsumeLogs chain returns, but it seemed like a good idea to rewrite the processor using channels instead of mutexes, the preferred Go synchronization method

From a [mutex profile](https://github.com/user-attachments/files/17832088/mutex-4.pb.gz) of a stuck agent:


<img width="1478" alt="image" src="https://github.com/user-attachments/assets/8e1ce0a2-b81a-4d0d-9e51-634585a72833">

##### Checklist

- [ ] Changes are tested
- [ ] CI has passed
