### PR TITLE
Fix: all outdated branding from observIQ to Bindplane

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright observIQ Inc.
+   Copyright Bindplane Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ check-license:
 # This target adds a license copyright header is on every source file that is missing one
 .PHONY: add-license
 add-license:
-	@ADDLICENSEOUT=`addlicense -y "" -c "observIQ, Inc." $(ALL_SRC) 2>&1`; \
+	@ADDLICENSEOUT=`addlicense -y "" -c "Bindplane, Inc." $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENSEOUT" ]; then \
 			echo "addlicense FAILED => add License errors:\n"; \
 			echo "$$ADDLICENSEOUT\n"; \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://observiq.com">
+<a href="https://bindplane.com">
   <p align="center">
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="https://res.cloudinary.com/du4nxa27k/image/upload/v1734001913/bindplane-logo_czndai.svg" width="auto" height="50">
@@ -9,12 +9,12 @@
 </a>
 
 <p align="center">
-  The Bindplane Distro for OpenTelemetry Collector (BDOT Collector) is Bindplane’s distribution of the upstream <a href="https://github.com/open-telemetry/opentelemetry-collector">OpenTelemetry Collector</a>. It’s the first distribution to implement the <a href="https://opentelemetry.io/docs/specs/opamp/">Open Agent Management Protocol</a> (OpAMP) and is designed to be fully managed with <a href="https://observiq.com/">Bindplane Telemetry Pipeline</a>. The BDOT Collector is built using the <a href="https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder">OpenTelemetry Collector Builder</a>.
+  The Bindplane Distro for OpenTelemetry Collector (BDOT Collector) is Bindplane’s distribution of the upstream <a href="https://github.com/open-telemetry/opentelemetry-collector">OpenTelemetry Collector</a>. It’s the first distribution to implement the <a href="https://opentelemetry.io/docs/specs/opamp/">Open Agent Management Protocol</a> (OpAMP) and is designed to be fully managed with <a href="https://bindplane.com/">Bindplane Telemetry Pipeline</a>. The BDOT Collector is built using the <a href="https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder">OpenTelemetry Collector Builder</a>.
 </p>
 
 <b>
   <p align="center">
-    <a href="https://observiq.com/docs/getting-started/quickstart-guide">
+    <a href="https://bindplane.com/docs/getting-started/quickstart-guide">
       Get Started! &nbsp;👉&nbsp;
     </a>
   </p>
@@ -22,12 +22,12 @@
 
 <b>
   <p align="center">
-    <a href="https://observiq.com">Website</a>&nbsp;|&nbsp;
-    <a href="https://observiq.com/docs/advanced-setup/installation">Docs</a>&nbsp;|&nbsp;
-    <a href="https://observiq.com/docs/how-to-guides/routing-telemetry">How-to Guides</a>&nbsp;|&nbsp;
-    <a href="https://observiq.com/docs/feature-guides/processors">Feature Guides</a>&nbsp;|&nbsp;
-    <a href="https://observiq.com/blog">Blog</a>&nbsp;|&nbsp;
-    <a href="https://observiq.com/mastering-opentelemetry">OTel Hub</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com">Website</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com/docs/advanced-setup/installation">Docs</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com/docs/how-to-guides/routing-telemetry">How-to Guides</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com/docs/feature-guides/processors">Feature Guides</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com/blog">Blog</a>&nbsp;|&nbsp;
+    <a href="https://bindplane.com/mastering-opentelemetry">OTel Hub</a>&nbsp;|&nbsp;
     <a href="https://www.launchpass.com/bindplane">Slack</a>
   </p>
 </b>
@@ -53,7 +53,7 @@
 </p>
 <p align="center">
   <i>
-    Learn how to connect Bindplane Distro for OpenTelemetry Collector to telemetry <a href="https://observiq.com/docs/resources/sources">sources</a> and <a href="https://observiq.com/docs/resources/destinations">destinations</a>, and use <a href="https://observiq.com/docs/resources/processors">processors</a> to transform data.
+    Learn how to connect Bindplane Distro for OpenTelemetry Collector to telemetry <a href="https://bindplane.com/docs/resources/sources">sources</a> and <a href="https://bindplane.com/docs/resources/destinations">destinations</a>, and use <a href="https://bindplane.com/docs/resources/processors">processors</a> to transform data.
   </i>
 </p>
 
@@ -67,7 +67,7 @@ If you're managing telemetry at scale you'll run in to these problems sooner or 
 
 ### An OpenTelemetry Collector you're used to
 
-The BDOT Collector is observIQ’s distribution of the upstream [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). It’s the first distribution to implement the [Open Agent Management Protocol](https://opentelemetry.io/docs/specs/opamp/) (OpAMP) and is designed to be fully managed with [Bindplane Telemetry Pipeline](https://observiq.com/solutions).
+The BDOT Collector is Bindplane's distribution of the upstream [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). It’s the first distribution to implement the [Open Agent Management Protocol](https://opentelemetry.io/docs/specs/opamp/) (OpAMP) and is designed to be fully managed with [Bindplane Telemetry Pipeline](https://bindplane.com/solutions).
 
 ### Focused on usability
 
@@ -79,11 +79,11 @@ Bundled with all core OpenTelemetry receivers, processors, and exporters as well
 
 ### Always production-ready and fully-supported
 
-Tested, verified, and supported by observIQ.
+Tested, verified, and supported by Bindplane.
 
 ## Getting Started
 
-Follow the [Getting Started](/docs/getting-started.md) guide for more detailed installation instructions, or view the list of [Supported Operating System Versions](https://observiq.com/docs/advanced-setup/installation/install-agent).
+Follow the [Getting Started](/docs/getting-started.md) guide for more detailed installation instructions, or view the list of [Supported Operating System Versions](https://bindplane.com/docs/advanced-setup/installation/install-agent).
 
 To continue with the quick start, follow along below.
 
@@ -127,8 +127,8 @@ For more installation information, and how to configure OpAMP, see [installing o
 
 With the BDOT Collector installed, it will start collecting basic metrics about the host machine printing them to the log. To further configure your collector edit the `config.yaml` file just like you would an OpenTelemetry Collector. To find your `config.yaml` file based on your operating system, reference the table below:
 
-| OS      | Default Location                                              |
-|:--------|:--------------------------------------------------------------|
+| OS      | Default Location                                                |
+| :------ | :-------------------------------------------------------------- |
 | Linux   | `/opt/observiq-otel-collector/config.yaml`                      |
 | Windows | `C:\Program Files\observIQ OpenTelemetry Collector\config.yaml` |
 | macOS   | `/opt/observiq-otel-collector/config.yaml`                      |
@@ -197,7 +197,7 @@ receivers:
       processes:
 
 # Exporters send the data to a destination, in this case GCP.
-exporters: 
+exporters:
   googlecloud:
 
 # Service specifies how to construct the data pipelines using the configurations above.

--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/plugindocgen/main.go
+++ b/cmd/plugindocgen/main.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/plugindocgen/plugin_doc_generator.go
+++ b/cmd/plugindocgen/plugin_doc_generator.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/featuregates_test.go
+++ b/collector/featuregates_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/settings.go
+++ b/collector/settings.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/collector/settings_test.go
+++ b/collector/settings_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/counter/counter.go
+++ b/counter/counter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -1,4 +1,4 @@
-# Copyright  observIQ, Inc.
+# Copyright Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-# Copyright  observIQ, Inc.
+# Copyright Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-OpenTelemetry is at the core of standardizing telemetry solutions. At observIQ, we’re focused on building the very best in open source telemetry software. Our relationship with OpenTelemetry began in 2021, with observIQ, contributing our logging agent, Stanza, to the OpenTelemetry community. Now, we are shifting our focus to simplifying OpenTelemetry solutions to its large base of users. On that note, we launched a collector that combines the best of both worlds, with OpenTelemetry at its core, combined with observIQ’s functionalities to simplify its usage.
+OpenTelemetry is at the core of standardizing telemetry solutions. At Bindplane, we’re focused on building the very best in open source telemetry software. Our relationship with OpenTelemetry began in 2021, with Bindplane, contributing our logging agent, Stanza, to the OpenTelemetry community. Now, we are shifting our focus to simplifying OpenTelemetry solutions to its large base of users. On that note, we launched a collector that combines the best of both worlds, with OpenTelemetry at its core, combined with Bindplane’s functionalities to simplify its usage.
 
 In this post, we are taking you through the installation of the Bindplane Agent and the steps to configure the agent to gather host metrics, eventually forwarding those metrics to the Google Cloud Operations.
 
@@ -27,7 +27,7 @@ For more details on installation, see our [Linux](/docs/installation-linux.md), 
 
 ## Setting up pre-requisites and authentication credentials
 
-In the following example, we are using Google Cloud Operations as the destination. However, OpenTelemetry offers exporters for many destinations. Check out the list of exporters [here](/docs/exporters.md). 
+In the following example, we are using Google Cloud Operations as the destination. However, OpenTelemetry offers exporters for many destinations. Check out the list of exporters [here](/docs/exporters.md).
 
 ### Setting up Google Cloud exporter prerequisites:
 
@@ -49,7 +49,7 @@ sudo cp sa.json /opt/observiq-otel-collector/sa.json
 sudo chown observiq-otel-collector: /opt/observiq-otel-collector/sa.json
 sudo chmod 0400 /opt/observiq-otel-collector/sa.json
 ```
