### PR TITLE
Fix: Added additional information in logging of collector rollouts

### DIFF
--- a/opamp/observiq/agent_config_manager.go
+++ b/opamp/observiq/agent_config_manager.go
@@ -158,7 +158,9 @@ func (a *AgentConfigManager) updateExistingConfig(configName string, managedConf
 		return verifyDiskContents(managedConfig.ConfigPath, managedConfig.GetCurrentConfigHash(), newContents)
 	}
 
-	a.logger.Info("Applying changes to config file", zap.String("config", configName))
+	a.logger.Info("Applying changes to config file",
+		zap.String("OpAMPConfig", configName),
+		zap.String("OnDiskCollectorConfig", managedConfig.ConfigPath))
 	changed, err = managedConfig.Reload(newContents)
 	if err != nil {
 		err = fmt.Errorf("failed to reload config: %s: %w", configName, err)

--- a/opamp/observiq/agent_config_manager.go
+++ b/opamp/observiq/agent_config_manager.go
@@ -159,7 +159,6 @@ func (a *AgentConfigManager) updateExistingConfig(configName string, managedConf
 	}
 
 	a.logger.Info("Applying changes to config file",
-		zap.String("OpAMPConfig", configName),
 		zap.String("OnDiskCollectorConfig", managedConfig.ConfigPath))
 	changed, err = managedConfig.Reload(newContents)
 	if err != nil {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

```json
{
  "level":"info",
  "ts":"2024-09-25T11:31:29.779-0500",
  "logger":"config manager",
  "caller":"observiq/agent_config_manager.go:161",
  "msg":"Applying changes to config file",
  "config":"collector.yaml"
}
```
This log says specifies config:"collector.yaml" - it caused confusion with a customer. In short, the ConfigMap given by OpAMP calls this config "collector.yaml", but the actual config on-disk is "config.yaml". Might want to modify this somehow to reduce confusion (e.g. change key to opamp-config or confmap-config or something to specify that it's not the on-disk config. Including the on-disk config here might also help).

In essence this PR clarifies this by updating the log message.
Here is the updated log
```json
{"level":"info","ts":"2025-02-10T11:12:57.615-0500","logger":"config manager","caller":"observiq/agent_config_manager.go:161","msg":"Applying changes to config file","OpAMPConfig":"collector.yaml","OnDiskCollectorConfig":"local/config.yaml"}
```

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
