### PR TITLE
add `Parse` option to all log plugins

### DIFF
--- a/plugins/active_directory_logs.yaml
+++ b/plugins/active_directory_logs.yaml
@@ -33,6 +33,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     windowseventlog/general:
@@ -49,6 +54,12 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
+        - id: parse_logs
+          type: regex_parser
+          regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
+          parse_from: body
+        {{ end }}
     windowseventlog/web_services:
       channel: "Active Directory Web Services"
       max_reads: {{ .max_reads }}
@@ -62,6 +73,12 @@ template: |
           type: copy
           from: body
           to: attributes["log.record.original"]
+        {{ end }}
+        {{ if .parse }}
+        - id: parse_logs
+          type: regex_parser
+          regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
+          parse_from: body
         {{ end }}
     {{ if .enable_dns_server }}
     windowseventlog/dns:
@@ -77,6 +94,12 @@ template: |
           type: copy
           from: body
           to: attributes["log.record.original"]
+        {{ end }}
+        {{ if .parse }}
+        - id: parse_logs
+          type: regex_parser
+          regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
+          parse_from: body
         {{ end }}
     {{ end }}
     {{ if .enable_dfs_replication }}
@@ -94,6 +117,12 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
+        - id: parse_logs
+          type: regex_parser
+          regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
+          parse_from: body
+        {{ end }}
     {{ end }}
     {{ if .enable_file_replication }}
     windowseventlog/frs:
@@ -109,6 +138,12 @@ template: |
           type: copy
           from: body
           to: attributes["log.record.original"]
+        {{ end }}
+        {{ if .parse }}
+        - id: parse_logs
+          type: regex_parser
+          regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
+          parse_from: body
         {{ end }}
     {{ end }}
 

--- a/plugins/aerospike_logs.yaml
+++ b/plugins/aerospike_logs.yaml
@@ -17,6 +17,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     journald:
@@ -56,6 +61,7 @@ template: |
           from: body.MESSAGE
           to: body.message
         
+        {{ if .parse }}
         # Parse Aerospike's log and update the entry's Timestamp and Severity
         # fields with the values from the Aerospike log.
         - type: regex_parser
@@ -89,6 +95,7 @@ template: |
         # capture.
         - type: filter
           expr: 'body.context == "config"'
+        {{ end }}
 
         - type: add
           field: attributes.log_type

--- a/plugins/apache_cassandra_logs.yaml
+++ b/plugins/apache_cassandra_logs.yaml
@@ -46,6 +46,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     {{ if .enable_system_logs }}
@@ -66,6 +70,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<severity>[A-Z]+)\s+\[(?P<type>[^\]]+)\]\s+(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<message>.*\S)'
           severity:
@@ -74,6 +79,7 @@ template: |
             parse_from: attributes.timestamp
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
     {{ end }}
 
     {{ if .enable_debug_logs }}
@@ -94,6 +100,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<severity>[A-Z]+)\s+\[(?P<type>[^\]]+)\]\s+(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<message>.*\S)'
           severity:
@@ -102,6 +109,7 @@ template: |
             parse_from: attributes.timestamp
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
     {{ end }}
 
     {{ if .enable_gc_logs }}
@@ -122,14 +130,16 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
-      - type: regex_parser
-        if: 'body matches "[0-9]{4}-[0-9]{2}-[0-9]{2}T"'
-        regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{4}):\s+.*stopped: (?P<total_stopped_seconds>[\d\.]+).* took: (?P<stopping_threads_seconds>[\d\.]+)'
-        timestamp:
-          parse_from: attributes.timestamp
-          layout: '%FT%T.%L%z'
-          location: {{ .timezone }}
-  {{ end }}
+        {{ if .parse }}
+        - type: regex_parser
+          if: 'body matches "[0-9]{4}-[0-9]{2}-[0-9]{2}T"'
+          regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{4}):\s+.*stopped: (?P<total_stopped_seconds>[\d\.]+).* took: (?P<stopping_threads_seconds>[\d\.]+)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%FT%T.%L%z'
+            location: {{ .timezone }}
+        {{ end }}
+    {{ end }}
 
   service:
     pipelines:

--- a/plugins/apache_combined_logs.yaml
+++ b/plugins/apache_combined_logs.yaml
@@ -30,7 +30,7 @@ parameters:
     type: bool
     default: false
   - name: parse
-    description: When enabled, parses the log fields into structured data. When disabled, sends the raw log message in the body field.
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
     type: bool
     default: true
 

--- a/plugins/apache_combined_logs.yaml
+++ b/plugins/apache_combined_logs.yaml
@@ -29,6 +29,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured data. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     filelog:
@@ -52,6 +57,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*) "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)'
           parse_to: {{ .parse_to }}
@@ -66,6 +72,7 @@ template: |
               info2: 3xx
               warn: 4xx
               error: 5xx
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move

--- a/plugins/apache_common_logs.yaml
+++ b/plugins/apache_common_logs.yaml
@@ -29,6 +29,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     filelog:
@@ -50,6 +54,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
           parse_to: {{ .parse_to }}
@@ -73,6 +78,7 @@ template: |
           type: move
           from: attributes.raw_log
           to: body.raw_log
+        {{ end }}
         {{ end }}
 
   service:

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -55,6 +55,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured data. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -74,7 +78,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
-        {{ if eq .log_format "default" }}
+        {{ if and .parse (eq .log_format "default") }}
         - id: access_regex_parser
           type: regex_parser
           regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<timestamp>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
@@ -92,6 +96,7 @@ template: |
           output: end_filter
         {{ end }}
 
+        {{ if .parse }}
         - id: access_json_parser
           type: json_parser
           timestamp:
@@ -112,6 +117,7 @@ template: |
           parse_from: attributes.protocol
           regex: '(?P<protocol>[^/]*)/(?P<protocol_version>.*)'
           output: end_filter
+        {{ end }}
 
         # Noop filter to allow an exit point for other operators
         - id: end_filter
@@ -139,7 +145,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
-        {{ if eq .log_format "default" }}
+        {{ if and .parse (eq .log_format "default") }}
         - id: error_regex_parser
           type: regex_parser
           regex: '^\[(?P<timestamp>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] \[(?P<module>\w+):(?P<log_level>[\w\d]+)\] \[pid (?P<pid>\d+)(?::tid (?P<tid>[\d]+))?\](?: \[client (?P<client>[^\]]*)\])? (?P<error_code>[^:]+): (?P<message>.*)'
@@ -166,6 +172,7 @@ template: |
           output: end_filter
         {{ end }}
 
+        {{ if .parse }}
         - id: error_json_parser
           type: json_parser
           timestamp:
@@ -195,6 +202,7 @@ template: |
           parse_from: attributes.message
           regex: '(?P<error_code>[^:]*):(?P<message>.*)'
           output: end_filter
+        {{ end }}
 
         # Noop filter to allow an exit point for other operators
         - id: end_filter

