### PR TITLE
[extension/awss3eventextension]: Fix nested object handling

### DIFF
--- a/extension/awss3eventextension/internal/worker/worker.go
+++ b/extension/awss3eventextension/internal/worker/worker.go
@@ -133,6 +133,7 @@ func (w *Worker) downloadObject(ctx context.Context, object event.S3Object) erro
 		}
 	}
 
+	// #nosec: G304
 	tmpFile, err := os.Create(filepath.Join(filePathDir, filePathBase+".bptmp"))
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)

--- a/extension/awss3eventextension/internal/worker/worker.go
+++ b/extension/awss3eventextension/internal/worker/worker.go
@@ -123,7 +123,17 @@ func (w *Worker) downloadObject(ctx context.Context, object event.S3Object) erro
 
 	filePath := filepath.Join(bucketDir, object.Key)
 
-	tmpFile, err := os.Create(filepath.Join(filepath.Dir(filePath), filepath.Base(filePath)+".bptmp"))
+	filePathDir := filepath.Dir(filePath)
+	filePathBase := filepath.Base(filePath)
+
+	// The object could be nested in a directory structure
+	if filePathDir != bucketDir {
+		if err := os.MkdirAll(filePathDir, 0700); err != nil {
+			return fmt.Errorf("create object directory: %w", err)
+		}
+	}
+
+	tmpFile, err := os.Create(filepath.Join(filePathDir, filePathBase+".bptmp"))
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}

--- a/extension/awss3eventextension/internal/worker/worker.go
+++ b/extension/awss3eventextension/internal/worker/worker.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,27 +91,6 @@ func (w *Worker) ProcessMessage(ctx context.Context, msg types.Message, queueURL
 			zap.String("bucket", object.Bucket),
 			zap.String("key", object.Key),
 		)
