### PR TITLE
chore(linuxpackage): Move binary install to /usr/bin, from /opt/observiq-otel-collector

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ builds:
       - -X github.com/observiq/bindplane-otel-collector/internal/version.date={{ .Date }}
     no_unique_dist_dir: false
   - id: updater
-    binary: updater
+    binary: updater-observiq-otel-collector
     dir: ./updater/
     main: ./cmd/updater
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ builds:
       - -X github.com/observiq/bindplane-otel-collector/internal/version.date={{ .Date }}
     no_unique_dist_dir: false
   - id: updater
-    binary: updater-observiq-otel-collector
+    binary: update-observiq-otel-collector
     dir: ./updater/
     main: ./cmd/updater
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ builds:
       - -X github.com/observiq/bindplane-otel-collector/internal/version.date={{ .Date }}
     no_unique_dist_dir: false
   - id: updater
-    binary: update-observiq-otel-collector
+    binary: updater
     dir: ./updater/
     main: ./cmd/updater
     env:
@@ -124,6 +124,8 @@ archives:
 
 nfpms:
   - id: collector
+    ids:
+      - collector
     file_name_template: "{{ .PackageName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     package_name: observiq-otel-collector
     vendor: observIQ, Inc
@@ -220,6 +222,12 @@ nfpms:
           mode: 0644
           owner: root
           group: root
+      - src: dist/updater_{{ .Os }}_{{ if eq .Arch "amd64" }}amd64_v1{{ else if eq .Arch "arm64" }}arm64_v8.0{{ else if eq .Arch "arm" }}arm_{{ .Arm }}{{ else if eq .Arch "ppc64le" }}ppc64le_power8{{ else if eq .Arch "ppc64" }}ppc64_power8{{ end }}/updater
+        dst: /opt/observiq-otel-collector/updater
+        file_info:
+          mode: 0750
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
     scripts:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -134,7 +134,7 @@ nfpms:
     formats:
       - rpm
       - deb
-    bindir: /opt/observiq-otel-collector
+    bindir: /usr/bin
     contents:
       - dst: /opt/observiq-otel-collector
         type: dir

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -92,7 +92,7 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to observiq-otel-collector
-  chown -R observiq-otel-collector:observiq-otel-collector /usr/bin/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
+  chown -R observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/plugins/*
   chmod 0640 /opt/observiq-otel-collector/plugins/*
 
   # Initialize the log file to ensure it is owned by observiq-otel-collector.

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -92,7 +92,7 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to observiq-otel-collector
-  chown -R observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
+  chown -R observiq-otel-collector:observiq-otel-collector /usr/bin/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
   chmod 0640 /opt/observiq-otel-collector/plugins/*
 
   # Initialize the log file to ensure it is owned by observiq-otel-collector.

--- a/service/observiq-otel-collector.service
+++ b/service/observiq-otel-collector.service
@@ -11,7 +11,7 @@ Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+ExecStart=/usr/bin/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000
 SuccessExitStatus=0
 TimeoutSec=20


### PR DESCRIPTION

<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This is a prerequisite step for customizable installation directory. Goreleaser requires a static install dir for binaries. `/usr/bin` is more appropriate anyway. Once this is merged, we can implement opt in directory configuration for /opt/observiq-otel-collector`.

I suspect more work will need to be done in this PR when it comes to the updater binary, now named `update-observiq-otel-collector` in `/usr/bin`. The name change was to avoid potential confusion, and to fall inline with other "updater" programs on my system. e.g. `update-ca-trust` and `update-mime-database`.

### Testing

Preliminary testing looks good. I can upgrade from the latest release without breaking.

I still need to test end to end. @dpaasman00 it would be nice to know if you have any ideas on what should be tested. I intend to test agent upgrade via UI, offline agent updates, and upgrading from older releases.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
