### PR TITLE
chore(linuxpackage): Use staging directory for collector install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,6 +124,9 @@ archives:
 
 nfpms:
   - id: collector
+    ids:
+      - collector
+      - updater
     file_name_template: "{{ .PackageName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     package_name: observiq-otel-collector
     vendor: observIQ, Inc
@@ -137,33 +140,151 @@ nfpms:
     bindir: /usr/bin
     contents:
       - dst: /opt/observiq-otel-collector
+        type: ghost
+      - dst: /opt/observiq-otel-collector/config.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/logging.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/LICENSE
+        type: ghost
+      - dst: /opt/observiq-otel-collector/VERSION.txt
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/active_directory_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/aerospike_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/apache_cassandra_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/apache_combined_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/apache_common_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/apache_http_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/bindplane_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/cisco_asa_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/cisco_catalyst_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/cisco_meraki_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/cockroachdb_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/cockroachdb_metrics.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/common_event_format_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/container_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/couchbase_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/couchbase_metrics.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/couchdb_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/csv_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/elasticsearch_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/esxi_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/file_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/hadoop_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/haproxy_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/hbase_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/iis_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/ingress_nginx_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/jboss_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/json_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/kafka_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/kubelet_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/macos_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/mongodb_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/mysql_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/nginx_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/oracle_database_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/oracledb_metrics.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/pgbouncer_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/postgresql_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/rabbitmq_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/redis_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/sap_hana_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/solr_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/sql_server_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/syslog_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/tcp_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/tomcat_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/ubiquiti_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/udp_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/vcenter_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/w3c_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/wildfly_logs.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/windows_dhcp.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/plugins/zookeeper_logs.yaml
+        type: ghost
+      - dst: /usr/share/bdot/stage/observiq-otel-collector
         type: dir
         file_info:
-          mode: 0755
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          mode: 0750
+          owner: root
+          group: root
       - src: release_deps/config.yaml
-        dst: /opt/observiq-otel-collector/config.yaml
+        dst: /usr/share/bdot/stage/observiq-otel-collector/config.yaml
         file_info:
           mode: 0640
           owner: observiq-otel-collector
           group: observiq-otel-collector
         type: config|noreplace
       - src: release_deps/logging.yaml
-        dst: /opt/observiq-otel-collector/logging.yaml
+        dst: /usr/share/bdot/stage/observiq-otel-collector/logging.yaml
         file_info:
           mode: 0640
           owner: observiq-otel-collector
           group: observiq-otel-collector
         type: config|noreplace
       - src: LICENSE
-        dst: /opt/observiq-otel-collector/LICENSE
+        dst: /usr/share/bdot/stage/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
           owner: observiq-otel-collector
           group: observiq-otel-collector
       - src: release_deps/VERSION.txt
-        dst: /opt/observiq-otel-collector/VERSION.txt
+        dst: /usr/share/bdot/stage/observiq-otel-collector/VERSION.txt
         file_info:
           mode: 0644
           owner: observiq-otel-collector
@@ -174,7 +295,7 @@ nfpms:
           mode: 0755
           owner: observiq-otel-collector
           group: observiq-otel-collector
-      - dst: /opt/observiq-otel-collector/plugins
+      - dst: /usr/share/bdot/stage/observiq-otel-collector/plugins
         type: dir
         file_info:
           mode: 0750 # restrict plugins to owner / group only
