### PR TITLE
fix: Localize `Users` group in Windows installer (BPOP-1396)

### DIFF
--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -75,7 +75,7 @@
                 <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
                         <Permission User="Administrators" GenericAll="yes" />
-                        <Permission User="Users" GenericAll="no" />
+                        <Permission User="[OIQ_USER_GROUP_NAME]" GenericAll="no" />
                     </CreateFolder>
                 </Component>
                 {{define "FILES"}}

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -66,6 +66,22 @@
       "system": "yes",
       "action": "set",
       "part": "all"
+    },
+    {
+      "name": "OIQ_USER_GROUP_SID",
+      "value": "System.Security.Principal.SecurityIdentifier('S-1-5-32-545')",
+      "permanent": "no",
+      "system": "yes",
+      "action": "set",
+      "part": "all"
+    },
+    {
+      "name": "OIQ_USER_GROUP_NAME",
+      "value": "[OIQ_USER_GROUP_SID].Translate([System.Security.Principal.NTAccount]).Value",
+      "permanent": "no",
+      "system": "yes",
+      "action": "set",
+      "part": "all"
     }
   ],
   "registries": [


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
This PR replaces the hardcoded 'Users' group with a variable that gets the name of the group from the Windows system. This fixes an issue where Windows machines with other languages did not recognize the 'Users' group.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
