### PR TITLE
feat(secops): Request count metric

### DIFF
--- a/exporter/chronicleexporter/documentation.md
+++ b/exporter/chronicleexporter/documentation.md
@@ -22,6 +22,14 @@ The size of the payload in bytes.
 | ---- | ----------- | ---------- |
 | B | Histogram | Int |
 
+### otelcol_exporter_request_count
+
+The total number of requests made.
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {requests} | Sum | Int | false |
+
 ### otelcol_exporter_request_latency
 
 The latency of the request in milliseconds.

--- a/exporter/chronicleexporter/grpc_exporter.go
+++ b/exporter/chronicleexporter/grpc_exporter.go
@@ -164,11 +164,9 @@ func (exp *grpcExporter) uploadToChronicle(ctx context.Context, request *api.Bat
 		}
 	}
 
-	exp.telemetry.ExporterRequestLatency.Record(ctx, time.Since(start).Milliseconds(),
+	exp.telemetry.ExporterRequestLatency.Record(ctx, time.Since(start).Milliseconds())
+	exp.telemetry.ExporterRequestCount.Add(ctx, 1,
 		metric.WithAttributeSet(attribute.NewSet(attrErrorNone)))
-
-	// Record request count
-	exp.telemetry.ExporterRequestCount.Add(ctx, 1)
 
 	if exp.metrics != nil {
 		totalLogs := int64(len(request.GetBatch().GetEntries()))

--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -158,7 +158,7 @@ func (exp *httpExporter) uploadToChronicleHTTP(ctx context.Context, logs *api.Im
 		ctx, time.Since(start).Milliseconds(),
 		metric.WithAttributeSet(attribute.NewSet(statusAttr)),
 	)
-	exp.telemetry.ExporterRequestLatency.Record(ctx, time.Since(start).Milliseconds(),
+	exp.telemetry.ExporterRequestCount.Add(ctx, 1,
 		metric.WithAttributeSet(attribute.NewSet(attrErrorNone)))
 
 	respBody, err := io.ReadAll(resp.Body)

--- a/exporter/chronicleexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/chronicleexporter/internal/metadata/generated_telemetry.go
@@ -28,6 +28,7 @@ type TelemetryBuilder struct {
 	registrations          []metric.Registration
 	ExporterBatchSize      metric.Int64Histogram
 	ExporterPayloadSize    metric.Int64Histogram
+	ExporterRequestCount   metric.Int64UpDownCounter
 	ExporterRequestLatency metric.Int64Histogram
 }
 
@@ -72,6 +73,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithDescription("The size of the payload in bytes."),
 		metric.WithUnit("B"),
 		metric.WithExplicitBucketBoundaries([]float64{100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1e+06, 2e+06, 3e+06, 4e+06, 5e+06}...),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterRequestCount, err = builder.meter.Int64UpDownCounter(
+		"otelcol_exporter_request_count",
+		metric.WithDescription("The total number of requests made."),
+		metric.WithUnit("{requests}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterRequestLatency, err = builder.meter.Int64Histogram(

--- a/exporter/chronicleexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/chronicleexporter/internal/metadatatest/generated_telemetrytest.go
@@ -51,6 +51,22 @@ func AssertEqualExporterPayloadSize(t *testing.T, tt *componenttest.Telemetry, d
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualExporterRequestCount(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_request_count",
+		Description: "The total number of requests made.",
+		Unit:        "{requests}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: false,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_request_count")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualExporterRequestLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_request_latency",

--- a/exporter/chronicleexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/chronicleexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -21,12 +21,16 @@ func TestSetupTelemetry(t *testing.T) {
 	defer tb.Shutdown()
 	tb.ExporterBatchSize.Record(context.Background(), 1)
 	tb.ExporterPayloadSize.Record(context.Background(), 1)
+	tb.ExporterRequestCount.Add(context.Background(), 1)
 	tb.ExporterRequestLatency.Record(context.Background(), 1)
 	AssertEqualExporterBatchSize(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPayloadSize(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterRequestCount(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterRequestLatency(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),

--- a/exporter/chronicleexporter/metadata.yaml
+++ b/exporter/chronicleexporter/metadata.yaml
@@ -32,6 +32,13 @@ telemetry:
         value_type: int
         bucket_boundaries: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 10000, 15000, 20000, 30000, 60000]
 
+    exporter_request_count:
+      enabled: true
+      description: "The total number of requests made."
+      unit: "{requests}"
+      sum:
+        value_type: int
+
 tests:
   config:
     protocol: "grpc"

--- a/exporter/chronicleexporter/monitoring.go
+++ b/exporter/chronicleexporter/monitoring.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package chronicleexporter
 
 import "go.opentelemetry.io/otel/attribute"

--- a/exporter/chronicleexporter/monitoring.go
+++ b/exporter/chronicleexporter/monitoring.go
@@ -1,0 +1,10 @@
+package chronicleexporter
+
+import "go.opentelemetry.io/otel/attribute"
+
+var (
+	attrError = "error"
+
+	attrErrorNone    attribute.KeyValue = attribute.String(attrError, "none")
+	attrErrorUnknown attribute.KeyValue = attribute.String(attrError, "unknown")
+)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Adds a request count metric to the secops exporter. This is the number of requests made to the secops API. The gRPC exporter will add the error code as an attribute.

### Testing

Using Google Cloud, I can chart the error rate percentage and rate by error type (unknown, timeout, etc).

![Screenshot From 2025-05-07 13-51-24](https://github.com/user-attachments/assets/e1e7a66c-9829-4db5-b93f-7aff46d0ab82)

![Screenshot From 2025-05-07 13-50-56](https://github.com/user-attachments/assets/03587e49-3b16-4559-9300-ffe646447e2e)

![Screenshot From 2025-05-07 13-51-04](https://github.com/user-attachments/assets/e7f78853-9fd1-4772-a4e1-c92fb5485506)

##### Checklist
- [x] Changes are tested
- [x] CI has passed
