### PR TITLE
Revert "deps: Update module versions to v1.75.0"

### DIFF
--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/plugindocgen
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.74.0
 	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwardere
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/qradar
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,8 +4,8 @@ go 1.23.6
 
 require (
 	github.com/golang/snappy v1.0.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.74.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.123.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -4,41 +4,41 @@ go 1.23.7
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.75.0
-	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.75.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.75.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.75.0
-	github.com/observiq/bindplane-otel-collector/packagestate v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.74.0
+	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.74.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.74.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.123.0
@@ -209,8 +209,8 @@ require (
 )
 
 require (
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.75.0
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver v0.123.0
@@ -437,9 +437,9 @@ require (
 	github.com/netsampler/goflow2/v2 v2.2.2 // indirect
 	github.com/nginx/nginx-prometheus-exporter v1.4.1 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/observiq/bindplane-otel-collector/counter v1.75.0 // indirect
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.75.0 // indirect
+	github.com/observiq/bindplane-otel-collector/counter v1.74.0 // indirect
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.123.0 // indirect

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/internal/rehydration
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/consumer v1.29.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/datapointcountproc
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.75.0
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/counter v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.75.0
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/counter v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/processor/metricextractproce
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.123.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/report v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.74.0
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.123.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.75.0
-	github.com/observiq/bindplane-otel-collector/expr v1.75.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.75.0
+	github.com/observiq/bindplane-otel-collector/counter v1.74.0
+	github.com/observiq/bindplane-otel-collector/expr v1.74.0
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurem
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.123.0
 	github.com/stretchr/testify v1.10.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.75.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.1
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.75.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.74.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0

--- a/receiver/googlecloudstoragerehydrationreceiver/go.mod
+++ b/receiver/googlecloudstoragerehydrationreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	cloud.google.com/go/storage v1.51.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapirece
 go 1.23.6
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.75.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.74.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.75.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.74.0
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Reverts observIQ/bindplane-otel-collector#2292 and bumps modules to v1.74.1