### PR TITLE
chore: set chronicle collector ID based on license type

### DIFF
--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -107,6 +107,10 @@ type Config struct {
 	// This field is defaulted to 1048576 as that is the default Chronicle backend limit
 	// Setting this option to a value above the Chronicle backend limit may result in rejected log batch requests
 	BatchRequestSizeLimitHTTP int `mapstructure:"batch_request_size_limit_http"`
+
+	// LicenseType is the license type of the bindplane instance managing this agent.
+	// This field is used to determine collector ID for Chronicle.
+	LicenseType string `mapstructure:"license_type"`
 }
 
 // Validate checks if the configuration is valid.

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -45,6 +45,7 @@ type hostMetricsReporter struct {
 	stats       *api.AgentStatsEvent
 	logsDropped int64
 	logsSent    int64
+	licenseType string
 }
 
 type sendMetricsFunc func(context.Context, *api.BatchCreateEventsRequest) error
@@ -78,6 +79,7 @@ func newHostMetricsReporter(cfg *Config, set component.TelemetrySettings, export
 			WindowStartTime: now,
 			StartTime:       now,
 		},
+		licenseType: cfg.LicenseType,
 	}, nil
 }
 
@@ -115,7 +117,7 @@ func (hmr *hostMetricsReporter) getAndReset() *api.BatchCreateEventsRequest {
 	now := timestamppb.Now()
 	batchID := uuid.New()
 	source := &api.EventSource{
-		CollectorId: chronicleCollectorID[:],
+		CollectorId: getCollectorID(hmr.licenseType),
 		Namespace:   hmr.namespace,
 		CustomerId:  hmr.customerID,
 	}

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -38,8 +38,17 @@ const chronicleLogTypeField = `attributes["chronicle_log_type"]`
 const chronicleNamespaceField = `attributes["chronicle_namespace"]`
 const chronicleIngestionLabelsPrefix = `chronicle_ingestion_label`
 
-// This is a specific collector ID for Chronicle. It's used to identify bindplane agents in Chronicle.
-var chronicleCollectorID = uuid.MustParse("aaaa1111-aaaa-1111-aaaa-1111aaaa1111")
+// Specific collector IDs for Chronicle used to identify bindplane agents.
+var (
+	defaultCollectorID          = uuid.MustParse("aaaa1111-aaaa-1111-aaaa-1111aaaa1111")
+	googleEnterpriseCollectorID = uuid.MustParse("aaaa1111-aaaa-1111-aaaa-1111aaaa1112")
+	enterpriseCollectorID       = uuid.MustParse("aaaa1111-aaaa-1111-aaaa-1111aaaa1113")
+)
+
+const (
+	licenseTypeGoogleEnterprise = "GoogleEnterprise"
+	licenseTypeEnterprise       = "Enterprise"
+)
 
 var supportedLogTypes = map[string]string{
 	"windows_event.security":    "WINEVTLOG",
@@ -71,7 +80,7 @@ func newProtoMarshaler(cfg Config, teleSettings component.TelemetrySettings) (*p
 		cfg:          cfg,
 		teleSettings: teleSettings,
 		customerID:   customerID[:],
-		collectorID:  chronicleCollectorID[:],
+		collectorID:  getCollectorID(cfg.LicenseType),
 	}, nil
 }
 
@@ -578,5 +587,16 @@ func (m *protoMarshaler) buildHTTPRequest(entries []*api.Log) *api.ImportLogsReq
 				Logs:      entries,
 			},
 		},
+	}
+}
+
+func getCollectorID(licenseType string) []byte {
+	switch strings.ToLower(licenseType) {
+	case strings.ToLower(licenseTypeGoogleEnterprise):
+		return googleEnterpriseCollectorID[:]
+	case strings.ToLower(licenseTypeEnterprise):
+		return enterpriseCollectorID[:]
+	default:
+		return defaultCollectorID[:]
 	}
 }

--- a/exporter/chronicleexporter/marshal_test.go
+++ b/exporter/chronicleexporter/marshal_test.go
@@ -1698,3 +1698,68 @@ func Benchmark_getRawField(b *testing.B) {
 		})
 	}
 }
+
+func Test_getCollectorID(t *testing.T) {
+	cases := []struct {
+		name        string
+		licenseType string
+		expect      []byte
+	}{
+		{
+			name:        "GoogleEnterprise",
+			licenseType: "GoogleEnterprise",
+			expect:      googleEnterpriseCollectorID[:],
+		},
+		{
+			name:        "GoogleEnterprise lowercase",
+			licenseType: "googleenterprise",
+			expect:      googleEnterpriseCollectorID[:],
+		},
+		{
+			name:        "Enterprise",
+			licenseType: "Enterprise",
+			expect:      enterpriseCollectorID[:],
+		},
+		{
+			name:        "Google",
+			licenseType: "Google",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "FreeCloud",
+			licenseType: "FreeCloud",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "Free",
+			licenseType: "Free",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "Development",
+			licenseType: "Development",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "Trial",
+			licenseType: "Trial",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "Honeycomb",
+			licenseType: "Honeycomb",
+			expect:      defaultCollectorID[:],
+		},
+		{
+			name:        "unknown license type",
+			licenseType: "unknown",
+			expect:      defaultCollectorID[:],
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, getCollectorID(tc.licenseType))
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Change
Adds a field `license_type` to the chronicle exporter and sets the CollectorID field sent to chronicle based on the license type.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
