### PR TITLE
feat(linuxpackage): Support non root install

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -22,7 +22,11 @@ set -e
 [ -f /etc/default/observiq-otel-collector ] && . /etc/default/observiq-otel-collector
 [ -f /etc/sysconfig/observiq-otel-collector ] && . /etc/sysconfig/observiq-otel-collector
 
+# The collectors installation directory
 : "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
+
+# Whether or not to run the collector as an unprivileged user.
+: "${BDOT_UNPRIVILEGED:=false}"
 
 username="bdot"
 
@@ -85,6 +89,25 @@ EOF
 
   chown root:root "$config_file"
   chmod 0640 "$config_file"
+
+  # Ensure the override dir exists.
+  override_dir="/etc/systemd/system/observiq-otel-collector.service.d"
+  if [ ! -d "$override_dir" ]; then
+    mkdir -p "$override_dir"
+    echo "Created systemd override directory at $override_dir"
+  fi
+
+  # If BDOT_UNPRIVILEGED is true, add an override to run the service as the
+  # observiq-otel-collector (unprivileged) user.
+  override_user_path="${override_dir}/10-package-customizations-username.conf"
+  if [ "${BDOT_UNPRIVILEGED}" = "true" ]; then
+    username="observiq-otel-collector"
+    cat << EOF > "${override_user_path}"
+[Service]
+User=${username}
+EOF
+    echo "Configured systemd service to run as ${username} user in ${override_user_path}"
+  fi
 }
 
 install_initd_service() {

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -98,10 +98,9 @@ EOF
   fi
 
   # If BDOT_UNPRIVILEGED is true, add an override to run the service as the
-  # observiq-otel-collector (unprivileged) user.
+  # bdot (unprivileged) user.
   override_user_path="${override_dir}/10-package-customizations-username.conf"
   if [ "${BDOT_UNPRIVILEGED}" = "true" ]; then
-    username="observiq-otel-collector"
     cat << EOF > "${override_user_path}"
 [Service]
 User=${username}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When BDOT_UNPRIVILEGED is set in /etc/default/observiq-otel-collector or /etc/sysconfig/observiq-otel-collector, the package will deploy a systemd override to `10-package-customizations-username.conf`.

This PR establishes a pattern that can be used for additional overrides. The service can have many override files.

This PR will need a rebase when https://github.com/observIQ/bindplane-otel-collector/pull/2436 merges, switching to the new username.

Also, the updater does not require changes. Running without root means the updater cannot be used.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
