### PR TITLE
fix: Ignore error reading response body for a 200 in SecOps https exporter

### DIFF
--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -161,16 +161,16 @@ func (exp *httpExporter) uploadToChronicleHTTP(ctx context.Context, logs *api.Im
 	exp.telemetry.ExporterRequestCount.Add(ctx, 1,
 		metric.WithAttributeSet(attribute.NewSet(attrErrorNone)))
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err == nil && resp.StatusCode == http.StatusOK {
+	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
 
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		exp.set.Logger.Warn("Failed to read response body", zap.Error(err))
-	} else {
-		exp.set.Logger.Warn("Received non-OK response from Chronicle", zap.String("status", resp.Status), zap.ByteString("response", respBody))
 	}
+
+	exp.set.Logger.Warn("Received non-OK response from Chronicle", zap.String("status", resp.Status), zap.ByteString("response", respBody))
 
 	// TODO interpret with https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/coreinternal/errorutil/http.go
 	statusErr := errors.New(resp.Status)


### PR DESCRIPTION
### Proposed Change

Previously, we return no error only if we recieve a `200` from SecOps and read the response body with no error. Reading that body is only used for logging in the case of a non-200 response. We've been seeing timeouts reading that body, which cause the exporter to return a permanent error. This triggers a log that from the retry sender indicating dropped logs, which isn't the case. This change only attempts to read the response body in the case of a non-200 response.


```json
{
    "level":"warn",
    "ts":"2025-06-16T13:13:43.183-0500",
    "caller":"chronicleexporter/http_exporter.go:171",
    "msg":"Failed to read response body",
    "resource":{"service.instance.id":"01952532-5de9-788d-947f-c429df213c18"},"otelcol.component.id":"chronicle/Google_SecOps_https",
    "otelcol.component.kind":"exporter",
    "otelcol.signal":"logs",
    "error":"context deadline exceeded"
}
```

```json
{
    "level":"error",
    "ts":"2025-06-16T13:13:43.190-0500",
    "caller":"internal/queue_sender.go:57",
    "msg":"Exporting failed. Dropping data.",
    "resource":{"service.instance.id":"01952532-5de9-788d-947f-c429df213c18"},"otelcol.component.id":"chronicle/Google_SecOps_https",
    "otelcol.component.kind":"exporter",
    "otelcol.signal":"logs",
    "error":"not retryable error: upload to chronicle: Permanent error: 200 OK",
    "dropped_items":295,
    "stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewQueueSender.func1\n\t/home/runner/go/pkg/mod/go.opentelemetry.io/collector/exporter@v0.127.0/exporterhelper/internal/queue_sender.go:57\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch.(*disabledBatcher[...]).Consume\n\t/home/runner/go/pkg/mod/go.opentelemetry.io/collector/exporter@v0.127.0/exporterhelper/internal/queuebatch/disabled_batcher.go:22\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch.(*asyncQueue[...]).Start.func1\n\t/home/runner/go/pkg/mod/go.opentelemetry.io/collector/exporter@v0.127.0/exporterhelper/internal/queuebatch/async_queue.go:47"
}
```


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