-
-		// SQS will query escape S3 object paths, such as
-		// year=2025/month=05/day=01/hour=10/minute=31/logs_117078972.json
-		// and it will look like this: year%3D2025/month%3D05/day%3D01/hour%3D10/minute%3D32/logs_778496226.json
-		// The call to downloadObject will fail if we don't unescape the key.
-		originalKey := object.Key
-		objectStr, err := url.QueryUnescape(originalKey)
-		if err != nil {
-			w.tel.Logger.Error("unescape object key", zap.Error(err),
-				zap.String("bucket", object.Bucket),
-				zap.String("key", object.Key))
-			continue
-		}
-
-		if originalKey != objectStr {
-			object.Key = objectStr
-			w.tel.Logger.Debug("unescaped object key",
-				zap.String("original_key", originalKey),
-				zap.String("unescaped_key", objectStr),
-				zap.String("bucket", object.Bucket))
-		}
 
 		if err := w.downloadObject(ctx, object); err != nil {
 			if strings.Contains(err.Error(), "NoSuchKey") {

--- a/internal/aws/event/fdr_test.go
+++ b/internal/aws/event/fdr_test.go
@@ -43,6 +43,17 @@ func TestFDREventUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:     "single-escaped",
+			fileName: "single-escaped.json",
+			expectObjects: []event.S3Object{
+				{
+					Bucket: "cs-prod-cannon-8-dcba9n8oxpakjtn86o8w11bbthgagusw2b-s3alias",
+					Key:    "year=2025/month=05/day=01/hour=10/minute=32/logs_778496226.json",
+					Size:   13090,
+				},
+			},
+		},
+		{
 			name:     "multiple",
 			fileName: "multiple.json",
 			expectObjects: []event.S3Object{

--- a/internal/aws/event/s3_test.go
+++ b/internal/aws/event/s3_test.go
@@ -38,7 +38,7 @@ func TestS3EventUnmarshal(t *testing.T) {
 				{
 					EventType: "ObjectCreated:Put",
 					Bucket:    "s3eventreceiver-dev",
-					Key:       "test2.txt",
+					Key:       "year=2025/month=05/day=01/hour=10/minute=32/logs_778496226.json",
 					Size:      25,
 				},
 			},

--- a/internal/aws/event/testdata/fdr/single-escaped.json
+++ b/internal/aws/event/testdata/fdr/single-escaped.json
@@ -1,0 +1,16 @@
+{
+    "cid": "0123456789ABCDEFGHIJKLMNOPQRSTUV-WX",
+    "timestamp": 1662307838018,
+    "fileCount": 1,
+    "totalSize": 13090,
+    "bucket": "cs-prod-cannon-8-dcba9n8oxpakjtn86o8w11bbthgagusw2b-s3alias",
+    "pathPrefix": "abcd11658703038a-xyz593c5/data/61c7b298-bb3a-444f-9806-ef99a96c52a5",
+    "files":
+    [
+        {
+            "path": "year%3D2025%2Fmonth%3D05%2Fday%3D01%2Fhour%3D10%2Fminute%3D32%2Flogs_778496226.json",
+            "size": 13090,
+            "checksum": "272c1d2ff85083a586ccfec4e0cf5b11"
+        }
+    ]
+}

--- a/internal/aws/event/testdata/s3/created_single.json
+++ b/internal/aws/event/testdata/s3/created_single.json
@@ -27,7 +27,7 @@
                     "arn": "arn:aws:s3:::s3eventreceiver-dev"
                 },
                 "object": {
-                    "key": "test2.txt",
+                    "key": "year%3D2025/month%3D05/day%3D01/hour%3D10/minute%3D32/logs_778496226.json",
                     "size": 25,
                     "eTag": "a021c14602e4aebf8d8279e885b4bb7c",
                     "sequencer": "0067X3184E94X0E1A5"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When S3 objects are in sub directories, the extension fails with this error:

> {"level":"error","ts":"2025-05-01T09:43:54.136-0400","caller":"worker/worker.go:103","msg":"download object","error":"create temp file: open /opt/observiq-otel-collector/storage/s3event/s-01JT60ZG6N8S5NCCXGRBG5GETX/jsirianni/year%3D2025/month%3D05/day%3D01/hour%3D09/minute%3D43/logs_718579873.json.gz.bptmp: no such file or directory","bucket":"jsirianni","key":"year%3D2025/month%3D05/day%3D01/hour%3D09/minute%3D43/logs_718579873.json.gz","stacktrace":"[github.com/observiq/bindplane-otel-collector/extension/awss3eventextension/internal/worker.(*Worker).ProcessMessage](http://github.com/observiq/bindplane-otel-collector/extension/awss3eventextension/internal/worker.(*Worker).ProcessMessage)\n\t/home/runner/work/bindplane-otel-collector/bindplane-otel-collector/extension/awss3eventextension/internal/worker/worker.go:103\ngithub.com/observiq/bindplane-otel-collector/extension/awss3eventextension.(*awsS3EventExtension).runWorker\n\t/home/runner/work/bindplane-otel-collector/bindplane-otel-collector/extension/awss3eventextension/extension.go:95"}

This PR addresses the issue with two fixes:
-  Ensuring the directory is created before writing the object.
- Reversing the escaping done by SQS on S3 URI paths
  - The escaping caused the extension to fail to retrieve the object, because the escaped URL does not match the real object key.

### Testing

This resolve my issue, and files are now written:

```
/opt/observiq-otel-collector/storage/s3event
└── s-01JT60ZG6N8S5NCCXGRBG5GETX
    └── jsirianni
        └── year%3D2025
            └── month%3D05
                └── day%3D01
                    ├── hour%3D09
                    │   ├── minute%3D42
                    │   │   └── logs_823595435.json.gz.bptmp
                    │   ├── minute%3D46
                    │   │   └── logs_476303808.json.gz.bptmp
                    └── hour%3D10
                        ├── minute%3D00
                        │   └── logs_948656739.json.bptmp
                        ├── minute%3D01
                        │   └── logs_517821361.json.bptmp
```

I also tested objects that are in the root of the bucket. Working great.

Bindplane live preview shows logs consumed by the source type using this extension.

![Screenshot From 2025-05-01 11-02-04](https://github.com/user-attachments/assets/ebad4c49-db82-4ad9-ac3e-9796d41aad38)


##### Checklist
- [x] Changes are tested
- [x] CI has passed
