### PR TITLE
chore: Set Systemd LimitNOFILE=65000

### DIFF
--- a/service/observiq-otel-collector.service
+++ b/service/observiq-otel-collector.service
@@ -12,6 +12,7 @@ Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
 ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+LimitNOFILE=65000
 SuccessExitStatus=0
 TimeoutSec=20
 StandardOutput=journal


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

We have users operating collectors w/ > 1,000 concurrent TCP connections. Increasing the limit to 65,000 to match what we do w/ Bindplane.

![Screenshot From 2025-03-17 16-04-12](https://github.com/user-attachments/assets/1242f955-47f4-4d67-862c-7bbbdb6295c1)


##### Checklist
- [x] Changes are tested
- [x] CI has passed
