### PR TITLE
feat: Use timeout for Dial in secops forwarder

### DIFF
--- a/exporter/chronicleforwarderexporter/exporter.go
+++ b/exporter/chronicleforwarderexporter/exporter.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
@@ -52,11 +53,13 @@ type forwarderClient struct {
 }
 
 func (fc *forwarderClient) Dial(network string, address string) (net.Conn, error) {
-	return net.Dial(network, address)
+	return net.DialTimeout(network, address, 10*time.Second)
 }
 
 func (fc *forwarderClient) DialWithTLS(network string, addr string, config *tls.Config) (*tls.Conn, error) {
-	return tls.Dial(network, addr, config)
+	d := new(net.Dialer)
+	d.Timeout = 10 * time.Second
+	return tls.DialWithDialer(d, network, addr, config)
 }
 
 func (fc *forwarderClient) OpenFile(name string) (*os.File, error) {

--- a/exporter/chronicleforwarderexporter/factory.go
+++ b/exporter/chronicleforwarderexporter/factory.go
@@ -47,7 +47,7 @@ func createDefaultConfig() component.Config {
 				Endpoint:  "127.0.0.1:10514",
 				Transport: "tcp",
 				DialerConfig: confignet.DialerConfig{
-					Timeout: 10 * time.Second,
+					Timeout: 5 * time.Second,
 				},
 			},
 		},

--- a/exporter/chronicleforwarderexporter/factory.go
+++ b/exporter/chronicleforwarderexporter/factory.go
@@ -17,6 +17,7 @@ package chronicleforwarderexporter
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter/internal/metadata"
 	"go.opentelemetry.io/collector/component"
@@ -45,6 +46,9 @@ func createDefaultConfig() component.Config {
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",
 				Transport: "tcp",
+				DialerConfig: confignet.DialerConfig{
+					Timeout: 10 * time.Second,
+				},
 			},
 		},
 	}

--- a/exporter/chronicleforwarderexporter/factory_test.go
+++ b/exporter/chronicleforwarderexporter/factory_test.go
@@ -16,6 +16,7 @@ package chronicleforwarderexporter // import "github.com/observiq/bindplane-otel
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -33,6 +34,9 @@ func Test_createDefaultConfig(t *testing.T) {
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",
 				Transport: "tcp",
+				DialerConfig: confignet.DialerConfig{
+					Timeout: 10 * time.Second,
+				},
 			},
 		},
 	}

--- a/exporter/chronicleforwarderexporter/factory_test.go
+++ b/exporter/chronicleforwarderexporter/factory_test.go
@@ -35,7 +35,7 @@ func Test_createDefaultConfig(t *testing.T) {
 				Endpoint:  "127.0.0.1:10514",
 				Transport: "tcp",
 				DialerConfig: confignet.DialerConfig{
-					Timeout: 10 * time.Second,
+					Timeout: 5 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Call the `Dial` functions with a timeout to exit early in the case of a bad IP address. 

Uses the timeout already present in the configuration from the squashed `confignet.AddrConfig`. This way when BP starts adding this param to the exporter config it is backwards compatible

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
