### PR TITLE
Revert "chore: Update modules to v1.74.0", bump modules to v1.73.1, replace `stanza`

### DIFF
--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/plugindocgen
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.1
 	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/plugindocgen
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.0
 	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwardere
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwardere
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/qradar
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/qradar
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,8 +4,8 @@ go 1.23.6
 
 require (
 	github.com/golang/snappy v1.0.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,8 +4,8 @@ go 1.23.6
 
 require (
 	github.com/golang/snappy v1.0.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.1
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -6,39 +6,39 @@ toolchain go1.24.1
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.73.0
-	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.73.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.73.0
-	github.com/observiq/bindplane-otel-collector/packagestate v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.73.1
+	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.73.1
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.1
+	github.com/observiq/bindplane-otel-collector/internal/report v1.73.1
+	github.com/observiq/bindplane-otel-collector/packagestate v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.73.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.122.0
@@ -207,8 +207,8 @@ require (
 )
 
 require (
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver v0.122.0
@@ -429,9 +429,9 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/netsampler/goflow2/v2 v2.2.2 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/observiq/bindplane-otel-collector/counter v1.73.0 // indirect
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.0 // indirect
+	github.com/observiq/bindplane-otel-collector/counter v1.73.1 // indirect
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.122.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,39 +6,39 @@ toolchain go1.24.1
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.74.0
-	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.74.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.74.0
-	github.com/observiq/bindplane-otel-collector/packagestate v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.73.0
+	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.73.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.73.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.122.0
@@ -207,8 +207,8 @@ require (
 )
 
 require (
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver v0.122.0
@@ -429,9 +429,9 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/netsampler/goflow2/v2 v2.2.2 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/observiq/bindplane-otel-collector/counter v1.74.0 // indirect
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0 // indirect
+	github.com/observiq/bindplane-otel-collector/counter v1.73.0 // indirect
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.122.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -983,3 +983,6 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.11.0
 
 replace github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter => ./exporter/googlecloudstorageexporter
+
+// This is a temporary replacement to pull in Bomin's PR here: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38149
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20250319170526-bba46d3e01a9

--- a/go.sum
+++ b/go.sum
@@ -1993,6 +1993,8 @@ github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7oOxrWo=
 github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
+github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20250319170526-bba46d3e01a9 h1:2st0v1DCUXwhg9rfxZ8SGRjNp4yYZCOvPnNXwh4Iiz8=
+github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20250319170526-bba46d3e01a9/go.mod h1:tcg6BLGKdAnc2Tek63KtIYlf07OlMVHDVkl8UJXLaWg=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -2193,8 +2195,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetr
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.122.0/go.mod h1:xRVCkxl7mUlRsp65vfpOZXsbD1WrUYBQJPeeGA4adj4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0/go.mod h1:MMvJIC26DIEZo5DR4Ub/WJD1aPVxKGpgJolXxTtjgLE=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.122.0 h1:svIr2YfIsCg7zkEy9QA3RVdOq6ArvPqLOY/6noq5dWU=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.122.0/go.mod h1:tcg6BLGKdAnc2Tek63KtIYlf07OlMVHDVkl8UJXLaWg=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.122.0 h1:NRRPQX2h+BUgAFjHLtCL35lJPELpj45FmImiwT/1etE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.122.0/go.mod h1:cLRBD0KTx58pTi2HlkqwNnJ4YGlDMh/ka5CRjYouhHk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azurelogs v0.122.0 h1:YVQpFFdsNBFkU1F8mi0PmTqKZDSoND4/3C01+GSPVqg=

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/internal/rehydration
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/consumer v1.28.0

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/internal/rehydration
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/consumer v1.28.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/datapointcountproc
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.73.0
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.1
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/datapointcountproc
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.74.0
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.73.0
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.1
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.74.0
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/processor/metricextractproce
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/processor/metricextractproce
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/report v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.73.1
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/report v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.73.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.73.0
-	github.com/observiq/bindplane-otel-collector/expr v1.73.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.1
+	github.com/observiq/bindplane-otel-collector/expr v1.73.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.74.0
-	github.com/observiq/bindplane-otel-collector/expr v1.74.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/counter v1.73.0
+	github.com/observiq/bindplane-otel-collector/expr v1.73.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurem
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurem
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0
 	github.com/stretchr/testify v1.10.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/component/componenttest v0.122.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.1
 	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/component/componenttest v0.122.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -5,8 +5,8 @@ go 1.23.6
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/component/componenttest v0.122.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
 	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0
 	go.opentelemetry.io/collector/component/componenttest v0.122.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.62.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.1
 	github.com/observiq/bindplane-otel-collector/internal/testutils v1.73.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapirece
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapirece
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.122.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.28.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.73.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.73.1
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.74.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.73.0
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Doing a patch release, so reverting the last module version bump and going to v1.73.1. 

Since only change for patch is replacing the stanza pkg, including that replace in this PR too to avoid running CI more than necessary.