--- a/plugins/bindplane_logs.yaml
+++ b/plugins/bindplane_logs.yaml
@@ -23,6 +23,10 @@ parameters:
     description: The directory that the offset storage file will be created
     type: string
     default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -42,6 +46,7 @@ template: |
       attributes:
         log_type: "bindplane"
       operators:
+        {{ if .parse }}
         - type: json_parser
           parse_from: body
           parse_to: body
@@ -61,6 +66,7 @@ template: |
           field: body.level
         - type: remove
           field: body.timestamp
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/cisco_asa_logs.yaml
+++ b/plugins/cisco_asa_logs.yaml
@@ -14,6 +14,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -29,12 +33,14 @@ template: |
             from: body
             to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: cisco_parser
           type: regex_parser
           regex: '^(?P<timestamp>[\d\w\s:\-]+?)(?: asa )?: %(?P<message_id>[\w\d-]+):\s(?P<message>.*)'
           timestamp:
             parse_from: attributes.timestamp
             layout: '%b %d %Y %H:%M:%S'
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/cisco_catalyst_logs.yaml
+++ b/plugins/cisco_catalyst_logs.yaml
@@ -22,6 +22,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -37,6 +41,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: regex_router
           type: router
           default: catalyst_parser
@@ -69,7 +74,7 @@ template: |
               warn: 5
               info: 6
               debug: 7
-
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/cisco_meraki_logs.yaml
+++ b/plugins/cisco_meraki_logs.yaml
@@ -14,6 +14,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -27,6 +31,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: router
           default: catch_all_parser
           routes:
@@ -121,6 +126,7 @@ template: |
           type: add
           field: attributes.log_type
           value: 'cisco.meraki'
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/cockroachdb_logs.yaml
+++ b/plugins/cockroachdb_logs.yaml
@@ -95,6 +95,10 @@ parameters:
     description: The directory that the offset storage file will be created
     type: string
     default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -125,6 +129,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -140,6 +145,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -173,6 +179,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -188,6 +195,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -222,6 +230,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -237,6 +246,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -270,6 +280,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -285,6 +296,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -318,6 +330,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -333,6 +346,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -366,7 +380,8 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
-        - type: regex_parser
+        {{ if .parse }}
+          - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
           timestamp:
@@ -381,6 +396,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
@@ -414,6 +430,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<Type>[IWEF])(?P<timestamp>\d{6}\s+\d{2}:\d{2}:\d{2}\.\d{6})\s+(?P<GoID>\d+)\s*(?:(?P<Channel>\d+)@)?(?P<Location>\S+)\s+(?:)⋮?\s+(?P<Node>\[[^\]]+\])\s+(?:(?P<Counter>\d+\s+)?)(?P<Message>.*)'
           parse_to: {{ .parse_to }}
@@ -429,6 +446,7 @@ template: |
               warn: W
               error: E
               fatal: F
+        {{ end }}
         {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move

--- a/plugins/common_event_format_logs.yaml
+++ b/plugins/common_event_format_logs.yaml
@@ -29,7 +29,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
-
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     filelog:
@@ -49,6 +52,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+((?P<hostname>[^\s]+)\s+)?(?P<cef_headers>[\d\D]+)'
           timestamp:
@@ -93,7 +97,7 @@ template: |
           type: add
           field: attributes.log_type
           value: {{ .log_type }}
-
+        {{ end }}
   service:
     pipelines:
       logs:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -55,6 +55,10 @@ parameters:
     description: The directory that the offset storage file will be created
     type: string
     default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   extensions:
@@ -78,6 +82,7 @@ template: |
           {{end}}
         poll_interval: 500ms
         operators:
+          {{ if .parse }}
           {{ if eq .log_driver "auto" }}
           - type: router
             routes:
@@ -192,6 +197,7 @@ template: |
           - type: move
             from: attributes.container
             to: resource["k8s.container.name"]
+          {{ end }}
     {{ end }}
 
     {{ if eq .log_source "journald" }}
@@ -199,6 +205,7 @@ template: |
       storage: file_storage
       directory: {{ .journald_path }}
       operators:
+        {{ if .parse }}
         - type: router
           routes:
             - expr: 'body._COMM == "dockerd-current" and body.CONTAINER_NAME != nil'
@@ -243,6 +250,7 @@ template: |
         - type: add
           field: attributes.log_type
           value: container
+        {{ end }}
     {{ end }}
 
   service:

--- a/plugins/couchbase_logs.yaml
+++ b/plugins/couchbase_logs.yaml
@@ -76,6 +76,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     {{ if .enable_error_log}}
@@ -96,6 +101,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<type>[^:]*):(?P<couchbase_severity>[^,]*),(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+-\d{2}:\d{2}),(?P<node>[^@]*)@(?P<host>[^:]*):(?P<source>[^\]]+)\](?P<message>(?s).*[^\n\s])[\n\s]*$'
           timestamp:
@@ -103,6 +109,7 @@ template: |
             layout: '%Y-%m-%dT%H:%M:%S.%L%j'
           severity:
             parse_from: attributes.couchbase_severity
+        {{ end }}
     {{ end }} ## end error log receiver
 
     {{ if .enable_debug_log}}
@@ -123,6 +130,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<type>[^:]*):(?P<couchbase_severity>[^,]*),(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+-\d{2}:\d{2}),(?P<node>[^@]*)@(?P<host>[^:]*):(?P<source>[^\]]+)\](?P<message>(?s).*[^\n\s])[\n\s]*$'
           timestamp:
@@ -130,6 +138,7 @@ template: |
             layout: '%Y-%m-%dT%H:%M:%S.%L%j'
           severity:
             parse_from: attributes.couchbase_severity
+        {{ end }}
     {{ end }} ## end debug log receiver
 
     {{ if .enable_info_log}}
@@ -150,6 +159,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<type>[^:]*):(?P<couchbase_severity>[^,]*),(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+-\d{2}:\d{2}),(?P<node>[^@]*)@(?P<host>[^:]*):(?P<source>[^\]]+)\](?P<message>(?s).*[^\n\s])[\n\s]*$'
           timestamp:
@@ -157,6 +167,7 @@ template: |
             layout: '%Y-%m-%dT%H:%M:%S.%L%j'
           severity:
             parse_from: attributes.couchbase_severity
+        {{ end }}
     {{ end }} ## end info log receiver
 
     {{ if .enable_access_log}}
@@ -175,6 +186,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<status>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
           timestamp:
@@ -188,6 +200,7 @@ template: |
               info2: 3xx
               warn: 4xx
               error: 5xx
+        {{ end }}
     {{ end }} ## end http access log receiver
 
     {{ if .enable_internal_access_log}}
@@ -206,6 +219,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<status>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
           timestamp:
@@ -219,8 +233,8 @@ template: |
               info2: 3xx
               warn: 4xx
               error: 5xx
+        {{ end }}
     {{ end }} ## end internal access log receiver
