### PR TITLE
chore(linuxpackage): Rename observiq-otel-collector user to bdot

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -276,40 +276,40 @@ nfpms:
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/config.yaml
         file_info:
           mode: 0640
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
         type: config|noreplace
       - src: release_deps/logging.yaml
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/logging.yaml
         file_info:
           mode: 0640
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
         type: config|noreplace
       - src: LICENSE
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - src: release_deps/VERSION.txt
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/VERSION.txt
         file_info:
           mode: 0644
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
         file_info:
           mode: 0755
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/plugins
         type: dir
         file_info:
           mode: 0750 # restrict plugins to owner / group only
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       # Note: plugins owner/group/mode is set in the post-install script
       # Attempting to set the permissions here results in the following error:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
@@ -321,14 +321,14 @@ nfpms:
         type: dir
         file_info:
           mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/log
         type: dir
         file_info:
           mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
     scripts:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -27,7 +27,7 @@ elif command -v service > /dev/null 2>&1; then
 fi
 
 # Script Constants
-COLLECTOR_USER="observiq-otel-collector"
+COLLECTOR_USER="bdot"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 MANAGEMENT_YML_PATH="/opt/observiq-otel-collector/manager.yaml"
 PREREQS="curl printf $SVC_PRE sed uname cut"

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -24,10 +24,12 @@ set -e
 
 : "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
 
