### PR TITLE
chore(release): Publish release artifacts to GCS

### DIFF
--- a/.github/workflows/manual_gcs_release_test.yml
+++ b/.github/workflows/manual_gcs_release_test.yml
@@ -1,7 +1,6 @@
 name: Test GCS Release Bucket
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   test_gcs_release_bucket:

--- a/.github/workflows/manual_gcs_release_test.yml
+++ b/.github/workflows/manual_gcs_release_test.yml
@@ -1,6 +1,7 @@
 name: Test GCS Release Bucket
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test_gcs_release_bucket:

--- a/.github/workflows/manual_gcs_release_test.yml
+++ b/.github/workflows/manual_gcs_release_test.yml
@@ -1,0 +1,17 @@
+name: Test GCS Release Bucket
+on:
+  workflow_dispatch:
+
+jobs:
+  test_gcs_release_bucket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_PROJECT_ID }}
+          credentials_json: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_CREDENTIALS }}
+      - name: Test Gsutil
+        run: gsutil ls gs://bdot-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,13 @@ jobs:
         with:
           # For goreleaser
           fetch-depth: 0
+      - name: Install Gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_PROJECT_ID }}
+          credentials_json: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_CREDENTIALS }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -634,6 +634,17 @@ release:
     - glob: "./scripts/install/install_unix.sh"
     - glob: "./scripts/install/install_macos.sh"
 
+# https://console.cloud.google.com/storage/browser/bdot-release
+blobs:
+  - provider: gs
+    bucket: bdot-release
+    directory: "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    extra_files:
+      - glob: "./observiq-otel-collector*.msi"
+      - glob: "./observiq-otel-collector*.msi.sig"
+      - glob: "./scripts/install/install_unix.sh"
+      - glob: "./scripts/install/install_macos.sh"
+
 # https://goreleaser.com/customization/changelog/
 changelog:
   use: github


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Updates Goreleaser to publish artifacts to Google Cloud Storage in addition to Github. In the future, we will update install scripts to download from GCS instead of Github.

### Testing

This PR includes a manual github workflow for ensuring the GCS auth is working. I had it run in the PR with success.

![image](https://github.com/user-attachments/assets/cac832b7-eb1b-4b4f-a50f-22965df375ef)

Locally, I disabled the Github release / changelog steps and ran a full release against a local tag. I can see artifacts in the bucket, in the correct directory. I have since cleaned up the folder.

![Screenshot From 2025-04-16 15-25-21](https://github.com/user-attachments/assets/a408defd-9a27-4d11-ba65-1ca3b71c5b13)


##### Checklist
- [x] Changes are tested
- [x] CI has passed
