### PR TITLE
chore(dependabot): Disable CI for dependabot

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   setup-tools:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout Sources
@@ -23,6 +24,7 @@ jobs:
         run: make install-tools
 
   check-fmt:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
@@ -46,6 +48,7 @@ jobs:
         run: make check-fmt
 
   check-license:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
@@ -69,6 +72,7 @@ jobs:
         run: make check-license
 
   gosec:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
@@ -92,6 +96,7 @@ jobs:
         run: make gosec
 
   misspell:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
@@ -115,6 +120,7 @@ jobs:
         run: make misspell
 
   lint:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     needs:
       - setup-tools
@@ -139,6 +145,7 @@ jobs:
 
   # Below checks don't need to run `make install-tools`
   check-plugin-docs:
+    if: github.actor != 'dependabot[bot]'
     runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout Sources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    if: github.actor != 'dependabot[bot]'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_linux:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources
@@ -25,6 +26,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_darwin:
+    if: github.actor != 'dependabot[bot]'
     runs-on: macos-14
     steps:
       - name: Checkout Sources
@@ -43,6 +45,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   unit-tests:
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Dependabot PRs consume a lot of PR. We consolidate dependabot PRs into one PR during release time. Therefore, we can disable CI on dependabot PRs.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