- 
+
 Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable by creating a systemd override. A systemd override allows users to modify the systemd service configuration without modifying the service directly. This allows package upgrades to happen seamlessly. You can learn more about systemd units and overrides here.
 
 Run the following command
@@ -64,7 +64,7 @@ If this is the first time an override is being created, paste the following cont
 [Service]
 Environment=GOOGLE_APPLICATION_CREDENTIALS=/opt/observiq-otel-collector/sa.json
 ```
- 
+
 If an override is already in place, simply insert the Environment parameter into the existing Service section.
 
 Reload Systemd:
@@ -78,7 +78,7 @@ Restart the agent
 ```shell
 sudo systemctl restart observiq-otel-collector
 ```
- 
+
 ### Windows
 
 In this example, the key is placed at `C:/observiq/collector/sa.json`.
@@ -89,14 +89,14 @@ Run the following command
 ```batch
 setx GOOGLE_APPLICATION_CREDENTIALS "C:/observiq/collector/sa.json" /m
 ```
- 
+
 Restart the service using the services application.
 
 ## Configuring the agent
 
 In this sample configuration, the steps to use the host metrics receiver to fetch metrics from the host system and export them to Google Cloud Operations are detailed. This is how it works:
 
-The agent scrapes metrics and logs from the host and exports them to a destination assigned in the configuration file. 
+The agent scrapes metrics and logs from the host and exports them to a destination assigned in the configuration file.
 To export the metrics to Google Cloud Operations, use the configurations outlined in the googlecloudexporter as in the example `config.yaml` below.
 
 After the installation, the config file for the agent can be found at:
@@ -149,21 +149,21 @@ You should now be able to view the host metrics in your Metrics explorer. Nice w
 
 ### Metrics collected
 
-| Metric | Description | Metric Namespace |
-| --- | --- | --- |
-| Processes Created | Total number of created processes. | custom.googleapis.com/opencensus/system.processes.created |
-| Process Count | Total number of processes in each state. | custom.googleapis.com/opencensus/system.processes.count |
-| Process CPU time | Total CPU seconds broken down by different states. | custom.googleapis.com/opencensus/process.cpu.time |
-| Process Disk IO | Disk bytes transferred. | custom.googleapis.com/opencensus/process.disk.io |
-| File System Inodes Used | FileSystem inodes used. | custom.googleapis.com/opencensus/system.filesystem.inodes.usage |
-| File System Utilization | Filesystem bytes used. | custom.googleapis.com/opencensus/system.filesystem.usage |
-| Process Physical Memory Utilization | The amount of physical memory in use. | custom.googleapis.com/opencensus/process.memory.physical_usage |
-| Process Virtual Memory Utilization | Virtual memory size. | custom.googleapis.com/opencensus/process.memory.virtual_usage |
-| Networking Errors | The number of errors encountered. | custom.googleapis.com/opencensus/system.network.errors |
-| Networking Connections | The number of connections. | custom.googleapis.com/opencensus/system.network.connections |
+| Metric                              | Description                                        | Metric Namespace                                                |
+| ----------------------------------- | -------------------------------------------------- | --------------------------------------------------------------- |
+| Processes Created                   | Total number of created processes.                 | custom.googleapis.com/opencensus/system.processes.created       |
+| Process Count                       | Total number of processes in each state.           | custom.googleapis.com/opencensus/system.processes.count         |
+| Process CPU time                    | Total CPU seconds broken down by different states. | custom.googleapis.com/opencensus/process.cpu.time               |
+| Process Disk IO                     | Disk bytes transferred.                            | custom.googleapis.com/opencensus/process.disk.io                |
+| File System Inodes Used             | FileSystem inodes used.                            | custom.googleapis.com/opencensus/system.filesystem.inodes.usage |
+| File System Utilization             | Filesystem bytes used.                             | custom.googleapis.com/opencensus/system.filesystem.usage        |
+| Process Physical Memory Utilization | The amount of physical memory in use.              | custom.googleapis.com/opencensus/process.memory.physical_usage  |
+| Process Virtual Memory Utilization  | Virtual memory size.                               | custom.googleapis.com/opencensus/process.memory.virtual_usage   |
+| Networking Errors                   | The number of errors encountered.                  | custom.googleapis.com/opencensus/system.network.errors          |
+| Networking Connections              | The number of connections.                         | custom.googleapis.com/opencensus/system.network.connections     |
 
 ## What Next?
 
-Check out our list of supported [receivers](), [processors](), [exporters](), and [extensions]() for more information about making a config. To see more monitoring examples, be sure to follow the [Observability Blog](https://observiq.com/blog/).
+Check out our list of supported [receivers](), [processors](), [exporters](), and [extensions]() for more information about making a config. To see more monitoring examples, be sure to follow the [Observability Blog](https://bindplane.com/blog/).
 
 observIQ’s distribution is a game-changer for companies looking to implement the OpenTelemetry standards. The single line installer, seamlessly integrated receivers, exporter, and processor pool make working with this agent simple. For questions, requests, and suggestions, reach out to our support team at support@observIQ.com.

--- a/docs/installation-windows.md
+++ b/docs/installation-windows.md
@@ -3,6 +3,7 @@
 ## Installing
 
 To install the agent on Windows run the Powershell command below to install the MSI with no UI.
+
 ```pwsh
 msiexec /i "https://github.com/observIQ/bindplane-otel-collector/releases/latest/download/observiq-otel-collector.msi" /quiet
 ```
@@ -15,7 +16,7 @@ Installation artifacts are signed. Information on verifying the signature can be
 
 ### Managed Mode
 
-To install the agent with an OpAMP connection configuration set the following flags. 
+To install the agent with an OpAMP connection configuration set the following flags.
 
 ```sh
 msiexec /i "https://github.com/observIQ/bindplane-otel-collector/releases/latest/download/observiq-otel-collector.msi" /quiet ENABLEMANAGEMENT=1 OPAMPENDPOINT=<your_endpoint> OPAMPSECRETKEY=<secret-key>
