### PR TITLE
deps: Use correct `nop` receiver import

### DIFF
--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -94,8 +94,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/nopreceiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 var defaultReceivers = []receiver.Factory{
@@ -147,6 +147,7 @@ var defaultReceivers = []receiver.Factory{
 	mysqlreceiver.NewFactory(),
 	netflowreceiver.NewFactory(),
 	nginxreceiver.NewFactory(),
+	nopreceiver.NewFactory(),
 	oktareceiver.NewFactory(),
 	opencensusreceiver.NewFactory(),
 	otlpreceiver.NewFactory(),
@@ -155,7 +156,6 @@ var defaultReceivers = []receiver.Factory{
 	postgresqlreceiver.NewFactory(),
 	prometheusreceiver.NewFactory(),
 	rabbitmqreceiver.NewFactory(),
-	receivertest.NewNopFactory(),
 	redisreceiver.NewFactory(),
 	riakreceiver.NewFactory(),
 	routereceiver.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver v0.121.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.121.0
 	go.opentelemetry.io/collector/processor/processortest v0.121.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.121.0
 )
 
 require (
@@ -483,6 +482,7 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.121.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.121.0 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.121.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.121.0 // indirect
 	go.opentelemetry.io/collector/scraper v0.121.0 // indirect
 	go.opentelemetry.io/collector/scraper/scraperhelper v0.121.0 // indirect
@@ -804,6 +804,7 @@ require (
 	go.etcd.io/bbolt v1.4.0 // indirect
 	go.mongodb.org/atlas v0.37.0 // indirect
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
+	go.opentelemetry.io/collector/receiver/nopreceiver v0.121.0
 	go.opentelemetry.io/collector/semconv v0.121.0 // indirect; indir7.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2819,6 +2819,8 @@ go.opentelemetry.io/collector/processor/xprocessor v0.121.0 h1:AiqDKzpEYZpiP9y3R
 go.opentelemetry.io/collector/processor/xprocessor v0.121.0/go.mod h1:Puk+6YYKyqLVKqpftUXg0blMrd3BlH/Av+oiajp1sHQ=
 go.opentelemetry.io/collector/receiver v0.121.0 h1:gQGAiSXX5ZjAqb3fZVlZc4DjT90at/HmnKzNG/XIdZw=
 go.opentelemetry.io/collector/receiver v0.121.0/go.mod h1:CqvQRwGGOqq6PRI6qmkKzF7AYWwRZTpCX6w7U3wIAmQ=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.121.0 h1:fAlBC6JXyKnd6OY0oK0pk1ROc/VfA0OonrPOixXBZqQ=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.121.0/go.mod h1:iyAp4FFiNCkERuFnFhHNbhNiVrk04pEZJQTEw5KLMMA=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.121.0 h1:cTV+pzpO1hU7QqMbtOLB5Nb0hDigoAyDpTMBMWjaj4M=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.121.0/go.mod h1:dt9HG89hdBxpT7Bsr8GnSwH3uIRh1FdrYIcFgtmg1SA=
 go.opentelemetry.io/collector/receiver/receivertest v0.121.0 h1:kdwV0tkaawRwKoZ1hl2xeYo4Oqfoa5drNX5I2J+rKhk=


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Turns out we're using the wrong nop receiver import, receivertest, instead of the legit one which is causing issues with available components in bp

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
