### PR TITLE
fix: Don't allow unsquashed embedded fields in config unmarshalling

### DIFF
--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -40,7 +40,7 @@ const (
 
 // Config the configuration for the azureblob exporter
 type Config struct {
-	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:"timeout"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:",squash"`
 	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 

--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -40,9 +40,9 @@ const (
 
 // Config the configuration for the azureblob exporter
 type Config struct {
-	exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:"timeout"`
+	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
+	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 
 	// ConnectionString is the Azure Blob Storage connection key,
 	// which can be found in the Azure Blob Storage resource on the Azure Portal. (no default)

--- a/exporter/azureblobexporter/factory.go
+++ b/exporter/azureblobexporter/factory.go
@@ -38,11 +38,11 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		Partition:     minutePartition,
-		Compression:   noCompression,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		Partition:        minutePartition,
+		Compression:      noCompression,
 	}
 }
 
@@ -62,7 +62,7 @@ func createMetricsExporter(ctx context.Context, params exporter.Settings, config
 		exp.metricsDataPusher,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(cfg.TimeoutConfig),
-		exporterhelper.WithQueue(cfg.QueueConfig),
+		exporterhelper.WithQueue(cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
 	)
 }
@@ -83,7 +83,7 @@ func createLogsExporter(ctx context.Context, params exporter.Settings, config co
 		exp.logsDataPusher,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(cfg.TimeoutConfig),
-		exporterhelper.WithQueue(cfg.QueueConfig),
+		exporterhelper.WithQueue(cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
 	)
 }
@@ -104,7 +104,7 @@ func createTracesExporter(ctx context.Context, params exporter.Settings, config 
 		exp.tracesDataPusher,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(cfg.TimeoutConfig),
-		exporterhelper.WithQueue(cfg.QueueConfig),
+		exporterhelper.WithQueue(cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
 	)
 }

--- a/exporter/azureblobexporter/factory_test.go
+++ b/exporter/azureblobexporter/factory_test.go
@@ -24,11 +24,11 @@ import (
 
 func Test_createDefaultConfig(t *testing.T) {
 	expectedCfg := &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		Partition:     minutePartition,
-		Compression:   noCompression,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		Partition:        minutePartition,
+		Compression:      noCompression,
 	}
 
 	actual := createDefaultConfig()

--- a/exporter/azureblobexporter/generated_component_test.go
+++ b/exporter/azureblobexporter/generated_component_test.go
@@ -3,11 +3,20 @@
 package azureblobexporter
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 var typ = component.MustNewType("azureblob")
@@ -18,4 +27,86 @@ func TestComponentFactoryType(t *testing.T) {
 
 func TestComponentConfigStruct(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig()))
+}
+
+func TestComponentLifecycle(t *testing.T) {
+	factory := NewFactory()
+
+	tests := []struct {
+		createFn func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error)
+		name     string
+	}{
+
+		{
+			name: "logs",
+			createFn: func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateLogs(ctx, set, cfg)
+			},
+		},
+
+		{
+			name: "metrics",
+			createFn: func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateMetrics(ctx, set, cfg)
+			},
+		},
+
+		{
+			name: "traces",
+			createFn: func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateTraces(ctx, set, cfg)
+			},
+		},
+	}
+
+	cm, err := confmaptest.LoadConf("metadata.yaml")
+	require.NoError(t, err)
+	cfg := factory.CreateDefaultConfig()
+	sub, err := cm.Sub("tests::config")
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(&cfg))
+
+	for _, tt := range tests {
+		t.Run(tt.name+"-shutdown", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), exportertest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			err = c.Shutdown(context.Background())
+			require.NoError(t, err)
+		})
+	}
+}
+
+func generateLifecycleTestLogs() plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("resource", "R1")
+	l := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	l.Body().SetStr("test log message")
+	l.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return logs
+}
+
+func generateLifecycleTestMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("resource", "R1")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test_metric")
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("test_attr", "value_1")
+	dp.SetIntValue(123)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return metrics
+}
+
+func generateLifecycleTestTraces() ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("resource", "R1")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.Attributes().PutStr("test_attr", "value_1")
+	span.SetName("test_span")
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-1 * time.Second)))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return traces
 }

