### PR TITLE
fix: make topology processor backwards compatible with older bp versions

### DIFF
--- a/opamp/config.go
+++ b/opamp/config.go
@@ -201,7 +201,7 @@ type Config struct {
 	AgentName                   *string           `yaml:"agent_name,omitempty" mapstructure:"agent_name,omitempty"`
 	MeasurementsInterval        time.Duration     `yaml:"measurements_interval,omitempty" mapstructure:"measurements_interval,omitempty"`
 	ExtraMeasurementsAttributes map[string]string `yaml:"extra_measurements_attributes,omitempty" mapstructure:"extra_measurements_attributes,omitempty"`
-	TopologyInterval            time.Duration     `yaml:"topology_interval,omitempty" mapstructure:"topology_interval,omitempty"`
+	TopologyInterval            *time.Duration    `yaml:"topology_interval,omitempty" mapstructure:"topology_interval,omitempty"`
 }
 
 // TLSConfig represents the TLS config to connect to OpAmp server
@@ -282,6 +282,12 @@ func ParseConfig(configLocation string) (*Config, error) {
 		return nil, fmt.Errorf("%s: %w", errPrefixParse, err)
 	}
 
+	// Default topology interval to 1 minute if not specified
+	if config.TopologyInterval == nil {
+		defaultInterval := time.Minute
+		config.TopologyInterval = &defaultInterval
+	}
+
 	// Using Secure TLS check files
 	if config.TLS != nil && !config.TLS.InsecureSkipVerify {
 		// If CA file is specified
@@ -317,7 +323,6 @@ func (c Config) Copy() *Config {
 		Endpoint:             c.Endpoint,
 		AgentID:              c.AgentID,
 		MeasurementsInterval: c.MeasurementsInterval,
-		TopologyInterval:     c.TopologyInterval,
 	}
 
 	if c.SecretKey != nil {
@@ -337,6 +342,10 @@ func (c Config) Copy() *Config {
 	}
 	if c.ExtraMeasurementsAttributes != nil {
 		cfgCopy.ExtraMeasurementsAttributes = maps.Clone(c.ExtraMeasurementsAttributes)
+	}
+	if c.TopologyInterval != nil {
+		cfgCopy.TopologyInterval = new(time.Duration)
+		*cfgCopy.TopologyInterval = *c.TopologyInterval
 	}
 
 	return cfgCopy
@@ -382,7 +391,7 @@ func (c Config) CmpUpdatableFields(o Config) (equal bool) {
 		return false
 	}
 
-	if c.TopologyInterval != o.TopologyInterval {
+	if !CmpDurationPtr(c.TopologyInterval, o.TopologyInterval) {
 		return false
 	}
 
@@ -395,6 +404,22 @@ func (c Config) CmpUpdatableFields(o Config) (equal bool) {
 
 // CmpStringPtr compares two string pointers for equality
 func CmpStringPtr(p1, p2 *string) bool {
+	switch {
+	case p1 == nil && p2 == nil:
+		return true
+	case p1 == nil && p2 != nil:
+		fallthrough
+	case p1 != nil && p2 == nil:
+		fallthrough
+	case *p1 != *p2:
+		return false
+	default:
+		return true
+	}
+}
+
+// CmpDurationPtr compares two duration pointers for equality
+func CmpDurationPtr(p1, p2 *time.Duration) bool {
 	switch {
 	case p1 == nil && p2 == nil:
 		return true

--- a/opamp/config.go
+++ b/opamp/config.go
@@ -201,7 +201,7 @@ type Config struct {
 	AgentName                   *string           `yaml:"agent_name,omitempty" mapstructure:"agent_name,omitempty"`
 	MeasurementsInterval        time.Duration     `yaml:"measurements_interval,omitempty" mapstructure:"measurements_interval,omitempty"`
 	ExtraMeasurementsAttributes map[string]string `yaml:"extra_measurements_attributes,omitempty" mapstructure:"extra_measurements_attributes,omitempty"`
-	TopologyInterval            *time.Duration    `yaml:"topology_interval,omitempty" mapstructure:"topology_interval,omitempty"`
+	TopologyInterval            *time.Duration    `yaml:"topology_interval" mapstructure:"topology_interval"`
 }
 
 // TLSConfig represents the TLS config to connect to OpAmp server

--- a/opamp/config.go
+++ b/opamp/config.go
@@ -282,12 +282,6 @@ func ParseConfig(configLocation string) (*Config, error) {
 		return nil, fmt.Errorf("%s: %w", errPrefixParse, err)
 	}
 
-	// Default topology interval to 1 minute if not specified
-	if config.TopologyInterval == nil {
-		defaultInterval := time.Minute
-		config.TopologyInterval = &defaultInterval
-	}
-
 	// Using Secure TLS check files
 	if config.TLS != nil && !config.TLS.InsecureSkipVerify {
 		// If CA file is specified

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -175,7 +175,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		clientLogger,
 		args.TopologyReporter,
 		observiqClient.opampClient,
-		*args.Config.TopologyInterval,
+		args.Config.TopologyInterval,
 	)
 
 	return observiqClient, nil

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -175,7 +175,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		clientLogger,
 		args.TopologyReporter,
 		observiqClient.opampClient,
-		args.Config.TopologyInterval,
+		*args.Config.TopologyInterval,
 	)
 
 	return observiqClient, nil

--- a/opamp/observiq/reload_funcs.go
+++ b/opamp/observiq/reload_funcs.go
@@ -55,7 +55,7 @@ func managerReload(client *Client, managerConfigPath string) opamp.ReloadFunc {
 			updatedKeys = append(updatedKeys, "extra_measurements_attributes")
 		}
 
-		if client.currentConfig.TopologyInterval != newConfig.TopologyInterval {
+		if !opamp.CmpDurationPtr(client.currentConfig.TopologyInterval, newConfig.TopologyInterval) {
 			updatedKeys = append(updatedKeys, "topology_interval")
 		}
 
@@ -126,7 +126,7 @@ func managerReload(client *Client, managerConfigPath string) opamp.ReloadFunc {
 		// Set new measurements interval and attributes
 		client.measurementsSender.SetInterval(client.currentConfig.MeasurementsInterval)
 		client.measurementsSender.SetExtraAttributes(client.currentConfig.ExtraMeasurementsAttributes)
-		client.topologySender.SetInterval(*client.currentConfig.TopologyInterval)
+		client.topologySender.SetInterval(client.currentConfig.TopologyInterval)
 
 		return true, nil
 	}

--- a/opamp/observiq/reload_funcs.go
+++ b/opamp/observiq/reload_funcs.go
@@ -126,7 +126,7 @@ func managerReload(client *Client, managerConfigPath string) opamp.ReloadFunc {
 		// Set new measurements interval and attributes
 		client.measurementsSender.SetInterval(client.currentConfig.MeasurementsInterval)
 		client.measurementsSender.SetExtraAttributes(client.currentConfig.ExtraMeasurementsAttributes)
-		client.topologySender.SetInterval(client.currentConfig.TopologyInterval)
+		client.topologySender.SetInterval(*client.currentConfig.TopologyInterval)
 
 		return true, nil
 	}

--- a/opamp/observiq/reload_funcs_test.go
+++ b/opamp/observiq/reload_funcs_test.go
@@ -100,7 +100,7 @@ func Test_managerReload(t *testing.T) {
 					ident:              newIdentity(zap.NewNop(), *currConfig, "0.0.0"),
 					currentConfig:      *currConfig,
 					measurementsSender: newMeasurementsSender(zap.NewNop(), nil, mockOpAmpClient, 0, nil),
-					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, 0),
+					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, nil),
 				}
 				reloadFunc := managerReload(client, managerFilePath)
 

--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -25,7 +25,7 @@ import (
 // Config is the configuration for the processor
 type Config struct {
 	// Interval is the interval at which this processor sends topology messages to Bindplane
-	// This parameter is only used in topology processor v1.75.0 and earlier.
+	// Deprecated: This parameter is only used in topology processor v1.75.0 and earlier.
 	// Leave this in for backwards compatibility with Bindplane < v1.90.0
 	Interval time.Duration `mapstructure:"interval"`
 

--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -17,12 +17,17 @@ package topologyprocessor
 
 import (
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 )
 
 // Config is the configuration for the processor
 type Config struct {
+	// Interval is the interval at which this processor sends topology messages to Bindplane
+	// This parameter is only used in topology processor v1.75.0 and earlier.
+	Interval time.Duration `mapstructure:"interval"`
+
 	// Bindplane extension to use in order to report topology. Optional.
 	BindplaneExtension *component.ID `mapstructure:"bindplane_extension"`
 

--- a/processor/topologyprocessor/config.go
+++ b/processor/topologyprocessor/config.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	// Interval is the interval at which this processor sends topology messages to Bindplane
 	// This parameter is only used in topology processor v1.75.0 and earlier.
+	// Leave this in for backwards compatibility with Bindplane < v1.90.0
 	Interval time.Duration `mapstructure:"interval"`
 
 	// Bindplane extension to use in order to report topology. Optional.

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -16,6 +16,7 @@ package topologyprocessor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -29,6 +30,18 @@ func TestConfigValidate(t *testing.T) {
 			Configuration:      "myConfig",
 			OrganizationID:     "myorg",
 			BindplaneExtension: &bindplaneExtensionID,
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("Valid config w/ interval", func(t *testing.T) {
+		bindplaneExtensionID := component.MustNewID("bindplane")
+		cfg := Config{
+			AccountID:          "myacct",
+			Configuration:      "myConfig",
+			OrganizationID:     "myorg",
+			BindplaneExtension: &bindplaneExtensionID,
+			Interval:           time.Minute,
 		}
 		require.NoError(t, cfg.Validate())
 	})

--- a/processor/topologyprocessor/config_test.go
+++ b/processor/topologyprocessor/config_test.go
@@ -34,7 +34,7 @@ func TestConfigValidate(t *testing.T) {
 		require.NoError(t, cfg.Validate())
 	})
 
-	t.Run("Valid config w/ interval", func(t *testing.T) {
+	t.Run("Valid config with interval", func(t *testing.T) {
 		bindplaneExtensionID := component.MustNewID("bindplane")
 		cfg := Config{
 			AccountID:          "myacct",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
Re-adds the `interval` parameter to the topology processor, making it backwards compatible with bindplane < v1.90.0

##### Checklist
- [x] Changes are tested
- [x] CI has passed

Testing Notes
![image](https://github.com/user-attachments/assets/55c0dc5c-23ac-4e2b-ae67-beb1f7a57d39)
