### PR TITLE
fix(secops): Default Batch Request Size Limit should be 4MB

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -35,8 +35,8 @@ The exporter can be configured using the following fields:
 | `compression`                   | string            | `none`                                 | `false`  | The compression type to use when sending logs. valid values are `none` and `gzip`           |
 | `ingestion_labels`              | map[string]string |                                        | `false`  | Key-value pairs of labels to be applied to the logs when sent to chronicle.                 |
 | `collect_agent_metrics`         | bool              | `true`                                 | `false`  | Enables collecting metrics about the agent's process and log ingestion metrics              |
-| `batch_request_size_limit_grpc` | int               | `1048576`                              | `false`  | The maximum size, in bytes, allowed for a gRPC batch creation request.                      |
-| `batch_request_size_limit_http` | int               | `1048576`                              | `false`  | The maximum size, in bytes, allowed for a HTTP batch creation request.                      |
+| `batch_request_size_limit_grpc` | int               | `4000000`                              | `false`  | The maximum size, in bytes, allowed for a gRPC batch creation request.                      |
+| `batch_request_size_limit_http` | int               | `4000000`                              | `false`  | The maximum size, in bytes, allowed for a HTTP batch creation request.                      |
 
 ### Log Type
 

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -87,12 +87,12 @@ type Config struct {
 	Forwarder string `mapstructure:"forwarder"`
 
 	// BatchRequestSizeLimitGRPC is the maximum batch request size, in bytes, that can be sent to Chronicle via the GRPC protocol
-	// This field is defaulted to 1048576 as that is the default Chronicle backend limit
+	// This field is defaulted to 4000000 as that is the default Chronicle backend limit
 	// Setting this option to a value above the Chronicle backend limit may result in rejected log batch requests
 	BatchRequestSizeLimitGRPC int `mapstructure:"batch_request_size_limit_grpc"`
 
 	// BatchRequestSizeLimitHTTP is the maximum batch request size, in bytes, that can be sent to Chronicle via the HTTP protocol
-	// This field is defaulted to 1048576 as that is the default Chronicle backend limit
+	// This field is defaulted to 4000000 as that is the default Chronicle backend limit
 	// Setting this option to a value above the Chronicle backend limit may result in rejected log batch requests
 	BatchRequestSizeLimitHTTP int `mapstructure:"batch_request_size_limit_http"`
 

--- a/exporter/chronicleexporter/factory.go
+++ b/exporter/chronicleexporter/factory.go
@@ -35,8 +35,8 @@ func NewFactory() exporter.Factory {
 
 const (
 	defaultEndpoint                  = "malachiteingestion-pa.googleapis.com"
-	defaultBatchRequestSizeLimitGRPC = 1048576
-	defaultBatchRequestSizeLimitHTTP = 1048576
+	defaultBatchRequestSizeLimitGRPC = 4000000
+	defaultBatchRequestSizeLimitHTTP = 4000000
 )
 
 // createDefaultConfig creates the default configuration for the exporter.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->


The new secops API limit is 4 MB.

- Bindplane source PR https://github.com/observIQ/bindplane-op-enterprise/pull/5037
- Doc PR https://github.com/observIQ/observiq.com/pull/691

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
