### PR TITLE
chore: Clean up imports and force external testing in s3 event receiver

### DIFF
--- a/receiver/awss3eventreceiver/factory.go
+++ b/receiver/awss3eventreceiver/factory.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/metadata"
 )
 
 // errImproperCfgType error for when an invalid config type is passed to receiver creation funcs

--- a/receiver/awss3eventreceiver/factory_test.go
+++ b/receiver/awss3eventreceiver/factory_test.go
@@ -12,25 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package awss3eventreceiver
+package awss3eventreceiver_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver"
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/metadata"
 )
 
 // Test that the factory creates the default configuration correctly
 func TestFactoryCreateDefaultConfig(t *testing.T) {
-	factory := NewFactory()
+	factory := awss3eventreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
 	assert.Equal(t, metadata.Type, factory.Type())
@@ -39,7 +41,7 @@ func TestFactoryCreateDefaultConfig(t *testing.T) {
 
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 
-	receiverCfg, ok := cfg.(*Config)
+	receiverCfg, ok := cfg.(*awss3eventreceiver.Config)
 	require.True(t, ok)
 	assert.Equal(t, "", receiverCfg.SQSQueueURL)
 	assert.Equal(t, 15*time.Second, receiverCfg.StandardPollInterval)
@@ -52,10 +54,10 @@ func TestFactoryCreateDefaultConfig(t *testing.T) {
 // Test factory receiver creation methods
 func TestFactoryCreateReceivers(t *testing.T) {
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := awss3eventreceiver.NewFactory()
 
 	// Create valid config
-	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg := factory.CreateDefaultConfig().(*awss3eventreceiver.Config)
 	cfg.SQSQueueURL = "https://sqs.us-west-2.amazonaws.com/123456789012/test-queue"
 
 	// Create settings
@@ -77,10 +79,10 @@ func TestFactoryCreateReceivers(t *testing.T) {
 // Test factory error cases
 func TestFactoryCreateReceiverErrors(t *testing.T) {
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := awss3eventreceiver.NewFactory()
 
 	// Create invalid config
-	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg := factory.CreateDefaultConfig().(*awss3eventreceiver.Config)
 	cfg.SQSQueueURL = ""
 
 	// Create settings

--- a/receiver/awss3eventreceiver/receiver.go
+++ b/receiver/awss3eventreceiver/receiver.go
@@ -23,12 +23,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/backoff"
-	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/bpaws"
-	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/worker"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/backoff"
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/bpaws"
+	"github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver/internal/worker"
 )
 
 type logsReceiver struct {


### PR DESCRIPTION
This contains a few minor cleanup items noticed in #2352
1. Organize imports in the receiver
2. Test files use `_test` package to ensure we interacting with exported members only