--- a/exporter/azureblobexporter/go.mod
+++ b/exporter/azureblobexporter/go.mod
@@ -8,8 +8,10 @@ require (
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0
 	go.opentelemetry.io/collector/config/configretry v1.29.0
+	go.opentelemetry.io/collector/confmap v1.29.0
 	go.opentelemetry.io/collector/consumer v1.29.0
 	go.opentelemetry.io/collector/exporter v0.123.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.123.0
 	go.opentelemetry.io/collector/pdata v1.29.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -37,14 +39,19 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/confmap v1.29.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.123.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.123.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.123.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.123.0 // indirect
 	go.opentelemetry.io/collector/extension v1.29.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.123.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.29.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.123.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.123.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.123.0 // indirect
+	go.opentelemetry.io/collector/receiver v1.29.0 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.123.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.123.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/exporter/azureblobexporter/metadata.yaml
+++ b/exporter/azureblobexporter/metadata.yaml
@@ -10,4 +10,3 @@ tests:
   config:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
   skip_lifecycle: true
-  skip_shutdown: true

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -36,9 +36,9 @@ const (
 
 // Config defines configuration for the Chronicle exporter.
 type Config struct {
-	exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
+	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 
 	// Endpoint is the URL where Chronicle data will be sent.
 	Endpoint string `mapstructure:"endpoint"`

--- a/exporter/chronicleexporter/factory.go
+++ b/exporter/chronicleexporter/factory.go
@@ -44,7 +44,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		Protocol:                  protocolGRPC,
 		TimeoutConfig:             exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:               exporterhelper.NewDefaultQueueConfig(),
+		QueueBatchConfig:          exporterhelper.NewDefaultQueueConfig(),
 		BackOffConfig:             configretry.NewDefaultBackOffConfig(),
 		OverrideLogType:           true,
 		Compression:               noCompression,
@@ -82,7 +82,7 @@ func createLogsExporter(
 		exp.ConsumeLogs,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(c.TimeoutConfig),
-		exporterhelper.WithQueue(c.QueueConfig),
+		exporterhelper.WithQueue(c.QueueBatchConfig),
 		exporterhelper.WithRetry(c.BackOffConfig),
 		exporterhelper.WithStart(exp.Start),
 		exporterhelper.WithShutdown(exp.Shutdown),

--- a/exporter/chronicleexporter/factory_test.go
+++ b/exporter/chronicleexporter/factory_test.go
@@ -25,7 +25,7 @@ import (
 func Test_createDefaultConfig(t *testing.T) {
 	expectedCfg := &Config{
 		TimeoutConfig:             exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:               exporterhelper.NewDefaultQueueConfig(),
+		QueueBatchConfig:          exporterhelper.NewDefaultQueueConfig(),
 		BackOffConfig:             configretry.NewDefaultBackOffConfig(),
 		OverrideLogType:           true,
 		Endpoint:                  "malachiteingestion-pa.googleapis.com",

--- a/exporter/chronicleexporter/generated_component_test.go
+++ b/exporter/chronicleexporter/generated_component_test.go
@@ -3,11 +3,20 @@
 package chronicleexporter
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 var typ = component.MustNewType("chronicle")
@@ -18,4 +27,72 @@ func TestComponentFactoryType(t *testing.T) {
 
 func TestComponentConfigStruct(t *testing.T) {
 	require.NoError(t, componenttest.CheckConfigStruct(NewFactory().CreateDefaultConfig()))
+}
+
+func TestComponentLifecycle(t *testing.T) {
+	factory := NewFactory()
+
+	tests := []struct {
+		createFn func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error)
+		name     string
+	}{
+
+		{
+			name: "logs",
+			createFn: func(ctx context.Context, set exporter.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateLogs(ctx, set, cfg)
+			},
+		},
+	}
+
+	cm, err := confmaptest.LoadConf("metadata.yaml")
+	require.NoError(t, err)
+	cfg := factory.CreateDefaultConfig()
+	sub, err := cm.Sub("tests::config")
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(&cfg))
+
+	for _, tt := range tests {
+		t.Run(tt.name+"-shutdown", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), exportertest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			err = c.Shutdown(context.Background())
+			require.NoError(t, err)
+		})
+	}
+}
+
+func generateLifecycleTestLogs() plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("resource", "R1")
+	l := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	l.Body().SetStr("test log message")
+	l.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return logs
+}
+
+func generateLifecycleTestMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("resource", "R1")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test_metric")
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("test_attr", "value_1")
+	dp.SetIntValue(123)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return metrics
+}
+
+func generateLifecycleTestTraces() ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("resource", "R1")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.Attributes().PutStr("test_attr", "value_1")
+	span.SetName("test_span")
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-1 * time.Second)))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	return traces
 }

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0
 	go.opentelemetry.io/collector/config/configretry v1.29.0