-
 
     {{ if .enable_babysitter_log}}
     filelog/babysitter_logs:
@@ -240,6 +254,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<type>[^:]*):(?P<couchbase_severity>[^,]*),(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+-\d{2}:\d{2}),(?P<node>[^@]*)@(?P<host>[^:]*):(?P<source>[^\]]+)\](?P<message>(?s).*[^\n\s])[\n\s]*$'
           timestamp:
@@ -247,6 +262,7 @@ template: |
             layout: '%Y-%m-%dT%H:%M:%S.%L%j'
           severity:
             parse_from: attributes.couchbase_severity
+        {{ end }}
     {{ end }} ## end babysitter log receiver
 
     {{ if .enable_xdcr_logs}}
@@ -267,6 +283,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d*-\d{2}:\d{2}) (?P<couchbase_severity>[^ ]*) (?P<type>[^:]*):* (?P<message>.*)'
           timestamp:
@@ -274,12 +291,13 @@ template: |
             layout: '%Y-%m-%dT%H:%M:%S.%L%j'
           severity:
             parse_from: attributes.couchbase_severity
+        {{ end }}
     {{ end }} ## end xdcr log receiver
 
   service:
     pipelines:
       logs:
-        receivers: 
+        receivers:
           {{ if .enable_error_log }}
           - filelog/error_logs
           {{ end }}

--- a/plugins/couchdb_logs.yaml
+++ b/plugins/couchdb_logs.yaml
@@ -18,6 +18,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     filelog:
@@ -37,6 +42,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: id_router
           type: router
           routes:
@@ -78,6 +84,7 @@ template: |
         - id: end_filter
           type: filter
           expr: 'body == ""'
+        {{ end }}
   service:
     pipelines:
       logs:

--- a/plugins/csv_logs.yaml
+++ b/plugins/csv_logs.yaml
@@ -40,6 +40,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the CSV fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     filelog:
@@ -58,8 +63,10 @@ template: |
       attributes:
         log_type: '{{ .log_type }}'
       operators:
+        {{ if .parse }}
         - type: csv_parser
           header: {{ .header }}
+        {{ end }}
         {{ if .save_log_record_original }}
         - id: save_log_record_original
           type: copy

--- a/plugins/elasticsearch_logs.yaml
+++ b/plugins/elasticsearch_logs.yaml
@@ -35,6 +35,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     {{if .enable_json_logs}}
@@ -58,6 +63,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: json_parser
           timestamp:
             parse_from: attributes.timestamp
@@ -79,6 +85,7 @@ template: |
                 - ERROR
                 - CRITICAL
               fatal: FATAL
+        {{ end }}
     {{end}}
 
     {{if .enable_gc_logs}}
@@ -99,11 +106,13 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+\+\d+)\]\[\d+\]\[(?P<type>[A-z,]+)\s*\]\s*(?:GC\((?P<gc_run>\d+)\))?\s*(?P<message>.*)'
           timestamp:
             parse_from: attributes.timestamp
             layout: '%Y-%m-%dT%H:%M:%S.%s%z'
+        {{ end }}
     {{end}}
 
   service:

--- a/plugins/esxi_logs.yaml
+++ b/plugins/esxi_logs.yaml
@@ -26,6 +26,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers: 
@@ -46,6 +50,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: timestamp_router
           type: router
           default: severity_parser
@@ -112,7 +117,7 @@ template: |
             info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
             info2: [5,13,21,29,37,45,53,61,69,77,85,93,101,109,117,125,133,141,149,157,165,173,181,189]
             debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
-        
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -73,6 +73,11 @@ parameters:
     description: The directory that the offset storage file will be created
     type: string
     default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   extensions:
     file_storage:
@@ -102,12 +107,12 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
-        {{ if (eq .parse_format "json")}}
+        {{ if and .parse (eq .parse_format "json") }}
         - type: json_parser
           parse_to: {{ .parse_to }}
         {{ end }}
 
-        {{ if (eq .parse_format "regex")}}
+        {{ if and .parse (eq .parse_format "regex") }}
         - type: regex_parser
           regex: {{ .regex_pattern }}
           parse_to: {{ .parse_to }}

--- a/plugins/hadoop_logs.yaml
+++ b/plugins/hadoop_logs.yaml
@@ -40,6 +40,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     filelog:
@@ -69,6 +74,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         # Set log_type attribute based on file name
         - type: router
           routes:
@@ -102,6 +108,7 @@ template: |
               error3: alert
               fatal2: emergency
               fatal3: catastrophe
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/haproxy_logs.yaml
+++ b/plugins/haproxy_logs.yaml
@@ -24,6 +24,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -40,6 +44,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: initial_router
           type: router
           routes:
@@ -128,6 +133,7 @@ template: |
           type: add
           field: attributes.log_type
           value: 'haproxy'
+        {{ end }}
     
   service:
     pipelines:

--- a/plugins/hbase_logs.yaml
+++ b/plugins/hbase_logs.yaml
@@ -44,6 +44,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   receivers:
     {{ if .enable_master_log }}
@@ -64,6 +69,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           if:  'body matches "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)'
@@ -79,6 +85,7 @@ template: |
           timestamp:
             parse_from: attributes.timestamp
             layout: '%a %h %d %H:%M:%S %Z %Y'
+        {{ end }}
     {{ end }}
 
     {{ if .enable_region_log }}
@@ -99,6 +106,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           if:  'body matches "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)'
@@ -114,6 +122,7 @@ template: |
           timestamp:
             parse_from: attributes.timestamp
             layout: '%a %h %d %H:%M:%S %Z %Y'
+        {{ end }}
     {{ end }}
 
     {{ if .enable_zookeeper_log }}
@@ -134,6 +143,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           if:  'body matches "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)'
@@ -149,6 +159,7 @@ template: |
           timestamp:
             parse_from: attributes.timestamp
             layout: '%a %h %d %H:%M:%S %Z %Y'
+        {{ end }}
     {{ end }}
 
   service:

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -72,6 +72,11 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
+
 template: |
   extensions:
     file_storage:
@@ -122,6 +127,7 @@ template: |
         to: attributes.raw_log
       {{ end }}
 
+      {{ if .parse }}
       - type: csv_parser
         {{ if .w3c_header }}
         header: '{{ .w3c_header }}'
@@ -175,6 +181,7 @@ template: |
         parse_from: {{ .parse_to }}.timestamp
         layout: '%Y-%m-%d %H:%M:%S'
         location: {{.timezone}}
+      {{ end }}
 
       - id: add_log_type
         type: add
@@ -222,6 +229,7 @@ template: |
         from: body
         to: attributes.raw_log
       {{ end }}
