### PR TITLE
fix: Prevent panic in Chronicle HTTP exporter

### DIFF
--- a/exporter/chronicleexporter/grpc_exporter_test.go
+++ b/exporter/chronicleexporter/grpc_exporter_test.go
@@ -206,7 +206,7 @@ func TestGRPCJSONCredentialsError(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
 	defaultCfgMod(cfg)
-	cfg.Creds = "z" // This invalid JSON will cause the token source to error
+	cfg.Creds = "z"                    // This invalid JSON will cause the token source to error
 	require.NoError(t, cfg.Validate()) // TODO: Validate really should fail immediately when given invalid JSON as credentials
 
 	ctx := context.Background()

--- a/exporter/chronicleexporter/grpc_exporter_test.go
+++ b/exporter/chronicleexporter/grpc_exporter_test.go
@@ -191,3 +191,33 @@ func TestGRPCExporter(t *testing.T) {
 		})
 	}
 }
+
+// TestGRPCJSONCredentialsError tests that the GRPC exporter returns an error when the json credentials are invalid and does not panic during shutdown
+func TestGRPCJSONCredentialsError(t *testing.T) {
+	defaultCfgMod := func(cfg *Config) {
+		cfg.Protocol = protocolGRPC
+		cfg.CustomerID = "00000000-1111-2222-3333-444444444444"
+		cfg.LogType = "FAKE"
+		cfg.QueueBatchConfig.Enabled = false
+		cfg.BackOffConfig.Enabled = false
+	}
+
+	// Create and configure the exporter
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	defaultCfgMod(cfg)
+	cfg.Creds = "z" // This invalid JSON will cause the token source to error
+	require.NoError(t, cfg.Validate()) // TODO: Validate really should fail immediately when given invalid JSON as credentials
+
+	ctx := context.Background()
+	exp, err := f.CreateLogs(ctx, exportertest.NewNopSettings(typ), cfg)
+	require.NoError(t, err)
+
+	// Start should fail with invalid credentials
+	err = exp.Start(ctx, componenttest.NewNopHost())
+	require.Error(t, err)
+	require.EqualError(t, err, "load Google credentials: invalid character 'z' looking for beginning of value")
+
+	// Shutdown should not panic
+	require.NoError(t, exp.Shutdown(ctx))
+}

--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -78,9 +78,11 @@ func (exp *httpExporter) Start(ctx context.Context, _ component.Host) error {
 
 func (exp *httpExporter) Shutdown(context.Context) error {
 	defer http.DefaultTransport.(*http.Transport).CloseIdleConnections()
-	t := exp.client.Transport.(*oauth2.Transport)
-	if t.Base != nil {
-		t.Base.(*http.Transport).CloseIdleConnections()
+	if exp.client != nil {
+		t := exp.client.Transport.(*oauth2.Transport)
+		if t.Base != nil {
+			t.Base.(*http.Transport).CloseIdleConnections()
+		}
 	}
 	return nil
 }

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -215,7 +215,7 @@ func TestHTTPJSONCredentialsError(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
 	defaultCfgMod(cfg)
-	cfg.Creds = "z" // This invalid JSON will cause the token source to error
+	cfg.Creds = "z"                    // This invalid JSON will cause the token source to error
 	require.NoError(t, cfg.Validate()) // TODO: Validate really should fail immediately when given invalid JSON as credentials
 
 	ctx := context.Background()

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -198,8 +198,8 @@ func TestHTTPExporter(t *testing.T) {
 	}
 }
 
-// TestJSONCredentialsError tests that the exporter returns an error when the json credentials are invalid and does not panic during shutdown
-func TestJSONCredentialsError(t *testing.T) {
+// TestHTTPJSONCredentialsError tests that the HTTP exporter returns an error when the json credentials are invalid and does not panic during shutdown
+func TestHTTPJSONCredentialsError(t *testing.T) {
 	defaultCfgMod := func(cfg *Config) {
 		cfg.Protocol = protocolHTTPS
 		cfg.Location = "us"

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -197,3 +197,36 @@ func TestHTTPExporter(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONCredentialsError tests that the exporter returns an error when the json credentials are invalid and does not panic during shutdown
+func TestJSONCredentialsError(t *testing.T) {
+	defaultCfgMod := func(cfg *Config) {
+		cfg.Protocol = protocolHTTPS
+		cfg.Location = "us"
+		cfg.CustomerID = "00000000-1111-2222-3333-444444444444"
+		cfg.Project = "fake"
+		cfg.Forwarder = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		cfg.LogType = "FAKE"
+		cfg.QueueBatchConfig.Enabled = false
+		cfg.BackOffConfig.Enabled = false
+	}
+
+	// Create and configure the exporter
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	defaultCfgMod(cfg)
+	cfg.Creds = "z" // This invalid JSON will cause the token source to error
+	require.NoError(t, cfg.Validate()) // TODO: Validate really should fail immediately when given invalid JSON as credentials
+
+	ctx := context.Background()
+	exp, err := f.CreateLogs(ctx, exportertest.NewNopSettings(typ), cfg)
+	require.NoError(t, err)
+
+	// Start should fail with invalid credentials
+	err = exp.Start(ctx, componenttest.NewNopHost())
+	require.Error(t, err)
+	require.EqualError(t, err, "load Google credentials: invalid character 'z' looking for beginning of value")
+
+	// Shutdown should not panic
+	require.NoError(t, exp.Shutdown(ctx))
+}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The exporter will panic (HTTP only) if the json creds are malformed (like putting a 'z' in for creds)

We were missing a nil check in `Shutdown`. Added a test to validate that we error instead of panicking on shutdown in this situation.

Side note, we should really `Validate()` the JSON creds configuration field immediately in our Google destinations instead of letting it error later. 

# Testing

Previous (with most recent agent):

https://github.com/user-attachments/assets/2ce8240e-a1c3-4abc-ba90-cd7c4b2494a9

This PR (replaced agent binary): 

https://github.com/user-attachments/assets/179f6740-670e-4f8d-ad42-9045d2ea73d9


##### Checklist
- [x] Changes are tested
- [x] CI has passed