@@ -184,16 +305,16 @@ nfpms:
       # Attempting to set the permissions here results in the following error:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
       - src: release_deps/plugins/*
-        dst: /opt/observiq-otel-collector/plugins
+        dst: /usr/share/bdot/stage/observiq-otel-collector/plugins
       # Storage dir is used by stateful receivers, such as filelog receiver. It allows
       # receivers to track their progress and buffer data.
-      - dst: /opt/observiq-otel-collector/storage
+      - dst: /usr/share/bdot/stage/observiq-otel-collector/storage
         type: dir
         file_info:
           mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
-      - dst: /opt/observiq-otel-collector/log
+      - dst: /usr/share/bdot/stage/observiq-otel-collector/log
         type: dir
         file_info:
           mode: 0750

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -257,34 +257,34 @@ nfpms:
         type: ghost
       - dst: /opt/observiq-otel-collector/plugins/zookeeper_logs.yaml
         type: ghost
-      - dst: /usr/share/bdot/stage/observiq-otel-collector
+      - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector
         type: dir
         file_info:
           mode: 0750
           owner: root
           group: root
       - src: release_deps/config.yaml
-        dst: /usr/share/bdot/stage/observiq-otel-collector/config.yaml
+        dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/config.yaml
         file_info:
           mode: 0640
           owner: observiq-otel-collector
           group: observiq-otel-collector
         type: config|noreplace
       - src: release_deps/logging.yaml
-        dst: /usr/share/bdot/stage/observiq-otel-collector/logging.yaml
+        dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/logging.yaml
         file_info:
           mode: 0640
           owner: observiq-otel-collector
           group: observiq-otel-collector
         type: config|noreplace
       - src: LICENSE
-        dst: /usr/share/bdot/stage/observiq-otel-collector/LICENSE
+        dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
           owner: observiq-otel-collector
           group: observiq-otel-collector
       - src: release_deps/VERSION.txt
-        dst: /usr/share/bdot/stage/observiq-otel-collector/VERSION.txt
+        dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/VERSION.txt
         file_info:
           mode: 0644
           owner: observiq-otel-collector
@@ -295,7 +295,7 @@ nfpms:
           mode: 0755
           owner: observiq-otel-collector
           group: observiq-otel-collector
-      - dst: /usr/share/bdot/stage/observiq-otel-collector/plugins
+      - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/plugins
         type: dir
         file_info:
           mode: 0750 # restrict plugins to owner / group only
@@ -305,16 +305,16 @@ nfpms:
       # Attempting to set the permissions here results in the following error:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
       - src: release_deps/plugins/*
-        dst: /usr/share/bdot/stage/observiq-otel-collector/plugins
+        dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/plugins
       # Storage dir is used by stateful receivers, such as filelog receiver. It allows
       # receivers to track their progress and buffer data.
-      - dst: /usr/share/bdot/stage/observiq-otel-collector/storage
+      - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/storage
         type: dir
         file_info:
           mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
-      - dst: /usr/share/bdot/stage/observiq-otel-collector/log
+      - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/log
         type: dir
         file_info:
           mode: 0750
@@ -755,7 +755,7 @@ release:
     - glob: "./scripts/install/install_unix.sh"
     - glob: "./scripts/install/install_macos.sh"
 
-# https://console.cloud.google.com/storage/browser/bdot-release
+# https://console.cloud.google.com/storage/browser/observiq-otel-collector-release
 blobs:
   - provider: gs
     bucket: bdot-release

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -23,10 +23,10 @@ install() {
     chmod 0750 "${BDOT_CONFIG_HOME}"
     chown observiq-otel-collector:observiq-otel-collector "${BDOT_CONFIG_HOME}"
     cp -r --preserve \
-      /usr/share/bdot/stage/observiq-otel-collector/* \
+      /usr/share/observiq-otel-collector/stage/observiq-otel-collector/* \
       "${BDOT_CONFIG_HOME}"
 
-    rm -rf /usr/share/bdot
+    rm -rf /usr/share/observiq-otel-collector
 }
 
 manage_systemd_service() {

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -16,6 +16,19 @@
 
 set -e
 
+BDOT_CONFIG_HOME="/opt/observiq-otel-collector"
+
+install() {
+    mkdir -p "${BDOT_CONFIG_HOME}"
+    chmod 0750 "${BDOT_CONFIG_HOME}"
+    chown observiq-otel-collector:observiq-otel-collector "${BDOT_CONFIG_HOME}"
+    cp -r --preserve \
+      /usr/share/bdot/stage/observiq-otel-collector/* \
+      "${BDOT_CONFIG_HOME}"
+
+    rm -rf /usr/share/bdot
+}
+
 manage_systemd_service() {
   # Ensure sysv script isn't present, and if it is remove it
   if [ -f /etc/init.d/observiq-otel-collector ]; then
@@ -103,6 +116,6 @@ finish_permissions() {
   chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/log/collector.log
 }
 
-
+install
 finish_permissions
 manage_service


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Requires https://github.com/observIQ/bindplane-otel-collector/pull/2416

This is a prerequisite step for customizable installation directory. A follow up PR will implement a user configurable environment variable for overriding the default `/opt/observiq-otel-collector` directory.

All files in `nfpms[].contents` are now deployed to `/usr/share/observiq-otel-collector/stage/observiq-otel-collector`. The post install script manages copying the files into `/opt/observiq-otel-collector` (and eventually the user configured directory, if set).

All files previously managed by the package manager (anything in `nfpms[].contents`) is now marked as a `ghost` file / directory. This prevents the package manager from deleting them on upgrade. This is important because the package manager is now tracking `/usr/share/observiq-otel-collector`, not `/opt/observiq-otel-collector`.

Finally, the updater binary was moved to `/usr/bin/updat

### Testing

Still requires extensive testing. Particularly around upgrading from older installs.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
