### PR TITLE
chore: Update runner sizes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,7 +69,7 @@ jobs:
         run: make check-license
 
   gosec:
-    runs-on: ubuntu-24.04
+    runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
     steps:
@@ -115,7 +115,7 @@ jobs:
         run: make misspell
 
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
     steps:

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -43,7 +43,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest-8-cores, macos-13, windows-2022-8-cores]
+        os: [ubuntu-latest-4-cores, macos-13, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources
@@ -22,8 +22,8 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)
-        if: matrix.os != 'ubuntu-latest-8-cores'
+        if: matrix.os != 'ubuntu-latest-4-cores'
         run: make test-updater-integration
       - name: Run Updater Integration Tests (linux)
-        if: matrix.os == 'ubuntu-latest-8-cores'
+        if: matrix.os == 'ubuntu-latest-4-cores'
         run: sudo make test-updater-integration

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ else
 EXT?=
 endif
 
+SNAPSHOT := $(shell git rev-parse --short HEAD)
 PREVIOUS_TAG := $(shell git tag --sort=v:refname --no-contains HEAD | grep -E "[0-9]+\.[0-9]+\.[0-9]+$$" | tail -n1)
 CURRENT_TAG := $(shell git tag --sort=v:refname --points-at HEAD | grep -E "v[0-9]+\.[0-9]+\.[0-9]+$$" | tail -n1)
 # Version will be the tag pointing to the current commit, or the previous version tag if there is no such tag
-VERSION ?= $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG))
+VERSION ?= $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG)-SNAPSHOT-$(SNAPSHOT))
 
 # Build binaries for current GOOS/GOARCH by default
 .DEFAULT_GOAL := build-binaries
@@ -32,7 +33,7 @@ VERSION ?= $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG))
 # Builds just the agent for current GOOS/GOARCH pair
 .PHONY: agent
 agent:
-	go build -ldflags "-s -w -X github.com/observiq/bindplane-otel-collector/internal/version.version=1.71.5-SNAPSHOT-fd77aac2" -tags bindplane -o $(OUTDIR)/collector_$(GOOS)_$(GOARCH)$(EXT) ./cmd/collector
+	go build -ldflags "-s -w -X github.com/observiq/bindplane-otel-collector/internal/version.version=$(VERSION)" -tags bindplane -o $(OUTDIR)/collector_$(GOOS)_$(GOARCH)$(EXT) ./cmd/collector
 
 # Builds just the updater for current GOOS/GOARCH pair
 .PHONY: updater


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
During release, we had to bump the size of the workflow runners to get through it after the deprecation of the old ubuntu runners we were using. This PR is changing them to a more appropriate size for regular use.

Also updates the version used by the `make agent` command to be a snapshot build if not on a tag. This also fixes a change that was accidentally committed (not a major issue, only affects the dev cycle).

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
