### PR TITLE
fix: Do not use Start context for long running goroutines

### DIFF
--- a/receiver/awss3eventreceiver/receiver.go
+++ b/receiver/awss3eventreceiver/receiver.go
@@ -79,7 +79,9 @@ func newLogsReceiver(id component.ID, tel component.TelemetrySettings, cfg *Conf
 	}, nil
 }
 
-func (r *logsReceiver) Start(ctx context.Context, _ component.Host) error {
+func (r *logsReceiver) Start(_ context.Context, _ component.Host) error {
+	// Context passed to Start is not long running, so we can use a background context
+	ctx := context.Background()
 	r.startOnce.Do(func() {
 		// Create message channel
 		r.msgChan = make(chan workerMessage, r.cfg.Workers*2)


### PR DESCRIPTION
The context that is passed to `Start` is not intended for long running operations such as a persistent polling mechanism.

[See documentation here.](https://github.com/open-telemetry/opentelemetry-collector/blob/b4d17f61a3871b1c69e1a14f721411c4a732a982/component/component.go#L32-L36)