+	go.opentelemetry.io/collector/confmap v1.29.0
 	go.opentelemetry.io/collector/consumer v1.29.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.123.0
 	go.opentelemetry.io/collector/exporter v0.123.0
@@ -73,7 +74,6 @@ require (
 	github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/confmap v1.29.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.123.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.123.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.123.0 // indirect

--- a/exporter/chronicleexporter/grpc_exporter_test.go
+++ b/exporter/chronicleexporter/grpc_exporter_test.go
@@ -81,7 +81,7 @@ func TestGRPCExporter(t *testing.T) {
 		cfg.Protocol = protocolGRPC
 		cfg.CustomerID = "00000000-1111-2222-3333-444444444444"
 		cfg.LogType = "FAKE"
-		cfg.QueueConfig.Enabled = false
+		cfg.QueueBatchConfig.Enabled = false
 		cfg.BackOffConfig.Enabled = false
 	}
 

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -72,7 +72,7 @@ func TestHTTPExporter(t *testing.T) {
 		cfg.Project = "fake"
 		cfg.Forwarder = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 		cfg.LogType = "FAKE"
-		cfg.QueueConfig.Enabled = false
+		cfg.QueueBatchConfig.Enabled = false
 		cfg.BackOffConfig.Enabled = false
 	}
 

--- a/exporter/chronicleexporter/metadata.yaml
+++ b/exporter/chronicleexporter/metadata.yaml
@@ -48,4 +48,3 @@ tests:
       }
     customer_id: "123e4567-e89b-12d3-a456-426614174000" # fake customer id
   skip_lifecycle: true
-  skip_shutdown: true

