### PR TITLE
fix: fix topology processor for v2 agents

### DIFF
--- a/extension/bindplaneextension/extension.go
+++ b/extension/bindplaneextension/extension.go
@@ -85,6 +85,14 @@ func (b *bindplaneExtension) RegisterTopologyState(processorID string, topology 
 	return b.topologyRegistry.RegisterTopologyState(processorID, topology)
 }
 
+func (b *bindplaneExtension) SetIntervalChan() chan time.Duration {
+	return b.topologyRegistry.SetIntervalChan()
+}
+
+func (b *bindplaneExtension) Reset() {
+	b.topologyRegistry.Reset()
+}
+
 func (b *bindplaneExtension) setupCustomCapabilities(host component.Host) error {
 	ext, ok := host.GetExtensions()[b.cfg.OpAMP]
 	if !ok {

--- a/processor/topologyprocessor/bindplane_registry.go
+++ b/processor/topologyprocessor/bindplane_registry.go
@@ -22,6 +22,6 @@ import (
 
 // GetTopologyRegistry returns the topology registry that should be registered to based on the component ID.
 // nil, nil may be returned by this function. In this case, the processor should not register it's topology state anywhere.
-func GetTopologyRegistry(host component.Host, bindplane component.ID) (TopoRegistry, error) {
+func GetTopologyRegistry(host component.Host, bindplane *component.ID) (TopoRegistry, error) {
 	return BindplaneAgentTopologyRegistry, nil
 }

--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -26,14 +26,11 @@ const defaultInterval = time.Minute
 
 // Config is the configuration for the processor
 type Config struct {
-	// Enabled controls whether this processor is enabled or not.
-	Enabled bool `mapstructure:"enabled"`
-
 	// Interval is the interval at which this processor sends topology messages to Bindplane
 	Interval time.Duration `mapstructure:"interval"`
 
 	// Bindplane extension to use in order to report topology. Optional.
-	BindplaneExtension component.ID `mapstructure:"bindplane_extension"`
+	BindplaneExtension *component.ID `mapstructure:"bindplane_extension"`
 
 	// Name of the Config where this processor is present
 	Configuration string `mapstructure:"configuration"`
@@ -47,11 +44,6 @@ type Config struct {
 
 // Validate validates the processor configuration
 func (cfg Config) Validate() error {
-	// Processor not enabled no validation needed
-	if !cfg.Enabled {
-		return nil
-	}
-
 	if cfg.Interval < 10*time.Second {
 		return errors.New("`interval` must be at least 10 seconds")
 	}

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -29,7 +29,6 @@ func TestConfigValidate(t *testing.T) {
 
 	t.Run("interval too low", func(t *testing.T) {
 		cfg := Config{
-			Enabled:        true,
 			Interval:       8 * time.Second,
 			AccountID:      "myacct",
 			Configuration:  "myConfig",
@@ -41,7 +40,6 @@ func TestConfigValidate(t *testing.T) {
 
 	t.Run("Empty configuration", func(t *testing.T) {
 		cfg := Config{
-			Enabled:        true,
 			Interval:       defaultInterval,
 			AccountID:      "myacct",
 			OrganizationID: "myorg",
@@ -52,7 +50,6 @@ func TestConfigValidate(t *testing.T) {
 
 	t.Run("Empty AccountID", func(t *testing.T) {
 		cfg := Config{
-			Enabled:        true,
 			Interval:       defaultInterval,
 			OrganizationID: "myorg",
 			Configuration:  "myconfig",
@@ -63,7 +60,6 @@ func TestConfigValidate(t *testing.T) {
 
 	t.Run("Empty OrganizationID", func(t *testing.T) {
 		cfg := Config{
-			Enabled:       true,
 			Interval:      defaultInterval,
 			AccountID:     "myacct",
 			Configuration: "myconfig",

--- a/processor/topologyprocessor/factory.go
+++ b/processor/topologyprocessor/factory.go
@@ -46,7 +46,6 @@ func NewFactory() processor.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Enabled:  false,
 		Interval: defaultInterval,
 	}
 }

--- a/processor/topologyprocessor/factory_test.go
+++ b/processor/topologyprocessor/factory_test.go
@@ -29,7 +29,6 @@ func TestNewFactory(t *testing.T) {
 	require.Equal(t, componentType, factory.Type())
 
 	expectedCfg := &Config{
-		Enabled:  false,
 		Interval: defaultInterval,
 	}
 
@@ -67,12 +66,11 @@ func TestCreateProcessorTwice_Logs(t *testing.T) {
 	set.ID = processorID
 
 	cfg := &Config{
-		Enabled:            true,
 		Interval:           defaultInterval,
 		Configuration:      "myConf",
 		AccountID:          "myAcct",
 		OrganizationID:     "myOrg",
-		BindplaneExtension: bindplaneExtensionID,
+		BindplaneExtension: &bindplaneExtensionID,
 	}
 
 	l1, err := createLogsProcessor(context.Background(), set, cfg, consumertest.NewNop())
@@ -105,12 +103,11 @@ func TestCreateProcessorTwice_Metrics(t *testing.T) {
 	set.ID = processorID
 
 	cfg := &Config{
-		Enabled:            true,
 		Interval:           defaultInterval,
 		Configuration:      "myConf",
 		AccountID:          "myAcct",
 		OrganizationID:     "myOrg",
-		BindplaneExtension: bindplaneExtensionID,
+		BindplaneExtension: &bindplaneExtensionID,
 	}
 
 	l1, err := createMetricsProcessor(context.Background(), set, cfg, consumertest.NewNop())
@@ -143,12 +140,11 @@ func TestCreateProcessorTwice_Traces(t *testing.T) {
 	set.ID = processorID
 
 	cfg := &Config{
-		Enabled:            true,
 		Interval:           defaultInterval,
 		Configuration:      "myConf",
 		AccountID:          "myAcct",
 		OrganizationID:     "myOrg",
-		BindplaneExtension: bindplaneExtensionID,
+		BindplaneExtension: &bindplaneExtensionID,
 	}
 
 	l1, err := createTracesProcessor(context.Background(), set, cfg, consumertest.NewNop())

--- a/processor/topologyprocessor/ocb_registry.go
+++ b/processor/topologyprocessor/ocb_registry.go
@@ -24,14 +24,13 @@ import (
 
 // GetTopologyRegistry returns the topology registry that should be registered to based on the component ID.
 // nil, nil may be returned by this function. In this case, the processor should not register it's topology state anywhere.
-func GetTopologyRegistry(host component.Host, bindplane component.ID) (TopoRegistry, error) {
-	var emptyComponentID component.ID
-	if bindplane == emptyComponentID {
+func GetTopologyRegistry(host component.Host, bindplane *component.ID) (TopoRegistry, error) {
+	if bindplane == nil {
 		// No bindplane component referenced, so we won't register our topology state anywhere.
 		return nil, nil
 	}
 
-	ext, ok := host.GetExtensions()[bindplane]
+	ext, ok := host.GetExtensions()[*bindplane]
 	if !ok {
 		return nil, fmt.Errorf("bindplane extension %q does not exist", bindplane)
 	}

--- a/processor/topologyprocessor/processor.go
+++ b/processor/topologyprocessor/processor.go
@@ -43,11 +43,10 @@ type topologyUpdate struct {
 
 type topologyProcessor struct {
 	logger      *zap.Logger
-	enabled     bool
 	topology    *TopoState
 	interval    time.Duration
 	processorID component.ID
-	bindplane   component.ID
+	bindplane   *component.ID
 
 	startOnce sync.Once
 }
@@ -70,6 +69,7 @@ func newTopologyProcessor(logger *zap.Logger, cfg *Config, processorID component
 		topology:    topology,
 		processorID: processorID,
 		interval:    cfg.Interval,
+		bindplane:   cfg.BindplaneExtension,
 		startOnce:   sync.Once{},
 	}, nil
 }

--- a/processor/topologyprocessor/processor_test.go
+++ b/processor/topologyprocessor/processor_test.go
@@ -34,7 +34,6 @@ func TestProcessor_Logs(t *testing.T) {
 	processorID := component.MustNewIDWithName("topology", "1")
 
 	tmp, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -77,7 +76,6 @@ func TestProcessor_Metrics(t *testing.T) {
 	processorID := component.MustNewIDWithName("topology", "1")
 
 	tmp, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -121,7 +119,6 @@ func TestProcessor_Traces(t *testing.T) {
 	processorID := component.MustNewIDWithName("topology", "1")
 
 	tmp, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -165,7 +162,6 @@ func TestProcessor_MissingHeader(t *testing.T) {
 	processorID := component.MustNewIDWithName("topology", "1")
 
 	tmp, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -199,7 +195,6 @@ func TestProcessor_Logs_TwoInstancesSameID(t *testing.T) {
 	processorID := component.MustNewIDWithName("topology", "1")
 
 	tmp1, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -208,7 +203,6 @@ func TestProcessor_Logs_TwoInstancesSameID(t *testing.T) {
 	require.NoError(t, err)
 
 	tmp2, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID2",
 		AccountID:      "myAccountID2",
@@ -231,7 +225,6 @@ func TestProcessor_Logs_TwoInstancesDifferentID(t *testing.T) {
 	processorID2 := component.MustNewIDWithName("topology", "2")
 
 	tmp1, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID",
 		AccountID:      "myAccountID",
@@ -240,7 +233,6 @@ func TestProcessor_Logs_TwoInstancesDifferentID(t *testing.T) {
 	require.NoError(t, err)
 
 	tmp2, err := newTopologyProcessor(zap.NewNop(), &Config{
-		Enabled:        true,
 		Interval:       time.Second,
 		OrganizationID: "myOrgID2",
 		AccountID:      "myAccountID2",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
- Fixes the topology processor logic for non-bindplane agents to correctly reference the bindplane extension
- Removed the unused `enabled` parameter for the topology processor

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
