### PR TITLE
fix: fix topology processor header logic

### DIFF
--- a/processor/topologyprocessor/go.mod
+++ b/processor/topologyprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.22.6
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.117.0
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/collector/client v1.23.0
 	go.opentelemetry.io/collector/component v0.117.0
 	go.opentelemetry.io/collector/consumer v1.23.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.117.0
@@ -12,13 +13,13 @@ require (
 	go.opentelemetry.io/collector/processor v0.117.0
 	go.opentelemetry.io/collector/processor/processortest v0.117.0
 	go.uber.org/zap v1.27.0
-	google.golang.org/grpc v1.69.2
 )
 
 require (
 	go.opentelemetry.io/collector/component/componenttest v0.117.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.117.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.117.0 // indirect
+	google.golang.org/grpc v1.69.4 // indirect
 )
 
 require (

--- a/processor/topologyprocessor/go.sum
+++ b/processor/topologyprocessor/go.sum
@@ -48,6 +48,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.opentelemetry.io/collector/client v1.23.0 h1:X11yEZ2T3T1Cr1CfDPI0xjZgw7ekes7CVbF/NVYxGG0=
+go.opentelemetry.io/collector/client v1.23.0/go.mod h1:pfhOGJ13n5xH3HgmFwUHa1nBE1kCIa9X/DLTJVxtbVM=
 go.opentelemetry.io/collector/component v0.117.0 h1:A3Im4PqLyfduAdVyUgbOZdUs7J/USegdpnkoIAOuN3Y=
 go.opentelemetry.io/collector/component v0.117.0/go.mod h1:+SxJgeMwNV6y3aKNR2sP0PfovcUlRwC0+pEv4tTYdXA=
 go.opentelemetry.io/collector/component/componentstatus v0.117.0 h1:8PGN66p9o5L7xCfT4jDJHd3d2VdtIuzPU2mEXOSONt8=
@@ -125,8 +127,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 h1:X58yt85/IXCx0Y3ZwN6sEIKZzQtDEYaBWrDvErdXrRE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53/go.mod h1:GX3210XPVPUjJbTUbvwI8f2IpZDMZuPJWDzDuebbviI=
-google.golang.org/grpc v1.69.2 h1:U3S9QEtbXC0bYNvRtcoklF3xGtLViumSYxWykJS+7AU=
-google.golang.org/grpc v1.69.2/go.mod h1:vyjdE6jLBI76dgpDojsFGNaHlxdjXN9ghpnd2o7JGZ4=
+google.golang.org/grpc v1.69.4 h1:MF5TftSMkd8GLw/m0KM6V8CMOCY6NZ1NQDPGFgbTt4A=
+google.golang.org/grpc v1.69.4/go.mod h1:vyjdE6jLBI76dgpDojsFGNaHlxdjXN9ghpnd2o7JGZ4=
 google.golang.org/protobuf v1.36.2 h1:R8FeyR1/eLmkutZOM5CWghmo5itiG9z0ktFlTVLuTmU=
 google.golang.org/protobuf v1.36.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Proposed Change

The way headers were being read from the context previously was only compatible with gRPC requests, resulting in http gateway connections not being upserted and detected.

This change now reads the headers using the client.Info on the context, which works for both gRPC & http connections. Note: this change requires `include_metadata: true` on the exporter side for headers to be included in the client.Info, (updating default for `include_metadata` to true in [this PR](https://github.com/observIQ/bindplane-op-enterprise/pull/4265)).

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
