### PR TITLE
fix: Use `control-group` KillMode in systemd config

### DIFF
--- a/service/bindplane-otel-collector.service
+++ b/service/bindplane-otel-collector.service
@@ -17,6 +17,6 @@ TimeoutSec=20
 StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
-KillMode=process
+KillMode=control-group
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Need to use the value `control-group` for [KillMode](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html) in the systemd service config. [Linear ticket](https://linear.app/bindplane/issue/BPOP-1678/v2-agent-runs-more-than-one-collector-sub-process).

Testing:
- Checkout this branch and run `make clean`, `make install-tools`, and `make release-test`
- Get the relevant linux package (.rpm or .deb) on to your linux machine, as well as the script at `scripts/install/install_unix.sh`
- Run the script on the linux machine with `sudo ./install_unix.sh -f <path-to-linux-pkg> ...` followed by the remaining argument flags to connect to a bindplane instance like `-e` and `-s`. Do not provide a version using `-v`
- Roll a config out to the agent
- Run `systemctl status bindplane-otel-collector.service` to see the collector and supervisor running
- Stop the service with `systemctl stop bindplane-otel-collector.service` and rerun the status command to verify the collector is stopped

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
