### PR TITLE
fix: add observedTimestamp and timestamp to raw in Windows Event Trace Receiver 

### DIFF
--- a/receiver/windowseventtracereceiver/internal/etw/consumer.go
+++ b/receiver/windowseventtracereceiver/internal/etw/consumer.go
@@ -157,7 +157,8 @@ func (c *Consumer) rawEventCallback(eventRecord *advapi32.EventRecord) uintptr {
 	xmlBuilder.WriteString("</Event>")
 
 	event := &Event{
-		Raw: xmlBuilder.String(),
+		Timestamp: parseTimestamp(uint64(eventRecord.EventHeader.TimeStamp)),
+		Raw:       xmlBuilder.String(),
 	}
 
 	select {

--- a/receiver/windowseventtracereceiver/receiver.go
+++ b/receiver/windowseventtracereceiver/receiver.go
@@ -168,6 +168,8 @@ func (lr *logsReceiver) rawEvent(event *etw.Event) (plog.Logs, error) {
 	resourceLog := logs.ResourceLogs().AppendEmpty()
 	scopeLog := resourceLog.ScopeLogs().AppendEmpty()
 	record := scopeLog.LogRecords().AppendEmpty()
+	record.SetTimestamp(pcommon.NewTimestampFromTime(event.Timestamp))
+	record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	record.Body().SetStr(event.Raw)
 	return logs, nil
 }

--- a/receiver/windowseventtracereceiver/receiver.go
+++ b/receiver/windowseventtracereceiver/receiver.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -188,6 +189,7 @@ func (lr *logsReceiver) parseEvent(event *etw.Event) (plog.Logs, error) {
 // parseEventData parses the event data and sets the log record with that data
 func (lr *logsReceiver) parseEventData(event *etw.Event, record plog.LogRecord) {
 	record.SetTimestamp(pcommon.NewTimestampFromTime(event.Timestamp))
+	record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	record.SetSeverityNumber(parseSeverity(event.System.Level))
 
 	record.Body().SetEmptyMap()


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
Was missed in iniital implementation but we should be setting the observedTimestamp when we are receiving logs. 

Missed due to timestamp being emitted as unix epoch time which is fairly easy to gloss over

```json

    {
      "resource": {},
      "scopeLogs": [
        {
          "scope": {},
          "logRecords": [
            {
              "timeUnixNano": "1744746519110896200",
              "observedTimeUnixNano": "1744746520271985400",
              "body": {
                "stringValue": "\u003cEvent\u003e\n  \u003cSystem\u003e\n    \u003cProvider Name=\"Microsoft-Windows-Kernel-File\" Guid=\"{{EDD08927-9CC4-4E65-B970-C2560FB5C289}}\"/\u003e\n    \u003cEventID\u003e15\u003c/EventID\u003e\n    \u003cVersion\u003e1\u003c/Version\u003e\n    \u003cLevel\u003e4\u003c/Level\u003e\n    \u003cTask\u003e15\u003c/Task\u003e\n    \u003cOpcode\u003e0\u003c/Opcode\u003e\n    \u003cKeywords\u003e0x8000000000000120\u003c/Keywords\u003e\n    \u003cTimeCreated SystemTime=\"2025-04-15T19:48:39.1108962Z\"/\u003e\n    \u003cExecution ProcessID=\"5376\" ThreadID=\"2844\"/\u003e\n    \u003cComputer\u003ekeith-windows-kickbox\u003c/Computer\u003e\n  \u003c/System\u003e\n  \u003cEventData\u003e\n    \u003cData Name=\"ExtraFlags\"\u003e[0x0]\u003c/Data\u003e\n    \u003cData Name=\"ByteOffset\"\u003e[0x6700000]\u003c/Data\u003e\n    \u003cData Name=\"Irp\"\u003e[0xFFFFB48358FCCB08]\u003c/Data\u003e\n    \u003cData Name=\"FileObject\"\u003e[0xFFFFB483591074B0]\u003c/Data\u003e\n    \u003cData Name=\"FileKey\"\u003e[0xFFFFE70FBA75D170]\u003c/Data\u003e\n    \u003cData Name=\"IssuingThreadId\"\u003e[2844]\u003c/Data\u003e\n    \u003cData Name=\"IOSize\"\u003e[0x80000]\u003c/Data\u003e\n    \u003cData Name=\"IOFlags\"\u003e[0x0]\u003c/Data\u003e\n  \u003c/EventData\u003e\n\u003c/Event\u003e"
              },
              "traceId": "",
              "spanId": ""
            }
          ]
        }
      ]
    },
```


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
