### PR TITLE
feat: remove early return of TLSConfig when InsecureSkipVerify is true

### DIFF
--- a/opamp/config.go
+++ b/opamp/config.go
@@ -223,7 +223,6 @@ func (c Config) ToTLS(caCertPool *x509.CertPool) (*tls.Config, error) {
 
 	if c.TLS.InsecureSkipVerify {
 		tlsConfig.InsecureSkipVerify = true
-		return tlsConfig, nil
 	}
 
 	// Load CA cert if specified


### PR DESCRIPTION
### Proposed Change

Don't discard TLS Certificate Config if `InsecureSkipVerify` is set to `true`.

### Background

In the case where you would like to skip `server` certificate validation you don't necessarily want to skip `client` certificate validation on the `server-side`. Before this change, `client` certificates were disregarded completely and validations can't be done on the `server-side` hence it won't be possible to identify a collector connecting to your `OPAMP` server using TLS certs as a means of identification.

### Use Cases

1. **Self Signed Certificates - Server Side** - some companies run self-signed CA's internally to allow other services within the company to verify the server side certificates, however the `clients` connecting to these `servers` don't always have the means to have TLS certificates signed by the same CA and instead use trusted CA's out there such as `LetsEncrypt`. In this case you would want to set `InsecureSkipVerify` to `true`, but still validate and check/send the `client` certificates.
2. **Migration of CA's - Server Side** - in the same case where companies run their own self-signed CA's, when they want to migrate to public CA's such as `LetsEncrypt` on the server side, their collectors would not be able to connect to the `OPAMP` service until their own certificates have been regenerated and signed by the same CA. In this case you would want to set `InsecureSkipVerify` to `true` while the migration takes place.

#### Security Implications:

- **Risk**: Enabling `InsecureSkipVerify` can expose the client to man-in-the-middle (MITM) attacks, as the client will accept any certificate presented by the server, even if it is invalid or malicious.

- **Recommendation**: In production environments, it is strongly recommended to keep `InsecureSkipVerify` set to `false` and ensure that the server's certificate is properly validated.

However, this change allows temporary flexibility to do migrations and to get operators out of a position of being between a rock and a hard place.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