--- a/exporter/chronicleforwarderexporter/config.go
+++ b/exporter/chronicleforwarderexporter/config.go
@@ -37,7 +37,7 @@ const (
 
 // Config defines configuration for the Chronicle exporter.
 type Config struct {
-	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:"timeout"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:",squash"`
 	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 

--- a/exporter/chronicleforwarderexporter/config.go
+++ b/exporter/chronicleforwarderexporter/config.go
@@ -37,9 +37,9 @@ const (
 
 // Config defines configuration for the Chronicle exporter.
 type Config struct {
-	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:"timeout"`
+	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
+	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 
 	// ExportType is the type of export to use.
 	ExportType string `mapstructure:"export_type"`

--- a/exporter/chronicleforwarderexporter/factory.go
+++ b/exporter/chronicleforwarderexporter/factory.go
@@ -38,10 +38,10 @@ func NewFactory() exporter.Factory {
 // createDefaultConfig creates the default configuration for the exporter.
 func createDefaultConfig() component.Config {
 	return &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		ExportType:    exportTypeSyslog,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		ExportType:       exportTypeSyslog,
 		Syslog: SyslogConfig{
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",
@@ -77,7 +77,7 @@ func createLogsExporter(
 		exp.logsDataPusher,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(forwarderCfg.TimeoutConfig),
-		exporterhelper.WithQueue(forwarderCfg.QueueConfig),
+		exporterhelper.WithQueue(forwarderCfg.QueueBatchConfig),
 		exporterhelper.WithRetry(forwarderCfg.BackOffConfig),
 	)
 }

--- a/exporter/chronicleforwarderexporter/factory_test.go
+++ b/exporter/chronicleforwarderexporter/factory_test.go
@@ -26,10 +26,10 @@ import (
 
 func Test_createDefaultConfig(t *testing.T) {
 	expectedCfg := &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		ExportType:    exportTypeSyslog,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		ExportType:       exportTypeSyslog,
 		Syslog: SyslogConfig{
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",

--- a/exporter/googlecloudstorageexporter/config.go
+++ b/exporter/googlecloudstorageexporter/config.go
@@ -71,13 +71,13 @@ type Config struct {
 	Compression compressionType `mapstructure:"compression"`
 
 	// TimeoutConfig configures timeout settings for exporter operations.
-	exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	TimeoutConfig exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
 	// QueueConfig defines the queuing behavior for the exporter.
-	exporterhelper.QueueConfig `mapstructure:"sending_queue"`
+	QueueConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 
 	// BackOffConfig defines the retry behavior for failed operations.
-	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	BackOffConfig configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 }
 
 // Validate validates the config.

--- a/exporter/qradar/config.go
+++ b/exporter/qradar/config.go
@@ -29,9 +29,9 @@ import (
 
 // Config defines configuration for the QRadar exporter.
 type Config struct {
-	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:",squash"`
+	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
+	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 
 	// Syslog is the configuration for the connection to QRadar.
 	Syslog SyslogConfig `mapstructure:"syslog"`

--- a/exporter/qradar/factory.go
+++ b/exporter/qradar/factory.go
@@ -37,9 +37,9 @@ func NewFactory() exporter.Factory {
 // createDefaultConfig creates the default configuration for the exporter.
 func createDefaultConfig() component.Config {
 	return &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		Syslog: SyslogConfig{
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",
@@ -72,7 +72,7 @@ func createLogsExporter(
 		exp.logsDataPusher,
 		exporterhelper.WithCapabilities(exp.Capabilities()),
 		exporterhelper.WithTimeout(qradarCfg.TimeoutConfig),
-		exporterhelper.WithQueue(qradarCfg.QueueConfig),
+		exporterhelper.WithQueue(qradarCfg.QueueBatchConfig),
 		exporterhelper.WithRetry(qradarCfg.BackOffConfig),
 	)
 }

--- a/exporter/qradar/factory_test.go
+++ b/exporter/qradar/factory_test.go
@@ -25,9 +25,9 @@ import (
 
 func Test_createDefaultConfig(t *testing.T) {
 	expectedCfg := &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		Syslog: SyslogConfig{
 			AddrConfig: confignet.AddrConfig{
 				Endpoint:  "127.0.0.1:10514",

--- a/exporter/snowflakeexporter/config.go
+++ b/exporter/snowflakeexporter/config.go
@@ -33,9 +33,9 @@ const (
 
 // Config is the config for the Snowflake exporter
 type Config struct {
-	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	TimeoutConfig    exporterhelper.TimeoutConfig    `mapstructure:",squash"`
+	QueueBatchConfig exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
+	BackOffConfig    configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 
 	AccountIdentifier string             `mapstructure:"account_identifier"`
 	Username          string             `mapstructure:"username"`

--- a/exporter/snowflakeexporter/factory.go
+++ b/exporter/snowflakeexporter/factory.go
@@ -46,10 +46,10 @@ func createDefaultConfig() component.Config {
 	dsn, _ := gosnowflake.DSN(sfCfg)
 
 	return &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		Database:      defaultDatabase,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		Database:         defaultDatabase,
 		Logs: TelemetryConfig{
 			Schema: defaultLogsSchema,
 			Table:  defaultTable,
@@ -91,7 +91,7 @@ func createLogsExporter(
 		exporterhelper.WithShutdown(e.shutdown),
 		exporterhelper.WithCapabilities(e.Capabilities()),
 		exporterhelper.WithTimeout(e.cfg.TimeoutConfig),
-		exporterhelper.WithQueue(e.cfg.QueueConfig),
+		exporterhelper.WithQueue(e.cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(e.cfg.BackOffConfig),
 	)
 }
@@ -121,7 +121,7 @@ func createMetricsExporter(
 		exporterhelper.WithShutdown(e.shutdown),
 		exporterhelper.WithCapabilities(e.Capabilities()),
 		exporterhelper.WithTimeout(e.cfg.TimeoutConfig),
-		exporterhelper.WithQueue(e.cfg.QueueConfig),
+		exporterhelper.WithQueue(e.cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(e.cfg.BackOffConfig),
 	)
 }
@@ -151,7 +151,7 @@ func createTracesExporter(
 		exporterhelper.WithShutdown(e.shutdown),
 		exporterhelper.WithCapabilities(e.Capabilities()),
 		exporterhelper.WithTimeout(e.cfg.TimeoutConfig),
-		exporterhelper.WithQueue(e.cfg.QueueConfig),
+		exporterhelper.WithQueue(e.cfg.QueueBatchConfig),
 		exporterhelper.WithRetry(e.cfg.BackOffConfig),
 	)
 }

--- a/exporter/snowflakeexporter/factory_test.go
+++ b/exporter/snowflakeexporter/factory_test.go
@@ -24,10 +24,10 @@ import (
 
 func Test_createDefaultConfig(t *testing.T) {
 	expected := &Config{
-		TimeoutConfig: exporterhelper.NewDefaultTimeoutConfig(),
-		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),
-		BackOffConfig: configretry.NewDefaultBackOffConfig(),
-		Database:      defaultDatabase,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+		Database:         defaultDatabase,
 		Logs: TelemetryConfig{
 			Schema: defaultLogsSchema,
 			Table:  defaultTable,

--- a/receiver/bindplaneauditlogs/config.go
+++ b/receiver/bindplaneauditlogs/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	APIKey string `mapstructure:"api_key"`
 
 	// ClientConfig is the configuration for the HTTP client
-	confighttp.ClientConfig `mapstructure:",squash"`
+	ClientConfig confighttp.ClientConfig `mapstructure:",squash"`
 
 	// PollInterval is the interval at which the receiver polls for new audit logs
 	PollInterval time.Duration `mapstructure:"poll_interval"`
@@ -46,13 +46,13 @@ func (c *Config) Validate() error {
 		return errors.New("api_key cannot be empty")
 	}
 
-	if c.Endpoint == "" {
+	if c.ClientConfig.Endpoint == "" {
 		return errors.New("endpoint cannot be empty")
 	}
 
 	// parse the string into a url
 	var err error
-	c.bindplaneURL, err = url.Parse(c.Endpoint)
+	c.bindplaneURL, err = url.Parse(c.ClientConfig.Endpoint)
 	if err != nil {
 		return fmt.Errorf("error parsing endpoint: %w", err)
 	}

--- a/receiver/bindplaneauditlogs/logs.go
+++ b/receiver/bindplaneauditlogs/logs.go
@@ -63,7 +63,7 @@ func newBindplaneAuditLogsReceiver(cfg *Config, logger *zap.Logger, consumer con
 }
 
 func (r *bindplaneAuditLogsReceiver) Start(ctx context.Context, host component.Host) error {
-	client, err := r.cfg.ToClient(ctx, host, r.settings)
+	client, err := r.cfg.ClientConfig.ToClient(ctx, host, r.settings)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -184,7 +184,7 @@ func (r *bindplaneAuditLogsReceiver) processLogEvents(observedTime pcommon.Times
 
 	// Add resource attributes
 	resourceAttrs := resourceLogs.Resource().Attributes()
-	resourceAttrs.PutStr("bindplane_url", r.cfg.Endpoint)
+	resourceAttrs.PutStr("bindplane_url", r.cfg.ClientConfig.Endpoint)
 
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
 

--- a/receiver/httpreceiver/config.go
+++ b/receiver/httpreceiver/config.go
@@ -25,8 +25,8 @@ import (
 
 // Config defines the configuration for an HTTP receiver
 type Config struct {
-	Path                    string `mapstructure:"path"`
-	confighttp.ServerConfig `mapstructure:",squash"`
+	Path         string                  `mapstructure:"path"`
+	ServerConfig confighttp.ServerConfig `mapstructure:",squash"`
 }
 
 var (
@@ -39,18 +39,18 @@ var (
 
 // Validate ensures an HTTP receiver config is correct
 func (c *Config) Validate() error {
-	if c.Endpoint == "" {
+	if c.ServerConfig.Endpoint == "" {
 		return errNoEndpoint
 	}
 
-	if _, _, err := net.SplitHostPort(c.Endpoint); err != nil {
+	if _, _, err := net.SplitHostPort(c.ServerConfig.Endpoint); err != nil {
 		return errBadEndpoint
 	}
-	if c.TLSSetting != nil {
-		if c.TLSSetting.CertFile == "" && c.TLSSetting.CertPem == "" {
+	if c.ServerConfig.TLSSetting != nil {
+		if c.ServerConfig.TLSSetting.CertFile == "" && c.ServerConfig.TLSSetting.CertPem == "" {
 			return errNoCert
 		}
-		if c.TLSSetting.KeyFile == "" && c.TLSSetting.KeyPem == "" {
+		if c.ServerConfig.TLSSetting.KeyFile == "" && c.ServerConfig.TLSSetting.KeyPem == "" {
 			return errNoKey
 		}
 	}

--- a/receiver/m365receiver/client.go
+++ b/receiver/m365receiver/client.go
@@ -292,6 +292,9 @@ func (m *m365Client) GetJSON(ctx context.Context, endpoint string, end string, s
 		for _, b := range bodies {
 			var log = jsonLog{}
 			err = json.Unmarshal(b, &log)
+			if err != nil {
+				return []logData{}, err
+			}
 			data = append(data, logData{log: log, body: string(b)})
 		}
 	}

--- a/receiver/m365receiver/client_test.go
+++ b/receiver/m365receiver/client_test.go
@@ -123,7 +123,7 @@ func TestGetJSON(t *testing.T) {
 
 	// bad token
 	testClient.token = "bad"
-	testJSON, err = testClient.GetJSON(context.Background(), m365Mock.URL+"/testJSON", "", "")
+	_, err = testClient.GetJSON(context.Background(), m365Mock.URL+"/testJSON", "", "")
 	require.EqualError(t, err, "authorization denied")
 
 	m365Mock.Close()
@@ -183,7 +183,6 @@ func newMockServerCSV() *httptest.Server {
 			return
 		}
 		rw.WriteHeader(404)
-		return
 	}))
 }
 
@@ -267,7 +266,6 @@ func newMockServerSub() *httptest.Server {
 			))
 		}
 		rw.WriteHeader(404)
-		return
 	}))
 }
 
@@ -316,6 +314,5 @@ func newMockServerToken() *httptest.Server {
 			rw.Write([]byte(`{"error": "invalid_request"}`))
 		}
 		rw.WriteHeader(404)
-		return
 	}))
 }

--- a/receiver/m365receiver/config.go
+++ b/receiver/m365receiver/config.go
@@ -30,14 +30,14 @@ var clientSecretRegEx = regexp.MustCompile("^[a-zA-Z0-9-_.~]{1,40}$")
 
 // Config defines configuration for Microsoft Office 365 receiver.
 type Config struct {
-	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	confighttp.ClientConfig        `mapstructure:",squash"`
-	MetricsBuilderConfig           metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	TenantID                       string                        `mapstructure:"tenant_id"`
-	ClientID                       string                        `mapstructure:"client_id"`
-	ClientSecret                   string                        `mapstructure:"client_secret"`
-	Logs                           *LogsConfig                   `mapstructure:"logs"`
-	StorageID                      *component.ID                 `mapstructure:"storage"`
+	ControllerConfig     scraperhelper.ControllerConfig `mapstructure:",squash"`
+	ClientConfig         confighttp.ClientConfig        `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig  `mapstructure:",squash"`
+	TenantID             string                         `mapstructure:"tenant_id"`
+	ClientID             string                         `mapstructure:"client_id"`
+	ClientSecret         string                         `mapstructure:"client_secret"`
+	Logs                 *LogsConfig                    `mapstructure:"logs"`
+	StorageID            *component.ID                  `mapstructure:"storage"`
 }
 
 // LogsConfig defines configuration for the M365 logs receiver

--- a/receiver/m365receiver/integration_test.go
+++ b/receiver/m365receiver/integration_test.go
@@ -383,6 +383,5 @@ func httpTestHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	rw.WriteHeader(404)
-	return
 
 }

--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -98,7 +98,7 @@ func newM365Logs(cfg *Config, settings receiver.Settings, consumer consumer.Logs
 // creates the client for http requests, and initializes metadata struct
 func (l *m365LogsReceiver) Start(ctx context.Context, host component.Host) error {
 	// create default client
-	httpClient, err := l.cfg.ToClient(ctx, host, l.settings)
+	httpClient, err := l.cfg.ClientConfig.ToClient(ctx, host, l.settings)
 	if err != nil {
 		l.logger.Error("error creating HTTP client", zap.Error(err))
 		return err

--- a/receiver/m365receiver/logs_test.go
+++ b/receiver/m365receiver/logs_test.go
@@ -164,7 +164,7 @@ func TestParseOptionalAttributes(t *testing.T) {
 	w, e := m.Get("workload")
 	require.True(t, e)
 	require.Equal(t, "testWorkload", w.AsString())
-	w, e = m.Get("result_status")
+	_, e = m.Get("result_status")
 	require.False(t, e)
 }
 
@@ -203,6 +203,7 @@ func (mc *mockLogsClient) loadTestLogs(t *testing.T, file string) []logData {
 	for _, b := range data {
 		var log = jsonLog{}
 		err = json.Unmarshal([]byte(b), &log)
+		require.NoError(t, err)
 		ret = append(ret, logData{log: log, body: b})
 	}
 

--- a/receiver/m365receiver/scraper.go
+++ b/receiver/m365receiver/scraper.go
@@ -29,8 +29,6 @@ import (
 )
 
 type reportPair struct {
-	columns map[string]int //relevant metric name and index for csv file
-
 	endpoint string                                                                     //unique report endpoint
 	indexes  map[int]func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val int64) //map of csv file index and recordMetric func
 }
@@ -277,7 +275,7 @@ func newM365Scraper(
 }
 
 func (m *m365Scraper) start(ctx context.Context, host component.Host) error {
-	httpClient, err := m.cfg.ToClient(ctx, host, m.settings)
+	httpClient, err := m.cfg.ClientConfig.ToClient(ctx, host, m.settings)
 	if err != nil {
 		m.logger.Error("error creating HTTP client", zap.Error(err))
 		return err

--- a/receiver/sapnetweaverreceiver/client.go
+++ b/receiver/sapnetweaverreceiver/client.go
@@ -25,10 +25,10 @@ import (
 )
 
 func newSoapClient(ctx context.Context, cfg *Config, host component.Host, settings component.TelemetrySettings) (*soap.Client, error) {
-	httpClient, err := cfg.ToClient(ctx, host, settings)
+	httpClient, err := cfg.ClientConfig.ToClient(ctx, host, settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP Client: %w", err)
 	}
 
-	return soap.NewClient(cfg.Endpoint, soap.WithBasicAuth(cfg.Username, cfg.Password), soap.WithHTTPClient(httpClient)), nil
+	return soap.NewClient(cfg.ClientConfig.Endpoint, soap.WithBasicAuth(cfg.Username, cfg.Password), soap.WithHTTPClient(httpClient)), nil
 }

--- a/receiver/sapnetweaverreceiver/config.go
+++ b/receiver/sapnetweaverreceiver/config.go
@@ -43,8 +43,8 @@ var (
 
 // Config defines configuration for SAP Netweaver metrics receiver.
 type Config struct {
-	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	confighttp.ClientConfig        `mapstructure:"tls,omitempty,squash"`
+	ControllerConfig scraperhelper.ControllerConfig `mapstructure:",squash"`
+	ClientConfig     confighttp.ClientConfig        `mapstructure:"tls,omitempty,squash"`
 	// Metrics defines which metrics to enable for the scraper
 	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Endpoint string `mapstructure:"endpoint"`
@@ -64,7 +64,7 @@ func (cfg *Config) Validate() error {
 		errs = multierr.Append(errs, ErrNoPwd)
 	}
 
-	u, err := url.Parse(cfg.Endpoint)
+	u, err := url.Parse(cfg.ClientConfig.Endpoint)
 	if err != nil {
 		errs = multierr.Append(errs, ErrInvalidEndpoint)
 	}

--- a/receiver/sapnetweaverreceiver/config_test.go
+++ b/receiver/sapnetweaverreceiver/config_test.go
@@ -101,7 +101,7 @@ func TestValidate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			cfg := NewFactory().CreateDefaultConfig().(*Config)
-			cfg.Endpoint = tc.endpoint
+			cfg.ClientConfig.Endpoint = tc.endpoint
 			cfg.Username = tc.username
 			cfg.Password = tc.password
 			err := xconfmap.Validate(cfg)
@@ -126,10 +126,10 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(cfg))
 
 	expected := factory.CreateDefaultConfig().(*Config)
-	expected.Endpoint = "http://localhost:50013"
+	expected.ClientConfig.Endpoint = "http://localhost:50013"
 	expected.Password = "password"
 	expected.Username = "root"
-	expected.CollectionInterval = 60 * time.Second
+	expected.ControllerConfig.CollectionInterval = 60 * time.Second
 
 	require.Equal(t, expected, cfg)
 }

--- a/receiver/sapnetweaverreceiver/scraper_test.go
+++ b/receiver/sapnetweaverreceiver/scraper_test.go
@@ -139,7 +139,7 @@ func TestScraperScrape(t *testing.T) {
 	mockService.On("GetInstanceProperties").Return(InstancePropertiesResponse, nil)
 
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = defaultEndpoint
+	cfg.ClientConfig.Endpoint = defaultEndpoint
 	cfg.Username = "root"
 	cfg.Password = "password"
 	cfg.Profile = "/sapmnt/EPP/profile/EPP_D00_sap-app-1"
@@ -216,7 +216,7 @@ func TestScraperScrapeEmpty(t *testing.T) {
 	mockService.On("DpmonExecute", "echo q | /usr/sap/EPP/D00/exe/dpmon pf=/sapmnt/EPP/profile/EPP_D00_sap-app-1 v").Return("", nil)
 
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = defaultEndpoint
+	cfg.ClientConfig.Endpoint = defaultEndpoint
 	cfg.Username = "root"
 	cfg.Password = "password"
 	cfg.Profile = "/sapmnt/EPP/profile/EPP_D00_sap-app-1"
@@ -291,7 +291,7 @@ func TestScraperScrapeAPIError(t *testing.T) {
 	mockService.On("GetInstanceProperties").Return(nil, errors.New("unexpected error"))
 
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = defaultEndpoint
+	cfg.ClientConfig.Endpoint = defaultEndpoint
 	cfg.Username = "root"
 	cfg.Password = "password"
 	cfg.Profile = "/sapmnt/EPP/profile/EPP_D00_sap-app-1"

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -35,15 +35,15 @@ var (
 
 // Config struct to represent the configuration for the Splunk Search API receiver
 type Config struct {
-	confighttp.ClientConfig `mapstructure:",squash"`
-	Endpoint                string        `mapstructure:"endpoint"`
-	Username                string        `mapstructure:"splunk_username,omitempty"`
-	Password                string        `mapstructure:"splunk_password,omitempty"`
-	AuthToken               string        `mapstructure:"auth_token,omitempty"`
-	TokenType               string        `mapstructure:"token_type,omitempty"`
-	Searches                []Search      `mapstructure:"searches"`
-	JobPollInterval         time.Duration `mapstructure:"job_poll_interval"`
-	StorageID               *component.ID `mapstructure:"storage"`
+	ClientConfig    confighttp.ClientConfig `mapstructure:",squash"`
+	Endpoint        string                  `mapstructure:"endpoint"`
+	Username        string                  `mapstructure:"splunk_username,omitempty"`
+	Password        string                  `mapstructure:"splunk_password,omitempty"`
+	AuthToken       string                  `mapstructure:"auth_token,omitempty"`
+	TokenType       string                  `mapstructure:"token_type,omitempty"`
+	Searches        []Search                `mapstructure:"searches"`
+	JobPollInterval time.Duration           `mapstructure:"job_poll_interval"`
+	StorageID       *component.ID           `mapstructure:"storage"`
 }
 
 // Search struct to represent a Splunk search


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

As of the v0.123.0 release of the OpenTelemetry collector, unmarshalling structures that contain embedded structures without a mapstructure squash tag will fail to unmarshal.

This change alters all of our component configs to change any embedded structures in said configs to not be embedded any more.

Bonus: `exporterhelper.QueueConfig` was deprecated - `exporterhelper.QueueBatchConfig` is the recommended replacement.

##### Checklist
- [X] Changes are tested
- [X] CI has passed
