### PR TITLE
feat(linuxpackage): Support skipping Linux user creation

### DIFF
--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -16,18 +16,38 @@
 
 set -e
 
+# Read's optional package overrides. Users should deploy the override
+# file before installing BDOT for the first time. The override should
+# not be modified unless uninstalling and re-installing.
+[ -f /etc/default/observiq-otel-collector ] && . /etc/default/observiq-otel-collector
+[ -f /etc/sysconfig/observiq-otel-collector ] && . /etc/sysconfig/observiq-otel-collector
+
+: "${BDOT_SKIP_RUNTIME_USER_CREATION:=false}"
+
 username="observiq-otel-collector"
 
-if getent group "$username" > /dev/null 2>&1; then
-    echo "Group ${username} already exists."
-else
-    groupadd "$username"
-fi
+install() {
+    if [ "$BDOT_SKIP_RUNTIME_USER_CREATION" = "true" ]; then
+        echo "BDOT_SKIP_RUNTIME_USER_CREATION is set to true, skipping user and group creation"
+    else
+        echo "Creating ${username} user and group"
+        install_user
+    fi
+}
 
-if id "$username" > /dev/null 2>&1; then
-    echo "User ${username} already exists"
-    exit 0
-else
-    useradd --shell /sbin/nologin --system "$username" -g "$username"
-fi
+install_user() {
+    if getent group "$username" > /dev/null 2>&1; then
+        echo "Group ${username} already exists."
+    else
+        groupadd "$username"
+    fi
 
+    if id "$username" > /dev/null 2>&1; then
+        echo "User ${username} already exists"
+        exit 0
+    else
+        useradd --shell /sbin/nologin --system "$username" -g "$username"
+    fi
+}
+
+install


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When `BDOT_SKIP_RUNTIME_USER_CREATION` is set to true, the preinstall script will skip creating the username and group. This is useful if you need to manage Linux users with some other system, such as LDAP.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
