### PR TITLE
feat(v2): Add `config_apply_timeout` and `bootstrap_timeout`

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -642,6 +642,8 @@ create_supervisor_config() {
   command printf '  reports_remote_config: true\n' >>"$supervisor_yml_path"
   command printf 'agent:\n' >>"$supervisor_yml_path"
   command printf '  executable: "%s"\n' "$INSTALL_DIR/bindplane-otel-collector" >>"$supervisor_yml_path"
+  command printf '  config_apply_timeout: 30s\n' >>"$supervisor_yml_path"
+  command printf '  bootstrap_timeout: 5s\n' >>"$supervisor_yml_path"
   command printf '  description:\n' >>"$supervisor_yml_path"
   command printf '    non_identifying_attributes:\n' >>"$supervisor_yml_path"
   [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >>"$supervisor_yml_path"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -780,6 +780,8 @@ create_supervisor_config() {
   command printf '  reports_remote_config: true\n' >>"$supervisor_yml_path"
   command printf 'agent:\n' >>"$supervisor_yml_path"
   command printf '  executable: "%s"\n' "$INSTALL_DIR/bindplane-otel-collector" >>"$supervisor_yml_path"
+  command printf '  config_apply_timeout: 30s\n' >>"$supervisor_yml_path"
+  command printf '  bootstrap_timeout: 5s\n' >>"$supervisor_yml_path"
   command printf '  description:\n' >>"$supervisor_yml_path"
   command printf '    non_identifying_attributes:\n' >>"$supervisor_yml_path"
   [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >>"$supervisor_yml_path"

--- a/windows/install/generate-supervisor-yaml.bat
+++ b/windows/install/generate-supervisor-yaml.bat
@@ -35,6 +35,8 @@ set "reportsRemoteCfgField=  reports_remote_config: true"
 
 set "agentField=agent:"
 set "executablePathField=  executable: '%agentBinary%'"
+set "configApplyTimeoutField=  config_apply_timeout: 30s"
+set "bootstrapTimeoutField=  bootstrap_timeout: 5s"
 set "descriptionField=  description:"
 set "nonIdentifyingAttributesField=    non_identifying_attributes:"
 set "serviceLabelsField=      service.labels: "%labels%""


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Add overrides for the default values of `config_apply_timeout` and `bootstrap_timeout` supervisor params. 30s for the config timeout incase any components have a long start up - Travis' original request for this ticket. 5s for bootstrap timeout based on my own experience testing the supervisor (default is 3s which can be a touch too fast sometimes).

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
