### PR TITLE
fix: Ticker bug in gRPC metrics collection

### DIFF
--- a/exporter/chronicleexporter/grpc_exporter.go
+++ b/exporter/chronicleexporter/grpc_exporter.go
@@ -79,7 +79,7 @@ func (exp *grpcExporter) Start(ctx context.Context, _ component.Host) error {
 
 	if exp.cfg.CollectAgentMetrics {
 		f := func(ctx context.Context, request *api.BatchCreateEventsRequest) error {
-			_, err := exp.client.BatchCreateEvents(ctx, request)
+			_, err := exp.client.BatchCreateEvents(ctx, request, exp.buildOptions()...)
 			return err
 		}
 		metrics, err := newHostMetricsReporter(exp.cfg, exp.set, exp.exporterID, f)

--- a/exporter/chronicleexporter/grpc_exporter.go
+++ b/exporter/chronicleexporter/grpc_exporter.go
@@ -120,10 +120,7 @@ func (exp *grpcExporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 }
 
 func (exp *grpcExporter) uploadToChronicle(ctx context.Context, request *api.BatchCreateLogsRequest) error {
-	if exp.metrics != nil {
-		totalLogs := int64(len(request.GetBatch().GetEntries()))
-		defer exp.metrics.recordSent(totalLogs)
-	}
+
 	_, err := exp.client.BatchCreateLogs(ctx, request, exp.buildOptions()...)
 	if err != nil {
 		errCode := status.Code(err)
@@ -139,6 +136,10 @@ func (exp *grpcExporter) uploadToChronicle(ctx context.Context, request *api.Bat
 		default:
 			return consumererror.NewPermanent(fmt.Errorf("upload logs to chronicle: %w", err))
 		}
+	}
+	if exp.metrics != nil {
+		totalLogs := int64(len(request.GetBatch().GetEntries()))
+		exp.metrics.recordSent(totalLogs)
 	}
 	return nil
 }

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -85,13 +85,16 @@ func newHostMetricsReporter(cfg *Config, set component.TelemetrySettings, export
 
 func (hmr *hostMetricsReporter) start() {
 	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	hmr.cancel = cancel
 	hmr.wg.Add(1)
+
 	go func() {
-		defer hmr.wg.Done()
+		defer func() {
+			hmr.wg.Done()
+			ticker.Stop()
+		}()
+
 		for {
 			select {
 			case <-ctx.Done():

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -84,12 +84,13 @@ func newHostMetricsReporter(cfg *Config, set component.TelemetrySettings, export
 }
 
 func (hmr *hostMetricsReporter) start() {
-	ticker := time.NewTicker(5 * time.Minute)
 	ctx, cancel := context.WithCancel(context.Background())
 	hmr.cancel = cancel
 	hmr.wg.Add(1)
 
 	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+
 		defer func() {
 			hmr.wg.Done()
 			ticker.Stop()


### PR DESCRIPTION
### Proposed Change

Ticker was cancelled immediately after creation in hostMetricsReporter.start()

This was a regression introduced in `v1.67.0`


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