@@ -25,7 +26,7 @@ To read more about the generated connection configuration file see [OpAMP docs](
 
 ## Configuring the Agent
 
-After installing, the `observiq-otel-collector` service will be running and ready for configuration! 
+After installing, the `observiq-otel-collector` service will be running and ready for configuration!
 
 The agent logs to `C:\Program Files\observIQ OpenTelemetry Collector\log\collector.log` by default.
 
@@ -35,21 +36,23 @@ For more information on configuring the agent, see the [OpenTelemetry docs](http
 
 **Logging**
 
-Logs from the agent will appear in `<install_dir>/log` (`C:\Program Files\observIQ OpenTelemetry Collector\log` by default). 
+Logs from the agent will appear in `<install_dir>/log` (`C:\Program Files\observIQ OpenTelemetry Collector\log` by default).
 
 Stderr for the agent process can be found at `<install_dir>/log/observiq_collector.err` (`C:\Program Files\observIQ OpenTelemetry Collector\log\observiq_collector.err` by default).
 
 ## Restarting the Agent
+
 Restarting the agent may be done through the services dialog.
 To access the services dialog, press Win + R, enter `services.msc` into the Run dialog, and press enter.
 
 ![The run dialog](./screenshots/windows/launch-services.png)
 
-Locate the "observIQ Distro for OpenTelemetry Collector" service, right click the entry, and click "Restart" to restart the agent.
+Locate the "Bindplane Distro for OpenTelemetry Collector" service, right click the entry, and click "Restart" to restart the agent.
 
 ![The services dialog](./screenshots/windows/stop-restart-service.png)
 
 Alternatively, the Powershell command below may be run to restart the agent service.
+
 ```pwsh
 Restart-Service -Name "observiq-otel-collector"
 ```
@@ -61,11 +64,12 @@ To access the services dialog, press Win + R, enter `services.msc` into the Run 
 
 ![The run dialog](./screenshots/windows/launch-services.png)
 
-Locate the "observIQ Distro for OpenTelemetry Collector" service, right click the entry, and click "Stop" to stop the agent.
+Locate the "Bindplane Distro for OpenTelemetry Collector" service, right click the entry, and click "Stop" to stop the agent.
 
 ![The services dialog](./screenshots/windows/stop-restart-service.png)
 
 Alternatively, the Powershell command below may be run to stop the agent service.
+
 ```pwsh
 Stop-Service -Name "observiq-otel-collector"
 ```
@@ -82,6 +86,7 @@ Locate the "observIQ Distro for OpenTelemetry Collector" service, right click th
 ![The services dialog](./screenshots/windows/start-service.png)
 
 Alternatively, the Powershell command below may be run to start the agent service.
+
 ```pwsh
 Start-Service -Name "observiq-otel-collector"
 ```
@@ -92,13 +97,14 @@ To uninstall the agent on Windows, navigate to the control panel, then to the "U
 
 ![The control panel](./screenshots/windows/control-panel-uninstall.png)
 
-Locate the `"observIQ Distro for OpenTelemetry Collector"` entry, and select uninstall. 
+Locate the `"Bindplane Distro for OpenTelemetry Collector"` entry, and select uninstall.
 
 ![The uninstall or change a program dialog](./screenshots/windows/uninstall-collector.png)
 
 Follow the wizard to complete removal of the agent.
 
 Alternatively, Powershell command below may be run to uninstall the agent.
+
 ```pwsh
 (Get-WmiObject -Class Win32_Product -Filter "Name = 'observIQ Distro for OpenTelemetry Collector'").Uninstall()
 ```

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -1,6 +1,6 @@
 # OpAMP Configuration
 
-The Bindplane Agent can be setup as an agent that is managed by the [Bindplane OP platform](https://observiq.com/) via OpAMP.
+The Bindplane Agent can be setup as an agent that is managed by the [Bindplane OP platform](https://bindplane.com/) via OpAMP.
 
 ## Configuration
 
@@ -11,8 +11,8 @@ The agent can be configured to connect to the server a few different ways.
 The agent can be configured to read its connection config from a `manager.yaml` file. The `--manager` flag can be used to specify the location of this config file, by default it's `./manager.yaml`. The contents of the `manager.yaml` are detailed out in the table below.
 
 | Parameter  | Required | Description                                                                |
-| :--------  | :------: | :------------------------------------------------------------------------- |
-| endpoint   | X        | The API endpoint to communicate with the server via websocket              |
+| :--------- | :------: | :------------------------------------------------------------------------- |
+| endpoint   |    X     | The API endpoint to communicate with the server via websocket              |
 | secret_key |          | The Secret Key defined for the server to be used for authorization         |
 | agent_id   |          | A [ULID](https://github.com/ulid/spec) used to uniquely identify the agent |
 | labels     |          | A comma separated list of labels in the form `label=value`                 |
@@ -29,7 +29,7 @@ agent_id: 01H5MG7N9N36J28WEC8A8X5B17
 
 #### TLS Config
 
-If TLS is enabled on the server the agent will need to be configured in order to connect. 
+If TLS is enabled on the server the agent will need to be configured in order to connect.
 
 **Note**: If using TLS on the server the `endpoint` field will need to have the `wss` protocol for TLS enabled websockets.
 
@@ -42,20 +42,20 @@ If TLS is enabled on the server the agent will need to be configured in order to
 
 ### Environment variables
 
-The agent can also use environment variables to set portions of the connection configuration. This is useful for a containerized agent where a mounted volume might not be present. 
+The agent can also use environment variables to set portions of the connection configuration. This is useful for a containerized agent where a mounted volume might not be present.
 
 If the agent can not find the specified `manager.yaml` file it will search for the environment variables and create a `manager.yaml` at the location of the `--manager` command argument.
 
 **Note**: Only the `OPAMP_ENDPOINT` is required. If this is not set and there is no `manager.yaml` the agent will start in its normal standalone mode.
 
-| Environment Variable  | Required | Description                                                                       |
-| :-------------------- | :------: | :-------------------------------------------------------------------------------- |
-| OPAMP_ENDPOINT        | X        | The API endpoint to communicate with the server via websocket                     |
-| OPAMP_SECRET_KEY      |          | The Secret Key defined for the server to be used for authorization                |
-| OPAMP_AGENT_ID        |          | A UUID used to uniquely identify the agent. If not supplied one will be generated |
-| OPAMP_LABELS          |          | A comma separated list of labels in the form `label=value`                        |
-| OPAMP_AGENT_NAME      |          | Human readable name for the agent                                                 |
-| OPAMP_TLS_SKIP_VERIFY |          | Set to `"true"` to skip verification of the OpAMP server's TLS certificate        |
+| Environment Variable  | Required | Description                                                                                            |
+| :-------------------- | :------: | :----------------------------------------------------------------------------------------------------- |
+| OPAMP_ENDPOINT        |    X     | The API endpoint to communicate with the server via websocket                                          |
+| OPAMP_SECRET_KEY      |          | The Secret Key defined for the server to be used for authorization                                     |
+| OPAMP_AGENT_ID        |          | A UUID used to uniquely identify the agent. If not supplied one will be generated                      |
+| OPAMP_LABELS          |          | A comma separated list of labels in the form `label=value`                                             |
+| OPAMP_AGENT_NAME      |          | Human readable name for the agent                                                                      |
+| OPAMP_TLS_SKIP_VERIFY |          | Set to `"true"` to skip verification of the OpAMP server's TLS certificate                             |
 | OPAMP_TLS_CA          |          | File path to a certificate authority file that should be used to validate the server's TLS certificate |
-| OPAMP_TLS_CERT        |          | File path to a certificate file that will be used for client TLS authentication |
-| OPAMP_TLS_KEY         |          | File path to a private key file that will be used for client TLS authentication |
+| OPAMP_TLS_CERT        |          | File path to a certificate file that will be used for client TLS authentication                        |
+| OPAMP_TLS_KEY         |          | File path to a private key file that will be used for client TLS authentication                        |

--- a/docs/plugins/apache_http_logs.md
+++ b/docs/plugins/apache_http_logs.md
@@ -4,28 +4,28 @@ Log parser for Apache HTTP Server
 For optimal Apache HTTP parsing and enrichment, we recommend choosing 'observIQ' log format in which log Apache logging configuration is modified to output log entries as JSON files.
 
 Steps for updating config file apache2.conf:
-  1. Add the access Logformat and error ErrorLogFormat to the main apache configuration.
-     On Debian based systems, this can be found in /etc/apache2/apache2.conf
-  2. Modify CustomLog in sites-available configurations to use 'observiq' for the access log format.
-      ex: CustomLog ${env:APACHE_LOG_DIR}/access.log observiq
-  3. Restart Apache Http Server
+
+1. Add the access Logformat and error ErrorLogFormat to the main apache configuration.
+   On Debian based systems, this can be found in /etc/apache2/apache2.conf
+2. Modify CustomLog in sites-available configurations to use 'observiq' for the access log format.
+   ex: CustomLog ${env:APACHE_LOG_DIR}/access.log observiq
+3. Restart Apache Http Server
 
 The 'observIQ' log format is defined for access logs and error logs as follows:
 Logformat "{\"timestamp\":\"%{%Y-%m-%dT%T}t.%{usec_frac}t%{%z}t\",\"remote_addr\":\"%a\",\"protocol\":\"%H\",\"method\":\"%m\",\"query\":\"%q\",\"path\":\"%U\",\"status\":\"%>s\",\"http_user_agent\":\"%{User-agent}i\",\"http_referer\":\"%{Referer}i\",\"remote_user\":\"%u\",\"body_bytes_sent\":\"%b\",\"request_time_microseconds\":\"%D\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\"}" observiq
 ErrorLogFormat "{\"time\":\"%{cu}t\",\"module\":\"%-m\",\"client\":\"%-a\",\"http_x_forwarded_for\":\"%-{X-Forwarded-For}i\",\"log_level\":\"%-l\",\"pid\":\"%-P\",\"tid\":\"%-T\",\"message\":\"%-M\",\"logid\":{\"request\":\"%-L\",\"connection\":\"%-{c}L\"},\"request_note_name\":\"%-{name}n\"}"
 
-
 ## Configuration Parameters
 
-| Name | Description | Type | Default | Required | Values |
-|:-- |:-- |:-- |:-- |:-- |:-- |
-| log_format | When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file. | string | `default` | false | `default`, `observiq` |
-| enable_access_log | Enable to collect Apache HTTP Server access logs | bool | `true` | false |  |
-| access_log_path | Path to access log file | []string | `[/var/log/apache2/access.log]` | false |  |
-| enable_error_log | Enable to collect Apache HTTP Server error logs | bool | `true` | false |  |
-| error_log_path | Path to error log file | []string | `[/var/log/apache2/error.log]` | false |  |
-| start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
+| Name              | Description                                                                                                                                                                                                                                                                                                                          | Type     | Default                         | Required | Values                |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------------------------------ | :------- | :-------------------- |
+| log_format        | When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file. | string   | `default`                       | false    | `default`, `observiq` |
+| enable_access_log | Enable to collect Apache HTTP Server access logs                                                                                                                                                                                                                                                                                     | bool     | `true`                          | false    |                       |
+| access_log_path   | Path to access log file                                                                                                                                                                                                                                                                                                              | []string | `[/var/log/apache2/access.log]` | false    |                       |
+| enable_error_log  | Enable to collect Apache HTTP Server error logs                                                                                                                                                                                                                                                                                      | bool     | `true`                          | false    |                       |
+| error_log_path    | Path to error log file                                                                                                                                                                                                                                                                                                               | []string | `[/var/log/apache2/error.log]`  | false    |                       |
+| start_at          | At startup, where to start reading logs from the file (`beginning` or `end`)                                                                                                                                                                                                                                                         | string   | `end`                           | false    | `beginning`, `end`    |
+| timezone          | Timezone to use when parsing the timestamp                                                                                                                                                                                                                                                                                           | timezone | `UTC`                           | false    |                       |
 
 ## Example Config:
 

--- a/exporter/azureblobexporter/blob_client.go
+++ b/exporter/azureblobexporter/blob_client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/common_test.go
+++ b/exporter/azureblobexporter/common_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/config_test.go
+++ b/exporter/azureblobexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/doc.go
+++ b/exporter/azureblobexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/factory.go
+++ b/exporter/azureblobexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/factory_test.go
+++ b/exporter/azureblobexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/marshaler.go
+++ b/exporter/azureblobexporter/marshaler.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/azureblobexporter/marshaler_test.go
+++ b/exporter/azureblobexporter/marshaler_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/config_test.go
+++ b/exporter/chronicleexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// CopyrightBindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/doc.go
+++ b/exporter/chronicleexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/factory.go
+++ b/exporter/chronicleexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/factory_test.go
+++ b/exporter/chronicleexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/grpc_exporter.go
+++ b/exporter/chronicleexporter/grpc_exporter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/grpc_exporter_test.go
+++ b/exporter/chronicleexporter/grpc_exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/marshal_test.go
+++ b/exporter/chronicleexporter/marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleexporter/util.go
+++ b/exporter/chronicleexporter/util.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc......
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/config.go
+++ b/exporter/chronicleforwarderexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/config_test.go
+++ b/exporter/chronicleforwarderexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/doc.go
+++ b/exporter/chronicleforwarderexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/exporter.go
+++ b/exporter/chronicleforwarderexporter/exporter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/exporter_test.go
+++ b/exporter/chronicleforwarderexporter/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/factory.go
+++ b/exporter/chronicleforwarderexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/factory_test.go
+++ b/exporter/chronicleforwarderexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/marshal.go
+++ b/exporter/chronicleforwarderexporter/marshal.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc....
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/chronicleforwarderexporter/marshal_test.go
+++ b/exporter/chronicleforwarderexporter/marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/config_test.go
+++ b/exporter/googlecloudexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/exporter.go
+++ b/exporter/googlecloudexporter/exporter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/exporter_test.go
+++ b/exporter/googlecloudexporter/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlecloudexporter/factory_test.go
+++ b/exporter/googlecloudexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/googlemanagedprometheusexporter/factory_test.go
+++ b/exporter/googlemanagedprometheusexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/config.go
+++ b/exporter/qradar/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/config_test.go
+++ b/exporter/qradar/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/doc.go
+++ b/exporter/qradar/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/exporter.go
+++ b/exporter/qradar/exporter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/exporter_test.go
+++ b/exporter/qradar/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/factory.go
+++ b/exporter/qradar/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/factory_test.go
+++ b/exporter/qradar/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/marshal.go
+++ b/exporter/qradar/marshal.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/qradar/marshal_test.go
+++ b/exporter/qradar/marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/config.go
+++ b/exporter/snowflakeexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/config_test.go
+++ b/exporter/snowflakeexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/doc.go
+++ b/exporter/snowflakeexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_logs.go
+++ b/exporter/snowflakeexporter/exporter_logs.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_logs_test.go
+++ b/exporter/snowflakeexporter/exporter_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_metrics.go
+++ b/exporter/snowflakeexporter/exporter_metrics.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_metrics_test.go
+++ b/exporter/snowflakeexporter/exporter_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_traces.go
+++ b/exporter/snowflakeexporter/exporter_traces.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/exporter_traces_test.go
+++ b/exporter/snowflakeexporter/exporter_traces_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/factory.go
+++ b/exporter/snowflakeexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/factory_test.go
+++ b/exporter/snowflakeexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/database/database.go
+++ b/exporter/snowflakeexporter/internal/database/database.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/database/database_test.go
+++ b/exporter/snowflakeexporter/internal/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/common_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/common_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/exponential_histogram_metric.go
+++ b/exporter/snowflakeexporter/internal/metrics/exponential_histogram_metric.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/exponential_histogram_metric_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/exponential_histogram_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/gauge_metric.go
+++ b/exporter/snowflakeexporter/internal/metrics/gauge_metric.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/gauge_metric_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/gauge_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/histogram_metric.go
+++ b/exporter/snowflakeexporter/internal/metrics/histogram_metric.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/histogram_metric_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/histogram_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/sum_metric.go
+++ b/exporter/snowflakeexporter/internal/metrics/sum_metric.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/sum_metric_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/sum_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/summary_metric.go
+++ b/exporter/snowflakeexporter/internal/metrics/summary_metric.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/metrics/summary_metric_test.go
+++ b/exporter/snowflakeexporter/internal/metrics/summary_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/utility/utility.go
+++ b/exporter/snowflakeexporter/internal/utility/utility.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/snowflakeexporter/internal/utility/utility_test.go
+++ b/exporter/snowflakeexporter/internal/utility/utility_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/datapoint.go
+++ b/expr/datapoint.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/datapoint_test.go
+++ b/expr/datapoint_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/expression.go
+++ b/expr/expression.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/expression_test.go
+++ b/expr/expression_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/map.go
+++ b/expr/map.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/map_test.go
+++ b/expr/map_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl.go
+++ b/expr/ottl.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_condition.go
+++ b/expr/ottl_condition.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_condition_test.go
+++ b/expr/ottl_condition_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_expression.go
+++ b/expr/ottl_expression.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_expression_test.go
+++ b/expr/ottl_expression_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_map.go
+++ b/expr/ottl_map.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/ottl_map_test.go
+++ b/expr/ottl_map_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/record.go
+++ b/expr/record.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/record_test.go
+++ b/expr/record_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/span.go
+++ b/expr/span.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/expr/span_test.go
+++ b/expr/span_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/bindplaneextension/config.go
+++ b/extension/bindplaneextension/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/bindplaneextension/doc.go
+++ b/extension/bindplaneextension/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/bindplaneextension/extension.go
+++ b/extension/bindplaneextension/extension.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extension/bindplaneextension/factory.go
+++ b/extension/bindplaneextension/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/connectors.go
+++ b/factories/connectors.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/exporters.go
+++ b/factories/exporters.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/extensions.go
+++ b/factories/extensions.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/factories.go
+++ b/factories/factories.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/factories_test.go
+++ b/factories/factories_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/processors.go
+++ b/factories/processors.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -351,6 +351,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/mock v1.7.0-rc.1 // indirect
+	github.com/google/addlicense v1.1.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20240514112848-a1b1eeb09583 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1065,6 +1065,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
 github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -1430,6 +1431,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/addlicense v1.1.1 h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=
+github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/logging/config_test.go
+++ b/internal/logging/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/measurements/bindplane_agent_throughput.go
+++ b/internal/measurements/bindplane_agent_throughput.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/measurements/custom_message.go
+++ b/internal/measurements/custom_message.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/measurements/throughput.go
+++ b/internal/measurements/throughput.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/measurements/throughput_test.go
+++ b/internal/measurements/throughput_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/os/os.go
+++ b/internal/os/os.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/os/os_test.go
+++ b/internal/os/os_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/config.go
+++ b/internal/processor/snapshotprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/config_test.go
+++ b/internal/processor/snapshotprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/factory.go
+++ b/internal/processor/snapshotprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/factory_test.go
+++ b/internal/processor/snapshotprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/processor.go
+++ b/internal/processor/snapshotprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/processor/snapshotprocessor/processor_test.go
+++ b/internal/processor/snapshotprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/checkpoint.go
+++ b/internal/rehydration/checkpoint.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/checkpoint_test.go
+++ b/internal/rehydration/checkpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/consumer.go
+++ b/internal/rehydration/consumer.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/consumer_test.go
+++ b/internal/rehydration/consumer_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/helpers.go
+++ b/internal/rehydration/helpers.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/helpers_test.go
+++ b/internal/rehydration/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/storage_client.go
+++ b/internal/rehydration/storage_client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/rehydration/storage_client_test.go
+++ b/internal/rehydration/storage_client_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/agent_client.go
+++ b/internal/report/agent_client.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/agent_client_test.go
+++ b/internal/report/agent_client_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/client.go
+++ b/internal/report/client.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/manager.go
+++ b/internal/report/manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/manager_test.go
+++ b/internal/report/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/reporter.go
+++ b/internal/report/reporter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter.go
+++ b/internal/report/snapshot/filter.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_logs.go
+++ b/internal/report/snapshot/filter_logs.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_logs_test.go
+++ b/internal/report/snapshot/filter_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_metrics.go
+++ b/internal/report/snapshot/filter_metrics.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_metrics_test.go
+++ b/internal/report/snapshot/filter_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_test.go
+++ b/internal/report/snapshot/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_traces.go
+++ b/internal/report/snapshot/filter_traces.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/filter_traces_test.go
+++ b/internal/report/snapshot/filter_traces_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/mocks/mock_snapshotter.go
+++ b/internal/report/snapshot/mocks/mock_snapshotter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/snapshot_buffers.go
+++ b/internal/report/snapshot/snapshot_buffers.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/snapshot_buffers_test.go
+++ b/internal/report/snapshot/snapshot_buffers_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot/snapshotter.go
+++ b/internal/report/snapshot/snapshotter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot_reporter.go
+++ b/internal/report/snapshot_reporter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/report/snapshot_reporter_test.go
+++ b/internal/report/snapshot_reporter_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/managed.go
+++ b/internal/service/managed.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/managed_test.go
+++ b/internal/service/managed_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/service_others.go
+++ b/internal/service/service_others.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/standalone.go
+++ b/internal/service/standalone.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/service/standalone_test.go
+++ b/internal/service/standalone_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/testutils/common.go
+++ b/internal/testutils/common.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/client.go
+++ b/opamp/client.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/config.go
+++ b/opamp/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/config_manager.go
+++ b/opamp/config_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/config_manager_test.go
+++ b/opamp/config_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/config_test.go
+++ b/opamp/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/doc.go
+++ b/opamp/doc.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/downloadable_file_manager.go
+++ b/opamp/downloadable_file_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/helpers.go
+++ b/opamp/helpers.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/helpers_test.go
+++ b/opamp/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/managed_config.go
+++ b/opamp/managed_config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/managed_config_test.go
+++ b/opamp/managed_config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/agent_config_manager.go
+++ b/opamp/observiq/agent_config_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/agent_config_manager_test.go
+++ b/opamp/observiq/agent_config_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/identity.go
+++ b/opamp/observiq/identity.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/identity_test.go
+++ b/opamp/observiq/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/logger.go
+++ b/opamp/observiq/logger.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/measurements.go
+++ b/opamp/observiq/measurements.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/measurements_test.go
+++ b/opamp/observiq/measurements_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_downloadable_file_manager.go
+++ b/opamp/observiq/observiq_downloadable_file_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_downloadable_file_manager_test.go
+++ b/opamp/observiq/observiq_downloadable_file_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_packages_state_provider.go
+++ b/opamp/observiq/observiq_packages_state_provider.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/observiq_packages_state_provider_test.go
+++ b/opamp/observiq/observiq_packages_state_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/reload_funcs.go
+++ b/opamp/observiq/reload_funcs.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/reload_funcs_test.go
+++ b/opamp/observiq/reload_funcs_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/testdata/latest/quickupdater.test
+++ b/opamp/observiq/testdata/latest/quickupdater.test
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/testdata/latest/slowupdater.test
+++ b/opamp/observiq/testdata/latest/slowupdater.test
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/topology.go
+++ b/opamp/observiq/topology.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/updater_manager.go
+++ b/opamp/observiq/updater_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/updater_manager_others.go
+++ b/opamp/observiq/updater_manager_others.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/updater_manager_others_test.go
+++ b/opamp/observiq/updater_manager_others_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/updater_manager_windows.go
+++ b/opamp/observiq/updater_manager_windows.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/observiq/updater_manager_windows_test.go
+++ b/opamp/observiq/updater_manager_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/version.go
+++ b/opamp/version.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/opamp/version_test.go
+++ b/opamp/version_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packagestate/packages_state_manager.go
+++ b/packagestate/packages_state_manager.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packagestate/packages_state_manager_linux_test.go
+++ b/packagestate/packages_state_manager_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packagestate/packages_state_manager_test.go
+++ b/packagestate/packages_state_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/config.go
+++ b/processor/datapointcountprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/config_test.go
+++ b/processor/datapointcountprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/factory.go
+++ b/processor/datapointcountprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/factory_test.go
+++ b/processor/datapointcountprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/processor.go
+++ b/processor/datapointcountprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/datapointcountprocessor/processor_test.go
+++ b/processor/datapointcountprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/config.go
+++ b/processor/logcountprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/config_test.go
+++ b/processor/logcountprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/factory.go
+++ b/processor/logcountprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/factory_test.go
+++ b/processor/logcountprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/processor.go
+++ b/processor/logcountprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/logcountprocessor/processor_test.go
+++ b/processor/logcountprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/config.go
+++ b/processor/lookupprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/config_test.go
+++ b/processor/lookupprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/csv.go
+++ b/processor/lookupprocessor/csv.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/csv_test.go
+++ b/processor/lookupprocessor/csv_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/factory.go
+++ b/processor/lookupprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/factory_test.go
+++ b/processor/lookupprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/lookupprocessor/processor_test.go
+++ b/processor/lookupprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/config.go
+++ b/processor/maskprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/config_test.go
+++ b/processor/maskprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/factory.go
+++ b/processor/maskprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/factory_test.go
+++ b/processor/maskprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/processor.go
+++ b/processor/maskprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/maskprocessor/processor_test.go
+++ b/processor/maskprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/config.go
+++ b/processor/metricextractprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/config_test.go
+++ b/processor/metricextractprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/factory.go
+++ b/processor/metricextractprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/factory_test.go
+++ b/processor/metricextractprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/processor_expr.go
+++ b/processor/metricextractprocessor/processor_expr.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/processor_ottl.go
+++ b/processor/metricextractprocessor/processor_ottl.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricextractprocessor/processor_test.go
+++ b/processor/metricextractprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/config.go
+++ b/processor/metricstatsprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/config_test.go
+++ b/processor/metricstatsprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/factory.go
+++ b/processor/metricstatsprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/factory_test.go
+++ b/processor/metricstatsprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/avg_statistic.go
+++ b/processor/metricstatsprocessor/internal/stats/avg_statistic.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/first_statistic.go
+++ b/processor/metricstatsprocessor/internal/stats/first_statistic.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/helpers.go
+++ b/processor/metricstatsprocessor/internal/stats/helpers.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/helpers_test.go
+++ b/processor/metricstatsprocessor/internal/stats/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/last_statistic.go
+++ b/processor/metricstatsprocessor/internal/stats/last_statistic.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/max_statistic.go
+++ b/processor/metricstatsprocessor/internal/stats/max_statistic.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/min_statistic.go
+++ b/processor/metricstatsprocessor/internal/stats/min_statistic.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/stats.go
+++ b/processor/metricstatsprocessor/internal/stats/stats.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/internal/stats/stats_test.go
+++ b/processor/metricstatsprocessor/internal/stats/stats_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/metadata.go
+++ b/processor/metricstatsprocessor/metadata.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/metrics.go
+++ b/processor/metricstatsprocessor/metrics.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/processor.go
+++ b/processor/metricstatsprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstatsprocessor/processor_test.go
+++ b/processor/metricstatsprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/config.go
+++ b/processor/removeemptyvaluesprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/config_test.go
+++ b/processor/removeemptyvaluesprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/factory.go
+++ b/processor/removeemptyvaluesprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/factory_test.go
+++ b/processor/removeemptyvaluesprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/processor.go
+++ b/processor/removeemptyvaluesprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/removeemptyvaluesprocessor/processor_test.go
+++ b/processor/removeemptyvaluesprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/config.go
+++ b/processor/resourceattributetransposerprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/config_test.go
+++ b/processor/resourceattributetransposerprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/factory.go
+++ b/processor/resourceattributetransposerprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/factory_test.go
+++ b/processor/resourceattributetransposerprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/processor_logs.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/processor_logs_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/processor_metrics.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/resourceattributetransposerprocessor/processor_metrics_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/config.go
+++ b/processor/samplingprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/config_test.go
+++ b/processor/samplingprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/factory.go
+++ b/processor/samplingprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/factory_test.go
+++ b/processor/samplingprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/processor.go
+++ b/processor/samplingprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/samplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/config.go
+++ b/processor/snapshotprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/config_test.go
+++ b/processor/snapshotprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/factory.go
+++ b/processor/snapshotprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/factory_test.go
+++ b/processor/snapshotprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/processor.go
+++ b/processor/snapshotprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/processor_test.go
+++ b/processor/snapshotprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/report.go
+++ b/processor/snapshotprocessor/report.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/snapshotprocessor/request.go
+++ b/processor/snapshotprocessor/request.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/config.go
+++ b/processor/spancountprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/config_test.go
+++ b/processor/spancountprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/factory.go
+++ b/processor/spancountprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/factory_test.go
+++ b/processor/spancountprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/processor.go
+++ b/processor/spancountprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/spancountprocessor/processor_test.go
+++ b/processor/spancountprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/bindplane_registry.go
+++ b/processor/throughputmeasurementprocessor/bindplane_registry.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/config.go
+++ b/processor/throughputmeasurementprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/config_test.go
+++ b/processor/throughputmeasurementprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/factory.go
+++ b/processor/throughputmeasurementprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/factory_test.go
+++ b/processor/throughputmeasurementprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/ocb_registry.go
+++ b/processor/throughputmeasurementprocessor/ocb_registry.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/processor.go
+++ b/processor/throughputmeasurementprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/throughputmeasurementprocessor/processor_test.go
+++ b/processor/throughputmeasurementprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/bindplane_agent_topology.go
+++ b/processor/topologyprocessor/bindplane_agent_topology.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/bindplane_registry.go
+++ b/processor/topologyprocessor/bindplane_registry.go
@@ -1,4 +1,4 @@
-// // Copyright observIQ, Inc.
+// // Copyright Bindplane, Inc.
 // //
 // // Licensed under the Apache License, Version 2.0 (the "License");
 // // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/custom_message.go
+++ b/processor/topologyprocessor/custom_message.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/factory.go
+++ b/processor/topologyprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/factory_test.go
+++ b/processor/topologyprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/ocb_registry.go
+++ b/processor/topologyprocessor/ocb_registry.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/processor.go
+++ b/processor/topologyprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/processor_test.go
+++ b/processor/topologyprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/topologyprocessor/topology.go
+++ b/processor/topologyprocessor/topology.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/config.go
+++ b/processor/unrollprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/config_test.go
+++ b/processor/unrollprocessor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/factory.go
+++ b/processor/unrollprocessor/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/factory_test.go
+++ b/processor/unrollprocessor/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/processor.go
+++ b/processor/unrollprocessor/processor.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/unrollprocessor/processor_test.go
+++ b/processor/unrollprocessor/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/config.go
+++ b/receiver/awss3rehydrationreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/config_test.go
+++ b/receiver/awss3rehydrationreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/doc.go
+++ b/receiver/awss3rehydrationreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/factory.go
+++ b/receiver/awss3rehydrationreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/factory_test.go
+++ b/receiver/awss3rehydrationreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/internal/aws/s3_client.go
+++ b/receiver/awss3rehydrationreceiver/internal/aws/s3_client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/receiver_test.go
+++ b/receiver/awss3rehydrationreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/awss3rehydrationreceiver/reciever.go
+++ b/receiver/awss3rehydrationreceiver/reciever.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/config.go
+++ b/receiver/azureblobrehydrationreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/config_test.go
+++ b/receiver/azureblobrehydrationreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/doc.go
+++ b/receiver/azureblobrehydrationreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/factory.go
+++ b/receiver/azureblobrehydrationreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/factory_test.go
+++ b/receiver/azureblobrehydrationreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/internal/azureblob/blob_client.go
+++ b/receiver/azureblobrehydrationreceiver/internal/azureblob/blob_client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/internal/azureblob/blob_client_test.go
+++ b/receiver/azureblobrehydrationreceiver/internal/azureblob/blob_client_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/receiver.go
+++ b/receiver/azureblobrehydrationreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/azureblobrehydrationreceiver/receiver_test.go
+++ b/receiver/azureblobrehydrationreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/config.go
+++ b/receiver/httpreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/config_test.go
+++ b/receiver/httpreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/doc.go
+++ b/receiver/httpreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/factory.go
+++ b/receiver/httpreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/factory_test.go
+++ b/receiver/httpreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/logs.go
+++ b/receiver/httpreceiver/logs.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/httpreceiver/logs_test.go
+++ b/receiver/httpreceiver/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/client.go
+++ b/receiver/m365receiver/client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/client_test.go
+++ b/receiver/m365receiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/config.go
+++ b/receiver/m365receiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/config_test.go
+++ b/receiver/m365receiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/doc.go
+++ b/receiver/m365receiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/factory.go
+++ b/receiver/m365receiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/factory_test.go
+++ b/receiver/m365receiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/integration_test.go
+++ b/receiver/m365receiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/logs_test.go
+++ b/receiver/m365receiver/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/scraper.go
+++ b/receiver/m365receiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/m365receiver/scraper_test.go
+++ b/receiver/m365receiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/config.go
+++ b/receiver/oktareceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/config_test.go
+++ b/receiver/oktareceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/doc.go
+++ b/receiver/oktareceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/factory.go
+++ b/receiver/oktareceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/factory_test.go
+++ b/receiver/oktareceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/logs.go
+++ b/receiver/oktareceiver/logs.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/oktareceiver/logs_test.go
+++ b/receiver/oktareceiver/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/emitter.go
+++ b/receiver/pluginreceiver/emitter.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/emitter_test.go
+++ b/receiver/pluginreceiver/emitter_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/factory.go
+++ b/receiver/pluginreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/factory_test.go
+++ b/receiver/pluginreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/plugin.go
+++ b/receiver/pluginreceiver/plugin.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/plugin_test.go
+++ b/receiver/pluginreceiver/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/receiver.go
+++ b/receiver/pluginreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/receiver_test.go
+++ b/receiver/pluginreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/rendered_config.go
+++ b/receiver/pluginreceiver/rendered_config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/rendered_config_test.go
+++ b/receiver/pluginreceiver/rendered_config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/service.go
+++ b/receiver/pluginreceiver/service.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/service_test.go
+++ b/receiver/pluginreceiver/service_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/supplied_plugins_test.go
+++ b/receiver/pluginreceiver/supplied_plugins_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/pluginreceiver/timezone.go
+++ b/receiver/pluginreceiver/timezone.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/routereceiver/config.go
+++ b/receiver/routereceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/routereceiver/factory.go
+++ b/receiver/routereceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/routereceiver/factory_test.go
+++ b/receiver/routereceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/routereceiver/receiver.go
+++ b/receiver/routereceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/routereceiver/receiver_test.go
+++ b/receiver/routereceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/client.go
+++ b/receiver/sapnetweaverreceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/client_test.go
+++ b/receiver/sapnetweaverreceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/config.go
+++ b/receiver/sapnetweaverreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/config_test.go
+++ b/receiver/sapnetweaverreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/doc.go
+++ b/receiver/sapnetweaverreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/factory.go
+++ b/receiver/sapnetweaverreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/factory_test.go
+++ b/receiver/sapnetweaverreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/internal/models/request_model.go
+++ b/receiver/sapnetweaverreceiver/internal/models/request_model.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/internal/models/response_model.go
+++ b/receiver/sapnetweaverreceiver/internal/models/response_model.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc....
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/metrics.go
+++ b/receiver/sapnetweaverreceiver/metrics.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/scraper.go
+++ b/receiver/sapnetweaverreceiver/scraper.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/scraper_test.go
+++ b/receiver/sapnetweaverreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/sapnetweaverreceiver/webservice.go
+++ b/receiver/sapnetweaverreceiver/webservice.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/client.go
+++ b/receiver/splunksearchapireceiver/client.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/client_test.go
+++ b/receiver/splunksearchapireceiver/client_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/config_test.go
+++ b/receiver/splunksearchapireceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/factory.go
+++ b/receiver/splunksearchapireceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/factory_test.go
+++ b/receiver/splunksearchapireceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/integration_test.go
+++ b/receiver/splunksearchapireceiver/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/model.go
+++ b/receiver/splunksearchapireceiver/model.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/receiver.go
+++ b/receiver/splunksearchapireceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc....
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/splunksearchapireceiver/receiver_test.go
+++ b/receiver/splunksearchapireceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/config.go
+++ b/receiver/telemetrygeneratorreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/config_test.go
+++ b/receiver/telemetrygeneratorreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/doc.go
+++ b/receiver/telemetrygeneratorreceiver/doc.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/factory.go
+++ b/receiver/telemetrygeneratorreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/factory_test.go
+++ b/receiver/telemetrygeneratorreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/generators.go
+++ b/receiver/telemetrygeneratorreceiver/generators.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/host_metrics_generator.go
+++ b/receiver/telemetrygeneratorreceiver/host_metrics_generator.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/host_metrics_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/host_metrics_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/logs_generator.go
+++ b/receiver/telemetrygeneratorreceiver/logs_generator.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/logs_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/logs_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/logs_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/logs_receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/metrics_generator.go
+++ b/receiver/telemetrygeneratorreceiver/metrics_generator.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/metrics_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/metrics_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/metrics_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/metrics_receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/otlp_generator.go
+++ b/receiver/telemetrygeneratorreceiver/otlp_generator.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/otlp_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/otlp_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/receiver.go
+++ b/receiver/telemetrygeneratorreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/traces_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/traces_receiver.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/windows_events_generator.go
+++ b/receiver/telemetrygeneratorreceiver/windows_events_generator.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/receiver/telemetrygeneratorreceiver/windows_events_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/windows_events_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright observIQ, Inc.
+// Copyright Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/retrieve-available-components.sh
+++ b/scripts/retrieve-available-components.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright observIQ, Inc.
+# Copyright Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/support/create-support-bundle.bat
+++ b/scripts/support/create-support-bundle.bat
@@ -1,4 +1,4 @@
-:: Copyright  observIQ, Inc.
+:: Copyright  Bindplane, Inc.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.

--- a/scripts/support/create-support-bundle.ps1
+++ b/scripts/support/create-support-bundle.ps1
@@ -1,4 +1,4 @@
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/support/create-support-bundle.sh
+++ b/scripts/support/create-support-bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-module-version.sh
+++ b/scripts/update-module-version.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-otel.sh
+++ b/scripts/update-otel.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/updater/cmd/updater/main.go
+++ b/updater/cmd/updater/main.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/action/action.go
+++ b/updater/internal/action/action.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/action/file_action.go
+++ b/updater/internal/action/file_action.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/action/file_action_test.go
+++ b/updater/internal/action/file_action_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/action/service_action.go
+++ b/updater/internal/action/service_action.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/action/service_action_test.go
+++ b/updater/internal/action/service_action_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/file/file.go
+++ b/updater/internal/file/file.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/file/file_test.go
+++ b/updater/internal/file/file_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/install/install.go
+++ b/updater/internal/install/install.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/install/install_test.go
+++ b/updater/internal/install/install_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/logging/logging_others.go
+++ b/updater/internal/logging/logging_others.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/logging/logging_test.go
+++ b/updater/internal/logging/logging_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/logging/logging_windows.go
+++ b/updater/internal/logging/logging_windows.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path.go
+++ b/updater/internal/path/path.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path_darwin.go
+++ b/updater/internal/path/path_darwin.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path_linux.go
+++ b/updater/internal/path/path_linux.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path_test.go
+++ b/updater/internal/path/path_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path_windows.go
+++ b/updater/internal/path/path_windows.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/path/path_windows_test.go
+++ b/updater/internal/path/path_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/rollback/rollback.go
+++ b/updater/internal/rollback/rollback.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/rollback/rollback_test.go
+++ b/updater/internal/rollback/rollback_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service.go
+++ b/updater/internal/service/service.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_darwin.go
+++ b/updater/internal/service/service_darwin.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_darwin_test.go
+++ b/updater/internal/service/service_darwin_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_linux.go
+++ b/updater/internal/service/service_linux.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_linux_systemd_test.go
+++ b/updater/internal/service/service_linux_systemd_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_linux_sysv_test.go
+++ b/updater/internal/service/service_linux_sysv_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_test.go
+++ b/updater/internal/service/service_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_windows.go
+++ b/updater/internal/service/service_windows.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/service_windows_test.go
+++ b/updater/internal/service/service_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/service/testdata/test-windows-service.go
+++ b/updater/internal/service/testdata/test-windows-service.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/state/monitor.go
+++ b/updater/internal/state/monitor.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/state/monitor_test.go
+++ b/updater/internal/state/monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/updater/updater.go
+++ b/updater/internal/updater/updater.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/version/version.go
+++ b/updater/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc..
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updater/internal/version/version_test.go
+++ b/updater/internal/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright  observIQ, Inc.
+// Copyright  Bindplane, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/windows/LICENSE.rtf
+++ b/windows/LICENSE.rtf
@@ -68,7 +68,7 @@ You may add Your own copyright statement to Your modifications and may provide a
 APPENDIX: How to apply the Apache License to your work.\line\par
 
 \pard\li720\sa200\sl276\slmult1 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.\line\par
-Copyright observIQ Inc.\line\par
+Copyright Bindplane Inc.\line\par
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at\par
 {{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs18\par
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par

--- a/windows/scripts/build-msi.sh
+++ b/windows/scripts/build-msi.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/windows/scripts/fetch-dependencies.sh
+++ b/windows/scripts/fetch-dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/windows/scripts/test-install-msi.sh
+++ b/windows/scripts/test-install-msi.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/windows/scripts/test-uninstall-msi.sh
+++ b/windows/scripts/test-uninstall-msi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/windows/scripts/vagrant-prep.sh
+++ b/windows/scripts/vagrant-prep.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright  observIQ, Inc.
+# Copyright  Bindplane, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -1,6 +1,6 @@
 {
   "product": "observIQ Distro for OpenTelemetry Collector",
-  "company": "observIQ, Inc.",
+  "company": "Bindplane, Inc.",
   "license": "./LICENSE.rtf",
   "info": {
     "help-link": "https://observiq.com/contact/",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->
The following goes back through the code base and finds all non code based instances of observIQ and changes it to "Bindplane" this includes the licenses.

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