+      {{ if .parse }}
       - type: regex_parser
         regex: '^(?P<c_ip>[^,]+), (?P<cs_username>[^,]+), (?P<date>[^,]+), (?P<time>[^,]+), (?P<s_sitename>[^,]+), (?P<s_computername>[^,]+), (?P<s_ip>[^,]+), (?P<time_taken>[^,]+), (?P<cs_bytes>[^,]+), (?P<sc_bytes>[^,]+), (?P<sc_status>[^,]+), (?P<sc_win32_status>[^,]+), (?P<cs_method>[^,]+), (?P<cs_uri_stem>[^,]+), (?P<cs_uri_query>[^,]+),$'
         parse_to: {{ .parse_to }}
@@ -257,18 +265,20 @@ template: |
         parse_from: {{ .parse_to }}.timestamp
         layout: '%q/%g/%Y %H:%M:%S'
         location: {{.timezone}}
+      {{ end }}
 
       - id: add_log_type
         type: add
         field: 'attributes.log_type'
         value: 'microsoft_iis'
-      
+
       {{ if and .retain_raw_logs (eq .parse_to "body")}}
       - id: move_raw_log
         type: move
         from: attributes.raw_log
         to: body.raw_log
       {{ end }}
+
     {{end}}
 
     # NCSA format
@@ -304,6 +314,7 @@ template: |
         from: body
         to: attributes.raw_log
       {{ end }}
+      {{ if .parse }}
       - type: regex_parser
         # Note: The second, uncaptured group here is "Remote log name". This value is always "-" in IIS, so we don't include it
         regex: '^(?P<c_ip>[^\s]+) (?:[^\s]+) (?P<cs_username>[^\s]+) \[(?P<timestamp>[^]]+)\] "(?P<cs_method>[^\s]+) (?P<cs_uri_stem>[^\s?]+)(?:\?(?P<cs_uri_query>[^\s]+))? (?P<cs_version>[^\s]+)" (?P<sc_status>[^\s]+) (?P<sc_bytes>[^\s]+)$'
@@ -318,6 +329,8 @@ template: |
         timestamp:
           parse_from: {{ .parse_to }}.timestamp
           layout: '%d/%b/%Y:%H:%M:%S %z'
+
+      {{ end }}
       
       - id: add_log_type
         type: add

--- a/plugins/ingress_nginx_logs.yaml
+++ b/plugins/ingress_nginx_logs.yaml
@@ -19,6 +19,10 @@ parameters:
     description: Optional cluster name to be included in logs
     type: string
     default: ""
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
       filelog:
@@ -42,6 +46,7 @@ template: |
             from: attributes.log
             to: body
 
+          {{ if .parse }}
           # Detect log type
           - type: router
             routes:
@@ -99,6 +104,7 @@ template: |
             regex: '^(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-z0-9]{64})\.log$'
             parse_from: attributes["log.file.name"]
             output: add_type
+          {{ end }}
 
           - id: add_type
             type: add

--- a/plugins/jboss_logs.yaml
+++ b/plugins/jboss_logs.yaml
@@ -26,6 +26,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -49,6 +53,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: jboss_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}),\d{3}\s*(?P<jboss_severity>\w+)\s*\[(?P<category>[^\]]*)\]\s*\((?P<thread>[^)]*)\)( (?P<id>[^:]*):)? (?P<message>[\s\S]+)'
@@ -58,6 +63,7 @@ template: |
             location: {{ .timezone }}
           severity:
             parse_from: attributes.jboss_severity
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/json_logs.yaml
+++ b/plugins/json_logs.yaml
@@ -30,6 +30,10 @@ parameters:
       - beginning
       - end
     default: end
+  - name: parse
+    description: When enabled, parses the JSON fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     filelog:
@@ -48,8 +52,10 @@ template: |
       attributes:
         log_type: '{{ .log_type }}'
       operators:
+      {{ if .parse }}
       - type: json_parser
         parse_from: body
+      {{ end }}
 
   service:
     pipelines:

--- a/plugins/kafka_logs.yaml
+++ b/plugins/kafka_logs.yaml
@@ -57,6 +57,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -79,6 +83,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<severity>[^ ]+) (?P<message>.*)'
           severity:
@@ -93,6 +98,7 @@ template: |
             parse_from: attributes.time
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
 
         - id: add_type
           type: add
@@ -117,6 +123,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<severity>[^ ]+) (?P<message>.*)'
           severity:
@@ -131,6 +138,7 @@ template: |
             parse_from: attributes.time
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
 
         - id: add_type
           type: add
@@ -155,6 +163,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<severity>[^ ]+) (?P<message>.*)'
           severity:
@@ -169,6 +178,7 @@ template: |
             parse_from: attributes.time
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
 
         - id: add_type
           type: add
@@ -193,6 +203,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<severity>[^ ]+) (?P<message>.*)'
           severity:
@@ -207,6 +218,7 @@ template: |
             parse_from: attributes.time
             layout: '%F %T,%L'
             location: {{ .timezone }}
+        {{ end }}
 
         - id: add_type
           type: add

--- a/plugins/kubelet_logs.yaml
+++ b/plugins/kubelet_logs.yaml
@@ -27,6 +27,10 @@ parameters:
       - body
       - attributes
     default: body
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     journald:
@@ -51,6 +55,7 @@ template: |
             from: body
             to: attributes.raw_log
           {{ end }}
+          {{ if .parse }}
           # Parse kubelet klog formatted message
           - type: regex_parser
             regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
@@ -67,6 +72,7 @@ template: |
               parse_from: {{ .parse_to }}.timestamp
               layout: '%m%d %H:%M:%S.%s'
               location: {{ .timezone }}
+          {{ end }}
           - type: add
             field: attributes.log_type
             value: kubelet

--- a/plugins/macos_logs.yaml
+++ b/plugins/macos_logs.yaml
@@ -35,6 +35,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -59,12 +63,14 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<timestamp>\w{3}\s*\d{1,2} \d{2}:\d{2}:\d{2}) (---|(?P<host>[^ ]*))? ((?P<process>[^\[]*)\[(?P<pid>[^\]]*)\])?( \((?P<subprocess>[^\[]*)(\[(?P<spid>[^\]]*)\])?\))?(: )?(?P<message>[\w\W]*)'
           timestamp:
             parse_from: attributes.timestamp
             layout_type: gotime
             layout: 'Jan _2 15:04:05'
+        {{ end }}
     {{ end }} ## .enable_system_log
 
     {{ if .enable_install_log }}
@@ -78,6 +84,7 @@ template: |
         line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}|^\w{3}\s*\d{1,2} \d{2}:\d{2}:\d{2}'
       start_at: {{ .start_at }}
       operators:
+        {{ if .parse }}
         - id: id_router
           type: router
           routes:
@@ -101,6 +108,7 @@ template: |
             layout_type: gotime
             layout: 'Jan _2 15:04:05'
           output: add_type
+        {{ end }}
         - id: add_type
           type: add
           field: attributes.log_type

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -34,6 +34,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -63,6 +67,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: router
           default: legacy_parser
           routes:
@@ -161,6 +166,7 @@ template: |
           from: {{ .parse_to }}.attr.message
           to: {{ .parse_to }}.message
           output: add_log_type
