### PR TITLE
deps: Update Go to 1.23.6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -56,8 +55,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -80,8 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -104,8 +101,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -128,8 +124,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -151,8 +146,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
       - name: Plugin Doc Generation
         run: make create-plugin-docs
       - name: Check Changed Plugin Docs

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
           cache-dependency-path: |
             go.sum
             **/go.sum
@@ -51,8 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          check-latest: true
+          go-version-file: go.mod
           cache-dependency-path: |
             go.sum
             **/go.sum

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ fmt:
 
 .PHONY: tidy
 tidy:
-	$(MAKE) for-all CMD="go mod tidy -compat=1.22"
+	$(MAKE) for-all CMD="go mod tidy -compat=1.23"
 
 .PHONY: gosec
 gosec:

--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/plugindocgen
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.71.0

--- a/counter/go.mod
+++ b/counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/counter
 
-go 1.22.7
+go 1.23.6
 
 require github.com/stretchr/testify v1.10.0
 

--- a/exporter/azureblobexporter/go.mod
+++ b/exporter/azureblobexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/golang/mock v1.6.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/expr v1.71.0

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.50.0

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.118.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/qradar
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/expr v1.71.0

--- a/exporter/snowflakeexporter/go.mod
+++ b/exporter/snowflakeexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/expr/go.mod
+++ b/expr/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/expr
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.118.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/extension/bindplaneextension
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/golang/snappy v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/measurements/go.mod
+++ b/internal/measurements/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/measurements
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/rehydration
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/internal/testutils v1.71.0

--- a/internal/report/go.mod
+++ b/internal/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/report
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0

--- a/internal/testutils/go.mod
+++ b/internal/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/testutils
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/topology/go.mod
+++ b/internal/topology/go.mod
@@ -1,3 +1,3 @@
 module github.com/observiq/bindplane-otel-collector/internal/topology
 
-go 1.22.6
+go 1.23.6

--- a/packagestate/go.mod
+++ b/packagestate/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/packagestate
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opamp-go v0.9.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/counter v1.71.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/counter v1.71.0

--- a/processor/lookupprocessor/go.mod
+++ b/processor/lookupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/lookupprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/maskprocessor/go.mod
+++ b/processor/maskprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/maskprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/expr v1.71.0

--- a/processor/metricstatsprocessor/go.mod
+++ b/processor/metricstatsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.118.0

--- a/processor/removeemptyvaluesprocessor/go.mod
+++ b/processor/removeemptyvaluesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/resourceattributetransposerprocessor/go.mod
+++ b/processor/resourceattributetransposerprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/expr v1.71.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/internal/report v1.71.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/counter v1.71.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/internal/measurements v1.71.0

--- a/processor/topologyprocessor/go.mod
+++ b/processor/topologyprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/topologyprocessor
 
-go 1.22.6
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0

--- a/processor/unrollprocessor/go.mod
+++ b/processor/unrollprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/processor/unrollprocessor
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0

--- a/receiver/httpreceiver/go.mod
+++ b/receiver/httpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/httpreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.118.0

--- a/receiver/m365receiver/go.mod
+++ b/receiver/m365receiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/m365receiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/receiver/oktareceiver/go.mod
+++ b/receiver/oktareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/oktareceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/okta/okta-sdk-golang/v2 v2.20.0

--- a/receiver/pluginreceiver/go.mod
+++ b/receiver/pluginreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c

--- a/receiver/routereceiver/go.mod
+++ b/receiver/routereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/routereceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/sapnetweaverreceiver/go.mod
+++ b/receiver/sapnetweaverreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.71.0

--- a/receiver/telemetrygeneratorreceiver/go.mod
+++ b/receiver/telemetrygeneratorreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.118.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/updater
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION


<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Update Go version to `1.23.6`. Establishing new Go version update pattern similar to OTel. We'll lag behind a minor version and update whenever there's a new release (go 1.24 just released a few days ago, OTel just did a similar update to 1.23).

Also updates `make tidy` to use 1.23 and updates actions to consistently use `go-version-file` instead of hardcoding the go version.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
