### PR TITLE
feat: Allow for custom endpoints in chronicleexporter/http_exporter

### DIFF
--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -137,8 +137,8 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.Protocol == protocolHTTPS {
-		if cfg.Location == "" {
-			return errors.New("location is required when protocol is https")
+		if cfg.Endpoint == "" {
+			return errors.New("endpoint is required when protocol is https")
 		}
 		if cfg.Project == "" {
 			return errors.New("project is required when protocol is https")

--- a/exporter/chronicleexporter/config_test.go
+++ b/exporter/chronicleexporter/config_test.go
@@ -109,7 +109,7 @@ func TestConfigValidate(t *testing.T) {
 			expectedErr: "invalid compression type",
 		},
 		{
-			desc: "Protocol is https and location is empty",
+			desc: "Protocol is https and endpoint is empty",
 			config: &Config{
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
@@ -120,11 +120,12 @@ func TestConfigValidate(t *testing.T) {
 				BatchRequestSizeLimitHTTP: defaultBatchRequestSizeLimitHTTP,
 				BatchLogCountLimitHTTP:    defaultBatchLogCountLimitHTTP,
 			},
-			expectedErr: "location is required when protocol is https",
+			expectedErr: "endpoint is required when protocol is https",
 		},
 		{
 			desc: "Protocol is https and forwarder is empty",
 			config: &Config{
+				Endpoint:                  "myendpoint.com",
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
 				Protocol:                  protocolHTTPS,
@@ -139,6 +140,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Protocol is https and project is empty",
 			config: &Config{
+				Endpoint:                  "myendpoint.com",
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
 				Protocol:                  protocolHTTPS,
@@ -153,6 +155,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Protocol is https and http batch log count limit is 0",
 			config: &Config{
+				Endpoint:                  "myendpoint.com",
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
 				Protocol:                  protocolHTTPS,
@@ -168,6 +171,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Protocol is https and http batch request size limit is 0",
 			config: &Config{
+				Endpoint:                  "myendpoint.com",
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
 				Protocol:                  protocolHTTPS,
@@ -183,6 +187,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Valid https config",
 			config: &Config{
+				Endpoint:                  "myendpoint.com",
 				CredsFilePath:             "/path/to/creds_file",
 				LogType:                   "log_type_example",
 				Protocol:                  protocolHTTPS,

--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -156,6 +156,9 @@ func (exp *httpExporter) uploadToChronicleHTTP(ctx context.Context, logs *api.Im
 // URL for the request: https://{region}-chronicle.googleapis.com/{version}/projects/{project}/location/{region}/instances/{customerID}
 // Override for testing
 var httpEndpoint = func(cfg *Config, logType string) string {
+	if cfg.Location == "" {
+		return fmt.Sprintf("https://%s/v1alpha/projects/%s/instances/%s/logTypes/%s/logs:import", cfg.Endpoint, cfg.Project, cfg.CustomerID, logType)
+	}
 	formatString := "https://%s-%s/v1alpha/projects/%s/locations/%s/instances/%s/logTypes/%s/logs:import"
 	return fmt.Sprintf(formatString, cfg.Location, cfg.Endpoint, cfg.Project, cfg.Location, cfg.CustomerID, logType)
 }


### PR DESCRIPTION

Removes the requirement for Config.Location to be set so that users can use a custom endpoint. If Location is set, we construct the endpoint for backwards compatibility.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