+        {{ end }}
           
         - id: add_log_type
           type: add

--- a/plugins/mysql_logs.yaml
+++ b/plugins/mysql_logs.yaml
@@ -68,6 +68,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -98,6 +102,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: slow_query_router
           type: router
           routes:
@@ -328,15 +333,16 @@ template: |
         - id: end_filter
           type: filter
           expr: 'body == ""'
-    {{end}}
+        {{ end }}
+    {{ end }}
 
-    {{if .enable_error_log}}
+    {{ if .enable_error_log }}
     filelog/error_log:
       storage: file_storage
       include:
         {{ range $fp := .error_log_paths }}
         - '{{ $fp }}'
-        {{end}}
+        {{ end }}
       start_at: {{ .start_at }}
       attributes:
         log_type: 'mysql.error'
@@ -351,6 +357,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s+(?P<tid>\d+)\s+\[(?P<mysql_severity>[^\]]+)]\s+(?P<message>[\d\D\s]+)'
           timestamp:
@@ -367,15 +374,16 @@ template: |
                 - system
               info2:
                 - note
-    {{end}}
+        {{ end }}
+    {{ end }}
 
-    {{if .enable_general_log}}
+    {{ if .enable_general_log }}
     filelog/general_log:
       storage: file_storage
       include:
         {{ range $fp := .general_log_paths }}
         - '{{ $fp }}'
-        {{end}}
+        {{ end }}
       start_at: {{ .start_at }}
       multiline:
         line_start_pattern: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z|/\w+/\w+/mysqld,'
@@ -392,6 +400,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: router
           routes:
             - output: general_regex_parser
@@ -615,15 +624,16 @@ template: |
         - id: end_filter
           type: filter
           expr: 'body == ""'
-    {{end}}
+        {{ end }}
+    {{ end }}
 
-    {{if .enable_mariadb_audit_log}}
+    {{ if .enable_mariadb_audit_log }}
     filelog/mariadb_audit_log:
       storage: file_storage
       include:
         {{ range $fp := .mariadb_audit_log_paths }}
         - '{{ $fp }}'
-        {{end}}
+        {{ end }}
       start_at: {{ .start_at }}
       operators:
         # Example of log line:
@@ -634,6 +644,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: single_quote_router
           type: router
           default: mariadb_audit_regex_parser_lt
@@ -683,7 +694,8 @@ template: |
           type: add
           field: attributes.log_type
           value: 'mysql.audit'
-    {{end}}
+        {{ end }}
+    {{ end }}
 
   service:
     extensions: [file_storage]
@@ -692,13 +704,13 @@ template: |
         receivers:
           {{ if .enable_slow_log }}
           - filelog/slow_log
-          {{end}}
+          {{ end }}
           {{ if .enable_error_log }}
           - filelog/error_log
-          {{end}}
+          {{ end }}
           {{ if .enable_general_log }}
           - filelog/general_log
-          {{end}}
+          {{ end }}
           {{ if .enable_mariadb_audit_log }}
           - filelog/mariadb_audit_log
-          {{end}}
+          {{ end }}

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -63,6 +63,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -86,6 +90,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         {{ if eq .log_format "default" }}
         - type: regex_parser
           regex: '^(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?$'
@@ -135,6 +140,7 @@ template: |
             - attributes.http_request_requestUrl
             - attributes.request_time
         {{ end }}
+        {{ end }}
     {{end}} # end access log receiver
 
     {{ if .enable_error_log }}
@@ -155,6 +161,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<time>\d+[./-]\d+[./-]\d+[- ]\d+:\d+:\d+) \[(?P<log_level>[^\]]*)\] (?P<pid>\d+)#(?P<tid>\d+):(?: \*(?P<connection>\d+))? (?P<message>.*?)(?:, client: (?P<client>[^,]+))?(?:, server: (?P<server>[^,]+))?(?:, request: "(?P<request>[^"]*)")?(?:, subrequest: \"(?P<subrequest>[^\"]*)\")?(?:, upstream: \"(?P<upstream>[^"]*)\")?(?:, host: \"(?P<host>[^\"]*)\")?(?:, referrer: \"(?P<referer>[^"]*)\")?$'
           timestamp:
@@ -165,6 +172,7 @@ template: |
             mapping:
               error2: crit
               error3: emerg
+        {{ end }}
     {{end}} # end error log receiver
 
   service:

--- a/plugins/oracle_database_logs.yaml
+++ b/plugins/oracle_database_logs.yaml
@@ -44,6 +44,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -61,45 +65,47 @@ template: |
         line_start_pattern: '\w+\s+\w+\s{1,2}\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}\s+[-+]\d{2}:\d{2}\n|^Audit [fF]ile '
       operators:
         {{ if .save_log_record_original }}
-      - id: save_log_record_original
-        type: copy
-        from: body
-        to: attributes["log.record.original"]
+        - id: save_log_record_original
+          type: copy
+          from: body
+          to: attributes["log.record.original"]
         {{ end }}
-      - type: router
-        routes:
-          - output: audit_regex_parser_action
-            expr: body matches '\\w+ \\w+\\s{1,2}\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} [-+]\\d{2}:\\d{2}\\nLENGTH\\s:\\s\\D\\d+\\D\\nACTION'
-          - output: audit_regex_parser_session
-            expr: body matches '\\w+ \\w+\\s{1,2}\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} [-+]\\d{2}:\\d{2}\\nLENGTH:\\s\\D\\d+\\D\\nSESSION'
-          - output: server_start_regex_parser
-            expr: body startsWith 'Audit file '
-        default: add
+        {{ if .parse }}
+        - type: router
+          routes:
+            - output: audit_regex_parser_action
+              expr: body matches '\\w+ \\w+\\s{1,2}\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} [-+]\\d{2}:\\d{2}\\nLENGTH\\s:\\s\\D\\d+\\D\\nACTION'
+            - output: audit_regex_parser_session
+              expr: body matches '\\w+ \\w+\\s{1,2}\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} [-+]\\d{2}:\\d{2}\\nLENGTH:\\s\\D\\d+\\D\\nSESSION'
+            - output: server_start_regex_parser
+              expr: body startsWith 'Audit file '
+          default: add
 