+username="bdot"
+
 install() {
     mkdir -p "${BDOT_CONFIG_HOME}"
     chmod 0755 "${BDOT_CONFIG_HOME}"
-    chown observiq-otel-collector:observiq-otel-collector "${BDOT_CONFIG_HOME}"
+    chown "$username:$username" "${BDOT_CONFIG_HOME}"
     rm -f "${BDOT_CONFIG_HOME}/observiq-otel-collector" || true
     cp -r --preserve \
       /usr/share/observiq-otel-collector/stage/observiq-otel-collector/* \
@@ -64,7 +66,7 @@ StartLimitBurst=5
 [Service]
 Type=simple
 User=root
-Group=observiq-otel-collector
+Group=${username}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
@@ -432,7 +434,7 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to observiq-otel-collector
-  chown -R observiq-otel-collector:observiq-otel-collector ${BDOT_CONFIG_HOME}/observiq-otel-collector ${BDOT_CONFIG_HOME}/plugins/*
+  chown -R "$username:$username" ${BDOT_CONFIG_HOME}/observiq-otel-collector ${BDOT_CONFIG_HOME}/plugins/*
   chmod 0640 ${BDOT_CONFIG_HOME}/plugins/*
 
   # Initialize the log file to ensure it is owned by observiq-otel-collector.
@@ -440,7 +442,7 @@ finish_permissions() {
   # the root user. By doing so, we allow the user to switch to observiq-otel-collector
   # user for 'non root' installs.
   touch ${BDOT_CONFIG_HOME}/log/collector.log
-  chown observiq-otel-collector:observiq-otel-collector ${BDOT_CONFIG_HOME}/log/collector.log
+  chown "$username:$username" ${BDOT_CONFIG_HOME}/log/collector.log
 }
 
 install

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -16,18 +16,73 @@
 
 set -e
 
-username="observiq-otel-collector"
+username="bdot"
+legacy_username="observiq-otel-collector"
 
-if getent group "$username" > /dev/null 2>&1; then
-    echo "Group ${username} already exists."
-else
-    groupadd "$username"
-fi
+# Install creates the user and group for the collector
+# service. This function is idempotent and safe to call
+# multiple times.
+install() {
+    # Return early without output if the user and group already exist.
+    # This will help avoid confusion with the output in migrate_user().
+    if id "$username" > /dev/null 2>&1 && getent group "$username" > /dev/null 2>&1; then
+        return
+    fi
 
-if id "$username" > /dev/null 2>&1; then
-    echo "User ${username} already exists"
-    exit 0
-else
-    useradd --shell /sbin/nologin --system "$username" -g "$username"
-fi
+    if getent group "$username" > /dev/null 2>&1; then
+        echo "Group ${username} already exists."
+    else
+        groupadd "$username"
+    fi
 
+    if id "$username" > /dev/null 2>&1; then
+        echo "User ${username} already exists"
+        exit 0
+    else
+        useradd --shell /sbin/nologin --system "$username" -g "$username"
+    fi
+}
+
+# migrate_user migrates the legacy user to the new username.
+migrate_user() {
+    _migrate_user
+    _migrate_group
+
+    echo "User migration complete."
+}
+
+_migrate_user() {
+    if ! id "$legacy_username" > /dev/null 2>&1; then
+        echo "Skipping user migration: Legacy user ${legacy_username} does not exist."
+        return
+    fi
+
+    if id "$username" > /dev/null 2>&1; then
+        echo "Skipping user migration: User ${username} already exists."
+        return
+    fi
+
+    echo "Renaming user ${legacy_username} to ${username}"
+    usermod -l "$username" "$legacy_username"
+}
+
+_migrate_group() {
+    if ! getent group "$legacy_username" > /dev/null 2>&1; then
+        echo "Skipping group migration: Legacy group ${legacy_username} does not exist."
+        return
+    fi
+
+    if getent group "$username" > /dev/null 2>&1; then
+        echo "Skipping group migration: Group ${username} already exists."
+        return
+    fi
+
+    echo "Renaming group ${legacy_username} to ${username}"
+
+    # TODO(jsirianni /  Dylan-M): Groupmod will not work on AIX
+    # Discussion: https://github.com/observIQ/bindplane-otel-collector/pull/2436
+    groupmod -n "$username" "$legacy_username"
+}
+
+migrate_user
+install

--- a/updater/internal/updater/testdata/observiq-otel-collector.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.golden
@@ -1,46 +1,4 @@
-// Copyright observIQ, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Package updater provides templates for service files.
-package updater
-
-// Constants for service file templates
-const systemdServiceTemplate = `[Unit]
-Description=observIQ's distribution of the OpenTelemetry collector
-After=network.target
-StartLimitIntervalSec=120
-StartLimitBurst=5
-[Service]
-Type=simple
-User=root
-Group={{.Group}}
-Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
-WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
-LimitNOFILE=65000
-SuccessExitStatus=0
-TimeoutSec=20
-StandardOutput=journal
-Restart=on-failure
-RestartSec=5s
-KillMode=process
-[Install]
-WantedBy=multi-user.target`
-
-const initScriptTemplate = `#!/bin/sh
+#!/bin/sh
 # observIQ OTEL daemon
 # chkconfig: 2345 99 05
 # description: observIQ's distribution of the OpenTelemetry collector
@@ -293,4 +251,4 @@ if [ "$RCSTATUS" ]; then
   rc_exit
 fi
 
-exit "$RETVAL"`
+exit "$RETVAL" 

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -1,0 +1,23 @@
+[Unit]
+Description=observIQ's distribution of the OpenTelemetry collector
+After=network.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+[Service]
+Type=simple
+User=root
+Group=bdot
+Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+WorkingDirectory=/opt/observiq-otel-collector
+ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+LimitNOFILE=65000
+SuccessExitStatus=0
+TimeoutSec=20
+StandardOutput=journal
+Restart=on-failure
+RestartSec=5s
+KillMode=process
+[Install]
+WantedBy=multi-user.target 

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -15,7 +15,11 @@
 package updater
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/observiq/bindplane-otel-collector/packagestate"
@@ -44,7 +48,7 @@ func TestNewUpdater(t *testing.T) {
 		assert.NotNil(t, updater.rollbacker)
 		assert.NotNil(t, updater.monitor)
 		assert.NotNil(t, updater.logger)
-		assert.Equal(t, installDir, updater.installDir)
+		require.Equal(t, installDir, updater.installDir)
 	})
 
 	t.Run("New updater fails due to missing package statuses", func(t *testing.T) {
@@ -66,12 +70,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(nil)
@@ -93,12 +98,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(errors.New("insufficient permissions"))
@@ -116,12 +122,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -145,12 +152,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -174,12 +182,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -204,12 +213,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -234,12 +244,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -265,12 +276,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -296,12 +308,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(nil)
@@ -313,5 +326,63 @@ func TestUpdaterUpdate(t *testing.T) {
 
 		err := updater.Update()
 		require.ErrorContains(t, err, "failed while monitoring for success")
+	})
+}
+
+func TestGenerateServiceFiles(t *testing.T) {
+	t.Run("Generate service files successfully", func(t *testing.T) {
+		installDir := t.TempDir()
+		logger := zaptest.NewLogger(t)
+		u := &Updater{
+			installDir:               installDir,
+			logger:                   logger,
+			installedSystemdUnitPath: filepath.Join("testdata", "observiq-otel-collector.service.golden"),
+		}
+
+		// Cleanup the directory after test
+		defer os.RemoveAll(installDir)
+
+		err := u.generateServiceFiles()
+		require.NoError(t, err)
+
+		// Compare the generated files with golden files
+		compareFiles(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), u.installedSystemdUnitPath)
+
+		// Check file permissions
+		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), 0640)
+		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector"), 0755)
+	})
+}
+
+func compareFiles(t *testing.T, generatedFile, goldenFile string) {
+	generated, err := os.ReadFile(generatedFile)
+	require.NoError(t, err, fmt.Sprintf("file: %s", generatedFile))
+
+	golden, err := os.ReadFile(goldenFile)
+	require.NoError(t, err, fmt.Sprintf("file: %s", goldenFile))
+
+	// Trim the contents to ignore trailing newlines or spaces
+	generated = bytes.TrimSpace(generated)
+	golden = bytes.TrimSpace(golden)
+
+	require.Equal(t, string(golden), string(generated))
+}
+
+func checkFilePermissions(t *testing.T, filePath string, expectedPerm os.FileMode) {
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedPerm, info.Mode().Perm())
+}
+
+func TestReadGroupFromSystemdFile(t *testing.T) {
+	t.Run("Extract Group from systemd unit file", func(t *testing.T) {
+		u := &Updater{
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
+		}
+
+		group, err := u.readGroupFromSystemdFile()
+		require.NoError(t, err)
+		require.Equal(t, "bdot", group)
 	})
 }

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/observiq/bindplane-otel-collector/packagestate"
@@ -330,6 +331,12 @@ func TestUpdaterUpdate(t *testing.T) {
 }
 
 func TestGenerateServiceFiles(t *testing.T) {
+	// Windows does not use the files tested here, and has
+	// different newline characters that fail the test.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows as it is not applicable")
+		return
+	}
 	t.Run("Generate service files successfully", func(t *testing.T) {
 		installDir := t.TempDir()
 		logger := zaptest.NewLogger(t)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR renames the Linux user `observiq-otel-collector` to `bdot`.
- Updated Goreleaser package manifest to use username `bdot`
- Updated install script to use username `bdot`
- Updated postinstall package script to use username `bdot`
  - This includes updating the systemd heredoc to use group name `bdot`
- Added a migration function to the preinstall script for migrating from `observiq-otel-collector` to `bdot`, using the `usermod` command.

##### Checklist
- [ ] Changes are tested
- [x] CI has passed
