### PR TITLE
fix(windows): Enable overwrite of binary files during MSI package upgrade

### DIFF
--- a/windows/wix.json
+++ b/windows/wix.json
@@ -10,6 +10,7 @@
   "files": [
     {
       "path": "observiq-otel-collector.exe",
+      "overwrite": true,
       "service": {
         "name": "observiq-otel-collector",
         "start": "delayed",
@@ -19,7 +20,8 @@
       }
     },
     {
-      "path": "updater.exe"
+      "path": "updater.exe",
+      "overwrite": true
     },
     {
       "path": "config.yaml",
@@ -30,13 +32,16 @@
       "never_overwrite": true
     },
     {
-      "path": "opentelemetry-java-contrib-jmx-metrics.jar"
+      "path": "opentelemetry-java-contrib-jmx-metrics.jar",
+      "overwrite": true
     },
     {
-      "path": "VERSION.txt"
+      "path": "VERSION.txt",
+      "overwrite": true
     },
     {
-      "path": "LICENSE"
+      "path": "LICENSE",
+      "overwrite": true
     }
   ],
   "directories": [


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This should allow the MSI package upgrade to overwrite binaries even if they were replaced out of band using Bindplane's upgrade mechanism.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