-      - id: audit_regex_parser_action
-        type: regex_parser
-        regex: '^(?P<timestamp>\w+ \w+\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2})\nLENGTH : \D(?P<length>\d*)\D\nACTION :\[\d+\]\s+\D(?P<action>[\d\w[:ascii:]]+?)\D\nDATABASE USER:\[\d+\]\s+\D(?P<database_user>[^\s]+)\D\n(PRIVILEGE :\[\d+\]\s+\D(?P<privilege>[^\s]+)\D\n)?(CLIENT USER:\[\d+\]\s+\D(?P<client_user>[^\s]+|)\D\n)?(CLIENT TERMINAL:\[\d+\]\s+\D(?P<client_terminal>[^\s]+|)\D\n)?(STATUS:\[\d+\]\s+\D(?P<status_code>[^\s]+|)\D\n)?(DBID:\[\d+\]\s\D(?P<dbid>[^\s]+|)\D\n)?(SESSIONID:\[\d+\]\s+\D(?P<sessionid>[^\s]+|)\D\n)?(USERHOST:\[\d+\]\s+\D(?P<userhost>[^\s]+|)\D\n)?(CLIENT ADDRESS:\[\d+\]\s+\D(?P<client_address>[^\s]+|)\D\n)?(ACTION NUMBER:\[\d+\]\s+\D(?P<action_number>[^\s]+|)\D\n)?'
-        timestamp:
-          parse_from: attributes.timestamp
-          layout: '%a %h %g %H:%M:%S %Y %j'
-        output: add
+        - id: audit_regex_parser_action
+          type: regex_parser
+          regex: '^(?P<timestamp>\w+ \w+\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2})\nLENGTH : \D(?P<length>\d*)\D\nACTION :\[\d+\]\s+\D(?P<action>[\d\w[:ascii:]]+?)\D\nDATABASE USER:\[\d+\]\s+\D(?P<database_user>[^\s]+)\D\n(PRIVILEGE :\[\d+\]\s+\D(?P<privilege>[^\s]+)\D\n)?(CLIENT USER:\[\d+\]\s+\D(?P<client_user>[^\s]+|)\D\n)?(CLIENT TERMINAL:\[\d+\]\s+\D(?P<client_terminal>[^\s]+|)\D\n)?(STATUS:\[\d+\]\s+\D(?P<status_code>[^\s]+|)\D\n)?(DBID:\[\d+\]\s\D(?P<dbid>[^\s]+|)\D\n)?(SESSIONID:\[\d+\]\s+\D(?P<sessionid>[^\s]+|)\D\n)?(USERHOST:\[\d+\]\s+\D(?P<userhost>[^\s]+|)\D\n)?(CLIENT ADDRESS:\[\d+\]\s+\D(?P<client_address>[^\s]+|)\D\n)?(ACTION NUMBER:\[\d+\]\s+\D(?P<action_number>[^\s]+|)\D\n)?'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%a %h %g %H:%M:%S %Y %j'
+          output: add
 
-      - id: audit_regex_parser_session
-        type: regex_parser
-        regex: '^(?P<timestamp>\w+ \w+\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2})\nLENGTH: \D(?P<length>\d*)\D\n(SESSIONID:\[\d+\]\s+\D(?P<sessionid>[^\s]+|)\D[\n\s]+)?(ENTRYID:\[\d+\]\s+\D(?P<entryid>[^\s]+|)\D[\n\s]+)?(STATEMENT:\[\d+\]\s+\D(?P<statement>[^\s]+|)\D[\n\s]+)?(USERID:\[\d+\]\s+\D(?P<userid>[^\s]+|)\D[\n\s]+)?(USERHOST:\[\d+\]\s+\D(?P<userhost>[^\s]+|)\D[\n\s]+)?(TERMINAL:\[\d+\]\s+\D(?P<terminal>[\d\w[:ascii:]]+?|)\D[\n\s]+)?ACTION:\[\d+\]\s+\D(?P<action>[\d\w[:ascii:]]+?|)\D[\n\s]+(RETURNCODE:\[\d+\]\s+\D(?P<returncode>[^\s]+|)\D[\n\s]+)?(COMMENT\$$TEXT:\[\d+\]\s+\D(?P<comment_text>[^"]+|)\D[\n\s]+)?(LOGOFF\$$PREAD:\[\d+\]\s+\D(?P<logoff_pread>[^"]+|)\D[\n\s]+)?(LOGOFF\$$LREAD:\[\d+\]\s+\D(?P<logoff_lread>[^"]+|)\D[\n\s]+)?(LOGOFF\$$LWRITE:\[\d+\]\s+\D(?P<logoff_lwrite>[^"]+|)\D[\n\s]+)?(LOGOFF\$$DEAD:\[\d+\]\s+\D(?P<logoff_dead>[^"]+|)\D[\n\s]+)?(OBJ\$$CREATOR:\[\d+\]\s+\D(?P<obj_creator>[^"]+|)\D[\n\s]+)?(OBJ\$$NAME:\[\d+\]\s+\D(?P<obj_name>[^"]+|)\D[\n\s]+)?(OBJ\$$PRIVILEGES:\[\d+\]\s+\D(?P<obj_privileges>[^"]+|)\D[\n\s]+)?(AUTH\$$GRANTEE:\[\d+\]\s+\D(?P<auth_grantee>[^"]+|)\D[\n\s]+)?(OS\$$USERID:\[\d+\]\s+\D(?P<os_userid>[^\s]+|)\D[\n\s]+)?(DBID:\[\d+\]\s+\D(?P<dbid>[^\s]+|)\D[\n\s]+)?(SESSIONCPU:\[\d+\]\s+\D(?P<sessioncpu>\d+|)\D[\n\s]+)?(PRIV\$$USED:\[\d+\]\s+\D(?P<priv_user>[^\s]+|)\D[\n\s]+)?'
-        timestamp:
-          parse_from: attributes.timestamp
-          layout: '%a %h %g %H:%M:%S %Y %j'
-        output: add
+        - id: audit_regex_parser_session
+          type: regex_parser
+          regex: '^(?P<timestamp>\w+ \w+\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2})\nLENGTH: \D(?P<length>\d*)\D\n(SESSIONID:\[\d+\]\s+\D(?P<sessionid>[^\s]+|)\D[\n\s]+)?(ENTRYID:\[\d+\]\s+\D(?P<entryid>[^\s]+|)\D[\n\s]+)?(STATEMENT:\[\d+\]\s+\D(?P<statement>[^\s]+|)\D[\n\s]+)?(USERID:\[\d+\]\s+\D(?P<userid>[^\s]+|)\D[\n\s]+)?(USERHOST:\[\d+\]\s+\D(?P<userhost>[^\s]+|)\D[\n\s]+)?(TERMINAL:\[\d+\]\s+\D(?P<terminal>[\d\w[:ascii:]]+?|)\D[\n\s]+)?ACTION:\[\d+\]\s+\D(?P<action>[\d\w[:ascii:]]+?|)\D[\n\s]+(RETURNCODE:\[\d+\]\s+\D(?P<returncode>[^\s]+|)\D[\n\s]+)?(COMMENT\$$TEXT:\[\d+\]\s+\D(?P<comment_text>[^"]+|)\D[\n\s]+)?(LOGOFF\$$PREAD:\[\d+\]\s+\D(?P<logoff_pread>[^"]+|)\D[\n\s]+)?(LOGOFF\$$LREAD:\[\d+\]\s+\D(?P<logoff_lread>[^"]+|)\D[\n\s]+)?(LOGOFF\$$LWRITE:\[\d+\]\s+\D(?P<logoff_lwrite>[^"]+|)\D[\n\s]+)?(LOGOFF\$$DEAD:\[\d+\]\s+\D(?P<logoff_dead>[^"]+|)\D[\n\s]+)?(OBJ\$$CREATOR:\[\d+\]\s+\D(?P<obj_creator>[^"]+|)\D[\n\s]+)?(OBJ\$$NAME:\[\d+\]\s+\D(?P<obj_name>[^"]+|)\D[\n\s]+)?(OBJ\$$PRIVILEGES:\[\d+\]\s+\D(?P<obj_privileges>[^"]+|)\D[\n\s]+)?(AUTH\$$GRANTEE:\[\d+\]\s+\D(?P<auth_grantee>[^"]+|)\D[\n\s]+)?(OS\$$USERID:\[\d+\]\s+\D(?P<os_userid>[^\s]+|)\D[\n\s]+)?(DBID:\[\d+\]\s+\D(?P<dbid>[^\s]+|)\D[\n\s]+)?(SESSIONCPU:\[\d+\]\s+\D(?P<sessioncpu>\d+|)\D[\n\s]+)?(PRIV\$$USED:\[\d+\]\s+\D(?P<priv_user>[^\s]+|)\D[\n\s]+)?'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%a %h %g %H:%M:%S %Y %j'
+          output: add
 
