### PR TITLE
feat: Update SSAPI receiver to accept UTC timestamps (BPS-293)

### DIFF
--- a/receiver/splunksearchapireceiver/README.md
+++ b/receiver/splunksearchapireceiver/README.md
@@ -21,8 +21,8 @@ Unlike other receivers, the SSAPI receiver is not built to collect live data. In
 | token_type                    | string   | `(no default)`                                                                           | Specifies the type of token used to authenticate to Splunk using `auth_token`. Accepted values are "Bearer" or "Splunk". |
 | job_poll_interval | duration | `5s` | The receiver uses an API call to determine if a search has completed. Specifies how long to wait between polling for search job completion. |
 | searches.query | string | `required (no default)` | The Splunk search to run to retrieve the desired events. Queries must start with `search` and should not contain additional commands, nor any time fields (e.g. `earliesttime`) |
-| searches.earliest_time | string | `required (no default)` | The earliest timestamp to collect logs. Only logs that occurred at or after this timestamp will be collected. Must be in ISO 8601 or RFC3339 format. |
-| searches.latest_time | string | `required (no default)` | The latest timestamp to collect logs. Only logs that occurred at or before this timestamp will be collected. Must be in ISO 8601 or RFC3339 format. |
+| searches.earliest_time | string | `required (no default)` | The earliest timestamp to collect logs. Only logs that occurred at or after this timestamp will be collected. Must be in 'yyyy-MM-ddTHH:mm:ss' format (UTC). |
+| searches.latest_time | string | `required (no default)` | The latest timestamp to collect logs. Only logs that occurred at or before this timestamp will be collected. Must be in 'yyyy-MM-ddTHH:mm:ss' format (UTC). |
 | searches.event_batch_size | int | `100` | The amount of events to query from Splunk for a single request. |
 | storage | component | `required (no default)` | The component ID of a storage extension which can be used when polling for `logs`. The storage extension prevents duplication of data after an exporter error by remembering which events were previously exported. |
 

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -113,14 +113,15 @@ func (cfg *Config) Validate() error {
 		}
 
 		// parse time strings to time.Time
-		_, err := time.Parse(time.RFC3339, search.EarliestTime)
+		layout := "2006-01-02T15:04:05"
+		_, err := time.Parse(layout, search.EarliestTime)
 		if err != nil {
-			return errors.New("earliest_time failed to parse as RFC3339")
+			return errors.New("earliest_time failed to parse")
 		}
 
-		_, err = time.Parse(time.RFC3339, search.LatestTime)
+		_, err = time.Parse(layout, search.LatestTime)
 		if err != nil {
-			return errors.New("latest_time failed to parse as RFC3339")
+			return errors.New("latest_time failed to parse")
 		}
 
 	}

--- a/receiver/splunksearchapireceiver/config_test.go
+++ b/receiver/splunksearchapireceiver/config_test.go
@@ -42,8 +42,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -57,8 +57,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -72,8 +72,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -87,8 +87,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -103,8 +103,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -121,8 +121,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -136,8 +136,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -160,8 +160,8 @@ func TestValidate(t *testing.T) {
 			storage:  "file_storage",
 			searches: []Search{
 				{
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -176,7 +176,7 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:      "search index=_internal",
-					LatestTime: "2024-10-30T14:00:00.000Z",
+					LatestTime: "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -192,11 +192,11 @@ func TestValidate(t *testing.T) {
 				{
 					Query:        "search index=_internal",
 					EarliestTime: "-1hr",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
-			errText:     "earliest_time failed to parse as RFC3339",
+			errText:     "earliest_time failed to parse",
 		},
 		{
 			desc:     "Missing latest_time",
@@ -207,7 +207,7 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
 				},
 			},
 			errExpected: true,
@@ -222,12 +222,12 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
 					LatestTime:   "-1hr",
 				},
 			},
 			errExpected: true,
-			errText:     "latest_time failed to parse as RFC3339",
+			errText:     "latest_time failed to parse",
 		},
 		{
 			desc:     "Invalid query chaining",
@@ -238,8 +238,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal | stats count by sourcetype",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,
@@ -254,8 +254,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: false,
@@ -269,8 +269,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: false,
@@ -284,13 +284,13 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 				{
 					Query:        "search index=_audit",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: false,
@@ -304,8 +304,8 @@ func TestValidate(t *testing.T) {
 			searches: []Search{
 				{
 					Query:        "search index=_internal",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 					Limit:        10,
 				},
 			},
@@ -319,9 +319,9 @@ func TestValidate(t *testing.T) {
 			storage:  "file_storage",
 			searches: []Search{
 				{
-					Query:        "search index=_internal earliest=2024-10-30T04:00:00.000Z latest=2024-10-30T14:00:00.000Z",
-					EarliestTime: "2024-10-30T04:00:00.000Z",
-					LatestTime:   "2024-10-30T14:00:00.000Z",
+					Query:        "search index=_internal earliest=2024-10-30T04:00:00 latest=2024-10-30T14:00:00",
+					EarliestTime: "2024-10-30T04:00:00",
+					LatestTime:   "2024-10-30T14:00:00",
 				},
 			},
 			errExpected: true,

--- a/receiver/splunksearchapireceiver/integration_test.go
+++ b/receiver/splunksearchapireceiver/integration_test.go
@@ -39,8 +39,8 @@ func TestSplunkResultsPaginationFailure(t *testing.T) {
 	cfg.Searches = []Search{
 		{
 			Query:          "search index=otel",
-			EarliestTime:   "2024-11-14T00:00:00.000Z",
-			LatestTime:     "2024-11-14T23:59:59.000Z",
+			EarliestTime:   "2024-11-14T00:00:00",
+			LatestTime:     "2024-11-14T23:59:59",
 			EventBatchSize: 5,
 		},
 	}
@@ -104,8 +104,8 @@ func TestExporterFailure(t *testing.T) {
 	cfg.Searches = []Search{
 		{
 			Query:          "search index=otel",
-			EarliestTime:   "2024-11-14T00:00:00.000Z",
-			LatestTime:     "2024-11-14T23:59:59.000Z",
+			EarliestTime:   "2024-11-14T00:00:00",
+			LatestTime:     "2024-11-14T23:59:59",
 			EventBatchSize: 3,
 		},
 	}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Updates the Splunk Search API receiver to expect more generic timestamps so that the BP source can use an existing date/time picker component that does not include timezones.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
