### PR TITLE
fix: validate topology processor interval

### DIFF
--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -52,6 +52,10 @@ func (cfg Config) Validate() error {
 		return nil
 	}
 
+	if cfg.Interval < 10*time.Second {
+		return errors.New("`interval` must be at least 10 seconds")
+	}
+
 	if cfg.Configuration == "" {
 		return errors.New("`configuration` must be specified")
 	}

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -32,6 +32,7 @@ func TestConfigValidate(t *testing.T) {
 			Enabled:        true,
 			Interval:       8 * time.Second,
 			AccountID:      "myacct",
+			Configuration:  "myConfig",
 			OrganizationID: "myorg",
 		}
 		err := cfg.Validate()

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -16,6 +16,7 @@ package topologyprocessor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +25,17 @@ func TestConfigValidate(t *testing.T) {
 	t.Run("Default config is valid", func(t *testing.T) {
 		err := createDefaultConfig().(*Config).Validate()
 		require.NoError(t, err)
+	})
+
+	t.Run("interval too low", func(t *testing.T) {
+		cfg := Config{
+			Enabled:        true,
+			Interval:       8 * time.Second,
+			AccountID:      "myacct",
+			OrganizationID: "myorg",
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
 	})
 
 	t.Run("Empty configuration", func(t *testing.T) {


### PR DESCRIPTION
Validates topology processor interval parameter is at least 10 seconds 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