-      - id: server_start_regex_parser
-        type: regex_parser
-        regex: '(?P<message>[\d\w[:ascii:]]+)'
-        output: add
+        - id: server_start_regex_parser
+          type: regex_parser
+          regex: '(?P<message>[\d\w[:ascii:]]+)'
+          output: add
+        {{ end }}
 
-      - type: add
-        field: attributes.log_type
-        value: oracledb.audit
+        - type: add
+          field: attributes.log_type
+          value: oracledb.audit
     {{ end }}
 
     {{ if .enable_alert_log }}
@@ -119,6 +125,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: router
           routes:
             - output: xml_alert_regex_parser
@@ -160,6 +167,7 @@ template: |
           type: filter
           expr: 'attributes.message == ""'
           output: add
+        {{ end }}
 
         - type: add
           field: attributes.log_type
@@ -183,6 +191,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: listener_router
           type: router
           routes:
@@ -227,6 +236,7 @@ template: |
             parse_from: attributes.timestamp
             layout: '%Y-%m-%dT%T.%L%j'
           output: add
+        {{ end }}
 
         - type: add
           field: attributes.log_type

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -22,6 +22,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -41,6 +45,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: pgbouncer_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}(\s*[^\d\s]{3})?)\s*(\[)?(?P<pid>\d+)(\])? (?P<severity>\w+) (?P<message>.*)'
@@ -94,6 +99,7 @@ template: |
           parse_from: attributes.message
           regex: '^[CS]-\w*:\s\(?(?P<db_name>\w*)\)?\/\(?(?P<user_name>[^@]*)\)?@(?P<host>[^:]*):(?P<port>\d*)\s*'
           output: add_type
+        {{ end }}
 
         - id: add_type
           type: add

--- a/plugins/postgresql_logs.yaml
+++ b/plugins/postgresql_logs.yaml
@@ -35,6 +35,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -58,6 +62,7 @@ template: |
           from: body  
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?P<tid>\d+)\](?:\s+(?P<role>\S*)@(?P<user>\S*))?\s*(?P<level>\w+):\s+(?P<message>(?:\s*duration:\s*(?P<duration>[\d\.:]*)\s*ms\s*)?.*)'
           timestamp:
@@ -207,6 +212,7 @@ template: |
         - id: end_filter
           type: filter
           expr: 'body == ""'
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/rabbitmq_logs.yaml
+++ b/plugins/rabbitmq_logs.yaml
@@ -21,6 +21,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -46,6 +50,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}) \[(?P<severity>[a-z]+)\] \<(?P<process_id>\d+\.\d+\.\d+)\> (?P<message>.*)'
           timestamp:
@@ -55,6 +60,7 @@ template: |
             parse_from: attributes.severity
             mapping:
               info2: 'noti'
+        {{ end }}
   service:
     extensions: [file_storage]
     pipelines:

--- a/plugins/redis_logs.yaml
+++ b/plugins/redis_logs.yaml
@@ -31,6 +31,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -54,6 +58,7 @@ template: |
           from: body
           to: attributes["log.record.original"] 
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '^\[?(?P<pid>\d+):?(?P<role>[A-Z])?\]?\s+(?P<timestamp>\d{2}\s+\w+(?:\s+\d{4})?\s+\d{2}:\d{2}:\d{2}.\d{3})\s+(?P<level>[\*|#|\-|\.])\s+(?P<message>.*)'
           severity:
@@ -120,6 +125,7 @@ template: |
           field: attributes.role
           value: 'master'
           output: add_type
+        {{ end }}
 
         - id: add_type
           type: add

--- a/plugins/sap_hana_logs.yaml
+++ b/plugins/sap_hana_logs.yaml
@@ -34,6 +34,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -61,6 +65,7 @@ template: |
             from: body
             to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
           - id: sap_hana_parser
             type: regex_parser
             regex: '^\[(?P<thread_id>\d+)\]{(?P<connection_id>[^}]+)}\[(?P<transaction_id>[^\/]+)\/(?P<update_transaction_id>[^\]]+)\] (?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+) (?P<sap_severity>[^ ]+) (?P<component>[^ ]+)\s+(?P<source_file>[^ ]+) : (?P<message>.*)'
@@ -76,6 +81,7 @@ template: |
                 warn: w
                 error: e
                 fatal: f
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/solr_logs.yaml
+++ b/plugins/solr_logs.yaml
@@ -23,6 +23,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -46,6 +50,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: solr_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?P<level>[A-z]+)\s{1,5}\((?P<thread>[^\)]+)\)\s\[c?:?(?P<collection>[^\s]*)\ss?:?(?P<shard>[^\s]*)\sr?:?(?P<replica>[^\s]*)\sx?:?(?P<core>[^\]]*)\]\s(?P<source>[^\s]+)\s(?P<message>(?:[\s\S])+)\s?=?>?(?P<exception>[\s\S]*)'
@@ -54,6 +59,7 @@ template: |
             layout: '%Y-%m-%d %H:%M:%S.%L'
           severity:
             parse_from: attributes.level
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/sql_server_logs.yaml
+++ b/plugins/sql_server_logs.yaml
@@ -21,6 +21,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -36,10 +40,12 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: router
           routes:
             - output: add_type
               expr: 'body.provider.name matches "MSSQLSERVER"'
+        {{ end }}
         - id: add_type
           type: add
           field: attributes.log_type

--- a/plugins/syslog_logs.yaml
+++ b/plugins/syslog_logs.yaml
@@ -70,6 +70,10 @@ parameters:
       - body
       - attributes
     default: body
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     syslog:
@@ -98,6 +102,7 @@ template: |
           from: body
           to: {{ .parse_to }}.raw_log
         {{ end }}
