### PR TITLE
feat: Add upstream s3 rehydration receiver

### DIFF
--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -15,6 +15,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | AWS CloudWatch Container Insights Receiver | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/awscontainerinsightreceiver/README.md)       |
 | AWS ECS Container Metrics Receiver         | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/awsecscontainermetricsreceiver/README.md) |
 | AWS Kinesis Data Firehose Receiver         | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/awsfirehosereceiver/README.md)                       |
+| AWS S3 Receiver                            | [awss3receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/awss3receiver/README.md)                                   |
 | AWS S3 Rehydration Receiver                | [awss3rehydrationreceiver](../receiver/awss3rehydrationreceiver/README.md)                                                                                          |
 | AWS X-Ray Receiver                         | [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/awsxrayreceiver/README.md)                               |
 | Azure Blob Receiver                        | [azureblobreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.118.0/receiver/azureblobreceiver/README.md)                           |

--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver"
@@ -106,6 +107,7 @@ var defaultReceivers = []receiver.Factory{
 	awscontainerinsightreceiver.NewFactory(),
 	awsecscontainermetricsreceiver.NewFactory(),
 	awsfirehosereceiver.NewFactory(),
+	awss3receiver.NewFactory(),
 	awss3rehydrationreceiver.NewFactory(),
 	awsxrayreceiver.NewFactory(),
 	azureblobreceiver.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.118.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.118.0
@@ -381,6 +382,7 @@ require (
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.118.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.118.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2015,6 +2015,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2client
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.118.0/go.mod h1:K6Hs7Cgx12E02YyoNwEijytITPRE1QRed7R1HlG3o9k=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.118.0 h1:OWeWpgt3ZQ9kkB/ljdu7ewkBJPm0db2ZQx06IXiHoZY=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.118.0/go.mod h1:KWRv/4+lDRAd0aZlpjdNtDEBHsGUJAQxgub99hivIcs=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.118.0 h1:OjwttpZXJ98EORCfFqh3y1DNBR/qucTyKWvOH4YMTI0=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.118.0/go.mod h1:FG6L7/gXDQMpi/uNUfMhGGPDjhImsOB9ZdiG82+CIJo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.118.0 h1:KlIEiJprSJYUvc2XxXCu0uXM0/T/IbTKcyugEcjmnm4=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.118.0/go.mod h1:oE1OPZITVJobOfQBHokvUlCm4BILngcmba1jkKhBcKs=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.118.0 h1:QyF+bWK7cdhYDB+v+W/rgo/9WtIAztZbAmi1SAYtJ50=
@@ -2169,6 +2171,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontain
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.118.0/go.mod h1:YKiC6UXd0Mks5z1Y7X3mw7ML7J7sZYSP4jKCE97l0Rk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.118.0 h1:Gc2fxU0XAfIj3GrQapABpn78q0Hxk7W5Lv0ikq0IP2s=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.118.0/go.mod h1:Y97vVh3wPKwTBpQvUf08Az/gKft96CX23eeqVaeFwkA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.118.0 h1:JT6NXMpypf7KhS2Og269Tv2uwH45GU0rCV7mHfgk/4Q=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.118.0/go.mod h1:tb4MVneQfRxXew4nqqR8W22UH+rGDzH51y6lMZgZ9HE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.118.0 h1:8/n1POkYJU9KtL+z79M3qq87WTgakHEyDbu7A1wmrdM=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.118.0/go.mod h1:dUi2goqukOfF2IMazAI6o064ij2fJIYCeIZ6PXPuqyk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.118.0 h1:QLotMeRX8nW9woRq0vYu42RpvIDF31iOAxsWaKgvAc8=


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Adds the upstream [s3 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awss3receiver). Adding this in now for a customer and after some testing we can move to deprecate our version at a later date.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
