### PR TITLE
fix: prevent agent from emitting metrics that have already been emitted

### DIFF
--- a/internal/measurements/throughput.go
+++ b/internal/measurements/throughput.go
@@ -238,7 +238,7 @@ func NewResettableThroughputMeasurementsRegistry(emitCountMetrics bool) *Resetta
 	return &ResettableThroughputMeasurementsRegistry{
 		measurements:     &sync.Map{},
 		emitCountMetrics: emitCountMetrics,
-		lastReportTime:   time.Now(),
+		lastReportTime:   time.Time{}, // Set to zero time to indicate that no metrics have been reported yet
 	}
 }
 

--- a/internal/measurements/throughput.go
+++ b/internal/measurements/throughput.go
@@ -261,7 +261,7 @@ func (ctmr *ResettableThroughputMeasurementsRegistry) OTLPMeasurements(extraAttr
 	ctmr.measurements.Range(func(_, value any) bool {
 		tm := value.(*ThroughputMeasurements)
 		// Only include metrics collected after the last report time
-		if tm.LastCollectionTime().After(ctmr.lastReportTime) {
+		if !tm.LastCollectionTime().Before(ctmr.lastReportTime) {
 			OTLPThroughputMeasurements(tm, ctmr.emitCountMetrics, extraAttributes).MoveAndAppendTo(sm.Metrics())
 		}
 		return true
@@ -281,5 +281,5 @@ func (ctmr *ResettableThroughputMeasurementsRegistry) OTLPMeasurements(extraAttr
 // Reset unregisters all throughput measurements in this registry
 func (ctmr *ResettableThroughputMeasurementsRegistry) Reset() {
 	ctmr.measurements = &sync.Map{}
-	ctmr.lastReportTime = time.Now()
+	ctmr.lastReportTime = time.Time{} // Set to zero time to indicate that no metrics have been reported yet
 }

--- a/internal/measurements/throughput_test.go
+++ b/internal/measurements/throughput_test.go
@@ -316,13 +316,14 @@ func TestResettableThroughputMeasurementsRegistry(t *testing.T) {
 
 		// Add more metrics to both processors
 		tmp1.AddMetrics(context.Background(), metrics)
+		tmp1.AddMetrics(context.Background(), metrics) // simulate out of sync between processors
 		tmp2.AddMetrics(context.Background(), metrics)
 		reg.OTLPMeasurements(nil)
 
 		reg.measurements.Range(func(key, value any) bool {
 			processorID := key.(string)
 			if processorID == "throughputmeasurement/1" {
-				require.Equal(t, int64(2), value.(*processorMeasurements).lastCollectedSequence)
+				require.Equal(t, int64(3), value.(*processorMeasurements).lastCollectedSequence)
 			}
 			if processorID == "throughputmeasurement/2" {
 				require.Equal(t, int64(2), value.(*processorMeasurements).lastCollectedSequence)

--- a/internal/measurements/throughput_test.go
+++ b/internal/measurements/throughput_test.go
@@ -236,6 +236,80 @@ func TestResettableThroughputMeasurementsRegistry(t *testing.T) {
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreTimestamp()))
 	})
 
+	t.Run("Test sequence tracking", func(t *testing.T) {
+		reg := NewResettableThroughputMeasurementsRegistry(false)
+
+		mp := metric.NewMeterProvider()
+		defer mp.Shutdown(context.Background())
+
+		tmp, err := NewThroughputMeasurements(mp, "throughputmeasurement/1", map[string]string{})
+		require.NoError(t, err)
+
+		metrics, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "host-metrics.yaml"))
+		require.NoError(t, err)
+
+		// First batch of metrics
+		tmp.AddMetrics(context.Background(), metrics)
+		require.NoError(t, reg.RegisterThroughputMeasurements("throughputmeasurement/1", tmp))
+
+		// Get first batch of measurements
+		firstMetrics := reg.OTLPMeasurements(nil)
+		require.NotEmpty(t, firstMetrics.DataPointCount())
+
+		// Add more metrics
+		tmp.AddMetrics(context.Background(), metrics)
+
+		// Get second batch of measurements
+		secondMetrics := reg.OTLPMeasurements(nil)
+		require.NotEmpty(t, secondMetrics.DataPointCount())
+
+		// Verify sequence numbers
+		require.Equal(t, int64(2), tmp.SequenceNumber())
+		require.Equal(t, int64(2), reg.lastCollectedSequences["throughputmeasurement/1"])
+
+		// Verify no new metrics if sequence hasn't changed
+		emptyMetrics := reg.OTLPMeasurements(nil)
+		require.Empty(t, emptyMetrics.DataPointCount())
+	})
+
+	t.Run("Test multiple processors with different sequences", func(t *testing.T) {
+		reg := NewResettableThroughputMeasurementsRegistry(false)
+
+		mp := metric.NewMeterProvider()
+		defer mp.Shutdown(context.Background())
+
+		// Create two processors
+		tmp1, err := NewThroughputMeasurements(mp, "throughputmeasurement/1", map[string]string{})
+		require.NoError(t, err)
+		tmp2, err := NewThroughputMeasurements(mp, "throughputmeasurement/2", map[string]string{})
+		require.NoError(t, err)
+
+		metrics, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "host-metrics.yaml"))
+		require.NoError(t, err)
+
+		// Add metrics to first processor
+		tmp1.AddMetrics(context.Background(), metrics)
+		require.NoError(t, reg.RegisterThroughputMeasurements("throughputmeasurement/1", tmp1))
+
+		// Get first batch of measurements
+		firstMetrics := reg.OTLPMeasurements(nil)
+		require.NotEmpty(t, firstMetrics.DataPointCount())
+
+		// Add metrics to second processor
+		tmp2.AddMetrics(context.Background(), metrics)
+		require.NoError(t, reg.RegisterThroughputMeasurements("throughputmeasurement/2", tmp2))
+
+		// Get second batch of measurements
+		secondMetrics := reg.OTLPMeasurements(nil)
+		require.NotEmpty(t, secondMetrics.DataPointCount())
+
+		// Verify sequence numbers
+		require.Equal(t, int64(1), tmp1.SequenceNumber())
+		require.Equal(t, int64(1), tmp2.SequenceNumber())
+		require.Equal(t, int64(1), reg.lastCollectedSequences["throughputmeasurement/1"])
+		require.Equal(t, int64(1), reg.lastCollectedSequences["throughputmeasurement/2"])
+	})
+
 	t.Run("Test registered measurements are in OTLP payload (with count metrics)", func(t *testing.T) {
 		reg := NewResettableThroughputMeasurementsRegistry(true)
 

--- a/opamp/observiq/measurements.go
+++ b/opamp/observiq/measurements.go
@@ -68,7 +68,7 @@ func newMeasurementsSender(l *zap.Logger, reporter MeasurementsReporter, opampCl
 		isRunning:            false,
 		done:                 make(chan struct{}),
 		wg:                   &sync.WaitGroup{},
-		lastSuccessfulSend:   time.Now(),
+		lastSuccessfulSend:   time.Time{}, // Set to zero time to indicate that no metrics have been reported yet
 	}
 }
 

--- a/opamp/observiq/measurements_test.go
+++ b/opamp/observiq/measurements_test.go
@@ -143,3 +143,58 @@ func TestMeasurementsSender(t *testing.T) {
 		ms.Stop()
 	})
 }
+
+func TestResettableThroughputMeasurementsRegistry(t *testing.T) {
+	t.Run("Test OTLPMeasurements only reports new metrics", func(t *testing.T) {
+		mp := metric.NewMeterProvider()
+		defer mp.Shutdown(context.Background())
+
+		processorID := "throughputmeasurement/1"
+		tm, err := measurements.NewThroughputMeasurements(mp, processorID, map[string]string{})
+		require.NoError(t, err)
+
+		// Add initial metrics
+		m, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "host-metrics.yaml"))
+		require.NoError(t, err)
+		tm.AddMetrics(context.Background(), m)
+
+		reg := measurements.NewResettableThroughputMeasurementsRegistry(false)
+		require.NoError(t, reg.RegisterThroughputMeasurements(processorID, tm))
+
+		// First call should include all metrics
+		metrics := reg.OTLPMeasurements(nil)
+		require.Equal(t, 1, metrics.DataPointCount())
+
+		// Second call with no new metrics should return empty metrics
+		metrics = reg.OTLPMeasurements(nil)
+		require.Equal(t, 0, metrics.DataPointCount())
+
+		// Add new metrics
+		tm.AddMetrics(context.Background(), m)
+
+		// Third call should only include the new metrics
+		metrics = reg.OTLPMeasurements(nil)
+		require.Equal(t, 1, metrics.DataPointCount())
+
+		// Verify the values are doubled (since we added the same metrics twice)
+		rm := metrics.ResourceMetrics().At(0)
+		sm := rm.ScopeMetrics().At(0)
+		metric1 := sm.Metrics().At(0)
+
+		// Get the expected values from the golden file
+		expectedMetrics, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "expected-throughput.yaml"))
+		require.NoError(t, err)
+		expectedRM := expectedMetrics.ResourceMetrics().At(0)
+		expectedSM := expectedRM.ScopeMetrics().At(0)
+		expectedMetric1 := expectedSM.Metrics().At(0)
+
+		// Compare the values (doubled)
+		require.Equal(t,
+			expectedMetric1.Sum().DataPoints().At(0).IntValue()*2,
+			metric1.Sum().DataPoints().At(0).IntValue())
+
+		// Fourth call with no new metrics should return empty metrics
+		metrics = reg.OTLPMeasurements(nil)
+		require.Equal(t, 0, metrics.DataPointCount())
+	})
+}

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -288,6 +288,15 @@ func (c *Client) Disconnect(ctx context.Context) error {
 
 	c.safeSetDisconnecting(true)
 	c.collector.Stop(ctx)
+
+	// Reset the measurements registry to prevent resending old metrics on reconnect
+	if c.measurementsSender != nil {
+		c.measurementsSender.Stop()
+	}
+	if c.topologySender != nil {
+		c.topologySender.Stop()
+	}
+
 	return c.opampClient.Stop(ctx)
 }
 

--- a/opamp/observiq/testdata/metrics/expected-throughput-doubled.yaml
+++ b/opamp/observiq/testdata/metrics/expected-throughput-doubled.yaml
@@ -1,0 +1,14 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - name: otelcol_processor_throughputmeasurement_metric_data_size
+            sum:
+              dataPoints:
+                - asInt: "11350"
+                  attributes:
+                    - key: processor
+                      value:
+                        stringValue: throughputmeasurement/1
+                  timeUnixNano: "1000000"
+        scope: {}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This change adds timestamps when throughput metrics are both collected and sent, and ensures that we are only sending metrics that have been collected after last transmission.  This prevents a scenario where an agent re-emits metrics after a disconnect/reconnect, causing out of order metrics to be received on the server.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
