### PR TITLE
chore: add unroll processor to v2 manifest

### DIFF
--- a/manifests/observIQ/README.md
+++ b/manifests/observIQ/README.md
@@ -8,31 +8,31 @@ This is a list of components that will be available to use in the resulting coll
 
 | extensions                | exporters                      | processors                    | receivers                      | connectors            |
 | :------------------------ | :----------------------------- | :---------------------------- | :----------------------------- | :-------------------- |
-| zpagesextension           | debugexporter                  | batchprocessor                | nopreceiver                    | forwardconnector      |
-| ballastextension          | loggingexporter                | memorylimiterprocessor        | otlpreceiver                   | countconnector        |
-| ackextension              | nopexporter                    | attributesprocessor           | activedirectorydsreceiver      | datadogconnector      |
-| asapauthextension         | otlpexporter                   | cumulativetodeltaprocessor    | aerospikereceiver              | exceptionsconnector   |
-| awsproxy                  | otlphttpexporter               | deltatorateprocessor          | apachereceiver                 | grafanacloudconnector |
-| basicauthextension        | alibabacloudlogserviceexporter | filterprocessor               | apachesparkreceiver            | roundrobinconnector   |
-| bearertokenauthextension  | awscloudwatchlogsexporter      | groupbyattrsprocessor         | awscloudwatchreceiver          | routingconnector      |
-| jaegerencodingextension   | awsemfexporter                 | groupbytraceprocessor         | awscontainerinsightreceiver    | servicegraphconnector |
-| otlpencodingextension     | awskinesisexporter             | k8sattributesprocessor        | awsecscontainermetricsreceiver | spanmetricsconnector  |
-| zipkinencodingextension   | awsxrayexporter                | metricsgenerationprocessor    | awsfirehosereceiver            |                       |
-| headerssetterextension    | awss3exporter                  | metricstransformprocessor     | awsxrayreceiver                |                       |
-| healthcheckextension      | azuredataexplorerexporter      | probabilisticsamplerprocessor | azureblobreceiver              |                       |
-| httpforwarderextension    | azuremonitorexporter           | redactionprocessor            | azureeventhubreceiver          |                       |
-| jaegerremotesampling      | carbonexporter                 | remotetapprocessor            | azuremonitorreceiver           |                       |
-| oauth2clientauthextension | cassandraexporter              | resourcedetectionprocessor    | bigipreceiver                  |                       |
-| dockerobserver            | clickhouseexporter             | resourceprocessor             | carbonreceiver                 |                       |
-| ecsobserver               | coralogixexporter              | routingprocessor              | chronyreceiver                 |                       |
-| ecstaskobserver           | datadogexporter                | spanprocessor                 | cloudflarereceiver             |                       |
-| hostobserver              | datasetexporter                | sumologicprocessor            | cloudfoundryreceiver           |                       |
-| k8sobserver               | elasticsearchexporter          | tailsamplingprocessor         | collectdreceiver               |                       |
-| oidcauthextension         | fileexporter                   | transformprocessor            | couchdbreceiver                |                       |
-| opampextension            | googlecloudpubsubexporter      | datapointcountprocessor       | datadogreceiver                |                       |
-| pprofextension            | honeycombmarkerexporter        | logcountprocessor             | dockerstatsreceiver            |                       |
-| sigv4authextension        | influxdbexporter               | logdeduplicationprocessor     | elasticsearchreceiver          |                       |
-| filestorage               | instanaexporter                | lookupprocessor               | expvarreceiver                 |                       |
-| dbstorage                 | kafkaexporter                  | maskprocessor                 | filelogreceiver                |                       |
-| bindplaneextension        | loadbalancingexporter          | metricextractprocessor        | filestatsreceiver              |                       |
-|                           | logicmonitorexporter           |
+| ackextension              | alibabacloudlogserviceexporter | attributesprocessor           | activedirectorydsreceiver      | countconnector        |
+| asapauthextension         | awscloudwatchlogsexporter      | batchprocessor                | aerospikereceiver              | datadogconnector      |
+| awsproxy                  | awsemfexporter                 | cumulativetodeltaprocessor    | apachereceiver                 | exceptionsconnector   |
+| ballastextension          | awskinesisexporter             | datapointcountprocessor       | apachesparkreceiver            | forwardconnector      |
+| basicauthextension        | awss3exporter                  | deltatorateprocessor          | awscloudwatchreceiver          | grafanacloudconnector |
+| bearertokenauthextension  | awsxrayexporter                | filterprocessor               | awscontainerinsightreceiver    | roundrobinconnector   |
+| bindplaneextension        | azuredataexplorerexporter      | groupbyattrsprocessor         | awsecscontainermetricsreceiver | routingconnector      |
+| dbstorage                 | azuremonitorexporter           | groupbytraceprocessor         | awsfirehosereceiver            | servicegraphconnector |
+| dockerobserver            | carbonexporter                 | k8sattributesprocessor        | awsxrayreceiver                | spanmetricsconnector  |
+| ecsobserver               | cassandraexporter              | logcountprocessor             | azureblobreceiver              |                       |
+| ecstaskobserver           | clickhouseexporter             | logdeduplicationprocessor      | azureeventhubreceiver          |                       |
+| filestorage               | coralogixexporter              | lookupprocessor               | azuremonitorreceiver           |                       |
+| headerssetterextension    | datadogexporter                | maskprocessor                 | bigipreceiver                  |                       |
+| healthcheckextension      | datasetexporter                | memorylimiterprocessor        | carbonreceiver                 |                       |
+| hostobserver              | debugexporter                  | metricextractprocessor        | chronyreceiver                 |                       |
+| httpforwarderextension    | elasticsearchexporter          | metricsgenerationprocessor    | cloudflarereceiver             |                       |
+| jaegerencodingextension   | fileexporter                   | metricstransformprocessor     | cloudfoundryreceiver           |                       |
+| jaegerremotesampling      | googlecloudpubsubexporter      | probabilisticsamplerprocessor | collectdreceiver               |                       |
+| k8sobserver               | honeycombmarkerexporter        | redactionprocessor            | couchdbreceiver                |                       |
+| oauth2clientauthextension | influxdbexporter               | remotetapprocessor            | datadogreceiver                |                       |
+| oidcauthextension         | instanaexporter                | resourcedetectionprocessor    | dockerstatsreceiver            |                       |
+| opampextension            | kafkaexporter                  | resourceprocessor             | elasticsearchreceiver          |                       |
+| otlpencodingextension     | loadbalancingexporter          | routingprocessor              | expvarreceiver                 |                       |
+| pprofextension            | loggingexporter                | spanprocessor                 | filelogreceiver                |                       |
+| sigv4authextension        | logicmonitorexporter           | sumologicprocessor            | filestatsreceiver              |                       |
+| zipkinencodingextension   | nopexporter                    | tailsamplingprocessor         | nopreceiver                    |                       |
+|                           | otlpexporter                   | transformprocessor            | otlpreceiver                   |                       |
+|                           | otlphttpexporter               | unrollprocessor               |                                |                       |

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -137,6 +137,8 @@ processors:
     path: "./processor/spancountprocessor"
   - gomod: github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.66.0
     path: "./processor/throughputmeasurementprocessor"
+  - gomod: github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.66.0
+    path: "./processor/unrollprocessor"
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.114.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.114.0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
With #2021 merged, it seemed like it missed its way into the v2 manifests. This PR adds it back so that new processor types can use it with v2 installations!

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