+        {{ if .parse }}
         {{ if eq .data_flow "low" }}
         # Filter entries with debug severity (7); There is no actual severity field left by the syslog parser,
         # so we must calculate the severity from the priority
@@ -171,6 +176,7 @@ template: |
           from: attributes.version
           to: body.version
         {{end}}
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/tcp_logs.yaml
+++ b/plugins/tcp_logs.yaml
@@ -37,11 +37,17 @@ parameters:
       - "1.2"
       - "1.3"
     default: "1.2"
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     tcplog:
       listen_address: '{{ .listen_ip }}:{{ .listen_port }}'
+      {{ if .parse }}
       add_attributes: {{ .add_attributes }}
+      {{ end }}
       attributes:
         log_type: '{{ .log_type }}'
       {{ if .enable_tls }}

--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -54,6 +54,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -82,6 +86,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<remote_host>[^\s]+) - (?P<remote_user>[^\s]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[A-Z]+) (?P<path>[^\s]+)[^"]+" (?P<status>\d+) (?P<bytes_sent>[^\s]+)'
           parse_to: {{ .parse_to }}
@@ -101,6 +106,7 @@ template: |
           type: move
           from: attributes.raw_log
           to: body.raw_log
+        {{ end }}
         {{ end }}
     {{ end }}
 
@@ -129,6 +135,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         - type: regex_parser
           regex: '(?P<timestamp>\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2}.\d{3})\s(?P<tomcat_severity>\w+)\s\[(?P<thread>[^\[\]]+(?:\[[\d:]+\])?)\]\s(?P<tc_source>[^ ]+)\s(?P<message>[\s\S]+)'
           parse_to: {{ .parse_to }}
@@ -150,6 +157,7 @@ template: |
           type: move
           from: attributes.raw_log
           to: body.raw_log
+        {{ end }}
         {{ end }}
     {{ end }}
 

--- a/plugins/ubiquiti_logs.yaml
+++ b/plugins/ubiquiti_logs.yaml
@@ -18,6 +18,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 
 template: |
   receivers:
@@ -31,6 +35,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: router
           default: add_type
           routes:
@@ -95,6 +100,7 @@ template: |
             info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
             debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
           output: add_type
+        {{ end }}
 
         - id: add_type
           type: add

--- a/plugins/udp_logs.yaml
+++ b/plugins/udp_logs.yaml
@@ -18,13 +18,19 @@ parameters:
     description: Adds net.transport, net.peer.ip, net.peer.port, net.host.ip and net.host.port attributes
     type: bool
     default: true
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     udplog:
       listen_address: '{{ .listen_ip }}:{{ .listen_port}}'
       attributes:
         log_type: {{.log_type}}
+      {{ if .parse }}
       add_attributes: {{.add_attributes}}
+      {{ end }}
 
   service:
     pipelines:

--- a/plugins/vcenter_logs.yaml
+++ b/plugins/vcenter_logs.yaml
@@ -42,6 +42,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   receivers:
     tcplog:
@@ -68,6 +72,7 @@ template: |
           from: body
           to: attributes.raw_log
         {{ end }}
+        {{ if .parse }}
         # vcenter will (sometimes) prepend an id to the messages, check
         # for the id and drop it if it exists
         # example: '257 <14>1. . . '
@@ -151,6 +156,7 @@ template: |
           type: move
           from: attributes.raw_log
           to: body.raw_log
+        {{ end }}
         {{ end }}
   service:
     pipelines:

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -99,6 +99,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -143,6 +147,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - type: filter
           expr: 'body matches "^#"'
         - type: csv_parser
@@ -198,6 +203,7 @@ template: |
           layout: '{{ .timestamp_layout }}'
           layout_type: {{ .timestamp_layout_type }}
           location: {{.timezone}}
+        {{ end }}
           
   service:
     extensions: [file_storage]

--- a/plugins/wildfly_logs.yaml
+++ b/plugins/wildfly_logs.yaml
@@ -44,6 +44,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -61,6 +65,13 @@ template: |
       attributes:
         log_type: wildfly.standalone
       operators:
+        {{ if .save_log_record_original }}
+        - id: save_log_record_original
+          type: copy
+          from: body
+          to: attributes["log.record.original"]
+        {{ end }}
+        {{ if .parse }}
         - id: wildfly_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<level>\w+)(?:\s+\[(?P<source>.+?)\])?(?:\s+\((?P<thread>.+?)\))?\s+(?P<message>(?:(?P<messageCode>[\d\w]+):)?[^\n]*)'
@@ -70,6 +81,7 @@ template: |
             location: {{ .timezone }}
           severity:
             parse_from: attributes.level
+        {{ end }}
     
     filelog/domain_server:
       storage: file_storage
@@ -89,6 +101,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: wildfly_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<level>\w+)(?:\s+\[(?P<source>.+?)\])?(?:\s+\((?P<thread>.+?)\))?\s+(?P<message>(?:(?P<messageCode>[\d\w]+):)?[^\n]*)'
@@ -98,6 +111,7 @@ template: |
             location: {{ .timezone }}
           severity:
             parse_from: attributes.level
+        {{ end }}
 
     filelog/domain_controller:
       storage: file_storage
@@ -117,6 +131,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: wildfly_parser
           type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<level>\w+)(?:\s+\[(?P<source>.+?)\])?(?:\s+\((?P<thread>.+?)\))?\s+(?P<message>(?:(?P<messageCode>[\d\w]+):)?[^\n]*)'
@@ -126,6 +141,7 @@ template: |
             location: {{ .timezone }}
           severity:
             parse_from: attributes.level
+        {{ end }}
 
   service:
     extensions: [file_storage]

--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -20,6 +20,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -41,6 +45,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: windows_dhcp_router
           type: router
           routes:
@@ -52,6 +57,7 @@ template: |
           timestamp:
             parse_from: attributes.timestamp
             layout: '%m/%d/%y,%H:%M:%S'
+        {{ end }}
     
   service:
     extensions: [file_storage]

--- a/plugins/zookeeper_logs.yaml
+++ b/plugins/zookeeper_logs.yaml
@@ -26,6 +26,10 @@ parameters:
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool
     default: false
+  - name: parse
+    description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
+    type: bool
+    default: true
 template: |
   extensions:
     file_storage:
@@ -45,6 +49,7 @@ template: |
           from: body
           to: attributes["log.record.original"]
         {{ end }}
+        {{ if .parse }}
         - id: regex_router
           type: router
           routes: 
@@ -89,6 +94,7 @@ template: |
           type: add
           field: attributes.log_type
           value: 'zookeeper'
+        {{ end }}
 
   service:
     extensions: [file_storage]


### PR DESCRIPTION
### Proposed Change
- Added field to all log plugins:
- When `Parse` is true, we need to send the raw body, instead of doing the plugin parsing. 
- When false, it send the raw log message in the body field.
- This is needed to merge before we merge this PR: https://github.com/observIQ/bindplane-op-enterprise/pull/5272

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
