### PR TITLE
feat: Webhook Exporter event per request limit (PIPE-293)

### DIFF
--- a/exporter/webhookexporter/README.md
+++ b/exporter/webhookexporter/README.md
@@ -22,7 +22,7 @@ The webhook exporter sends data to a configured HTTP endpoint. Here's how it pro
 
    - Data is extracted from the OpenTelemetry data model
    - Each entry's body is parsed as JSON if possible, otherwise kept as a string
-   - Entries are organized into batches based on the configured queue size
+   - Entries are organized into batches based on the configured `events_per_request_limit`. When this limit is set to 0 or not specified, all events are sent in a single request. When set to a positive value, events are split into multiple requests with at most this many events each.
 
 3. **HTTP Transmission**:
 
@@ -40,15 +40,16 @@ The webhook exporter sends data to a configured HTTP endpoint. Here's how it pro
 
 The following configuration options are available:
 
-| Field            | Type              | Default | Required | Description                                                                                                                                                                                                                                         |
-| ---------------- | ----------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| endpoint         | string            |         | `true`   | The URL where the webhook requests will be sent. Must start with http:// or https://                                                                                                                                                                |
-| verb             | string            |         | `true`   | The HTTP method to use for the webhook requests. Must be one of: POST, PATCH, PUT                                                                                                                                                                   |
-| content_type     | string            |         | `true`   | The Content-Type header for the webhook requests                                                                                                                                                                                                    |
-| headers          | map[string]string |         | `false`  | Additional HTTP headers to include in the webhook requests                                                                                                                                                                                          |
-| sending_queue    | map               |         | `false`  | Determines how telemetry data is buffered before exporting. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information.        |
-| retry_on_failure | map               |         | `false`  | Determines how the exporter will attempt to retry after a failure. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information. |
-| timeout          | duration          | 30s     | `false`  | Time to wait per individual attempt to send data to a backend. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information.     |
+| Field                   | Type              | Default | Required | Description                                                                                                                                                                                                                                         |
+| ----------------------- | ----------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| endpoint                | string            |         | `true`   | The URL where the webhook requests will be sent. Must start with http:// or https://                                                                                                                                                                |
+| verb                    | string            |         | `true`   | The HTTP method to use for the webhook requests. Must be one of: POST, PATCH, PUT                                                                                                                                                                   |
+| content_type            | string            |         | `true`   | The Content-Type header for the webhook requests                                                                                                                                                                                                    |
+| events_per_request_limit| int               | 0       | `false`  | Maximum number of log events to send in a single request. When set to 0 or not specified, all events are sent in one request. When set to a positive value, events are batched into separate requests with at most this many events each.        |
+| headers                 | map[string]string |         | `false`  | Additional HTTP headers to include in the webhook requests                                                                                                                                                                                          |
+| sending_queue           | map               |         | `false`  | Determines how telemetry data is buffered before exporting. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information.        |
+| retry_on_failure        | map               |         | `false`  | Determines how the exporter will attempt to retry after a failure. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information. |
+| timeout                 | duration          | 30s     | `false`  | Time to wait per individual attempt to send data to a backend. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information.     |
 
 ### Example Configurations
 
@@ -80,6 +81,26 @@ exporters:
       initial_interval: 5s
       max_interval: 30s
       max_elapsed_time: 300s
+```
+
+#### Events Per Request Limit Configuration
+
+```yaml
+exporters:
+  webhook:
+    endpoint: https://api.example.com/webhook
+    verb: POST
+    content_type: application/json
+    headers:
+      X-API-Key: "your-api-key"
+    events_per_request_limit: 100  # Send at most 100 log events per request
+    sending_queue:
+      enabled: true
+      queue_size: 1000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
 ```
 
 #### Mutual TLS Configuration

--- a/exporter/webhookexporter/config.go
+++ b/exporter/webhookexporter/config.go
@@ -70,6 +70,9 @@ type SignalConfig struct {
 	// ContentType specifies the Content-Type header for the webhook requests
 	// This field is required
 	ContentType string `mapstructure:"content_type"`
+
+	// EventsPerRequestLimit specifies the maximum number of events to send in a single request
+	EventsPerRequestLimit int `mapstructure:"events_per_request_limit"`
 }
 
 // Validate checks if the configuration is valid

--- a/exporter/webhookexporter/config_test.go
+++ b/exporter/webhookexporter/config_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestHTTPVerb_UnmarshalText(t *testing.T) {
@@ -133,11 +132,9 @@ func TestConfig_Validate(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint: "https://example.com",
 					},
-					Verb:        POST,
-					ContentType: "application/json",
-					QueueBatchConfig: exporterhelper.QueueBatchConfig{
-						QueueSize: 20,
-					},
+					Verb:                  POST,
+					ContentType:           "application/json",
+					EventsPerRequestLimit: 20,
 				},
 			},
 			wantErr: false,
@@ -149,11 +146,9 @@ func TestConfig_Validate(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint: "https://example.com",
 					},
-					Verb:        POST,
-					ContentType: "application/json",
-					QueueBatchConfig: exporterhelper.QueueBatchConfig{
-						QueueSize: 0,
-					},
+					Verb:                  POST,
+					ContentType:           "application/json",
+					EventsPerRequestLimit: 0,
 				},
 			},
 			wantErr: false,
@@ -165,11 +160,9 @@ func TestConfig_Validate(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint: "https://example.com",
 					},
-					Verb:        POST,
-					ContentType: "application/json",
-					QueueBatchConfig: exporterhelper.QueueBatchConfig{
-						QueueSize: -1,
-					},
+					Verb:                  POST,
+					ContentType:           "application/json",
+					EventsPerRequestLimit: -1,
 				},
 			},
 			wantErr: false,

--- a/exporter/webhookexporter/exporter_logs.go
+++ b/exporter/webhookexporter/exporter_logs.go
@@ -78,7 +78,7 @@ func (le *logsExporter) shutdown(_ context.Context) error {
 func (le *logsExporter) logsDataPusher(ctx context.Context, ld plog.Logs) error {
 	le.logger.Debug("begin webhook logsDataPusher")
 
-	limit := int(le.cfg.QueueBatchConfig.QueueSize)
+	limit := le.cfg.EventsPerRequestLimit
 	if limit <= 0 {
 		// If no limit is set, send all logs in one request
 		return le.sendLogs(ctx, extractLogBodies(ld))

--- a/exporter/webhookexporter/exporter_logs_test.go
+++ b/exporter/webhookexporter/exporter_logs_test.go
@@ -551,47 +551,49 @@ func TestExtractLogsFromResourceLogs(t *testing.T) {
 	}
 }
 
-func TestLogsDataPusherWithQueueSettings(t *testing.T) {
+func TestLogsDataPusherWithBatchLimits(t *testing.T) {
 	testCases := []struct {
-		name            string
-		queueSettings   exporterhelper.QueueBatchConfig
-		numLogs         int
-		expectedBatches int
+		name                  string
+		eventsPerRequestLimit int
+		numLogs               int
+		expectedBatches       int
 	}{
 		{
-			name: "default queue settings",
-			queueSettings: exporterhelper.QueueBatchConfig{
-				Enabled:      true,
-				QueueSize:    5000,
-				NumConsumers: 10,
-			},
-			numLogs:         100,
-			expectedBatches: 1, // Default settings will batch all logs together
+			name:                  "no limit - all logs in single batch",
+			eventsPerRequestLimit: 0,
+			numLogs:               100,
+			expectedBatches:       1, // All logs sent in one request when limit is 0
 		},
 		{
-			name: "disabled queue",
-			queueSettings: exporterhelper.QueueBatchConfig{
-				Enabled: false,
-			},
-			numLogs:         50,
-			expectedBatches: 1, // No batching when queue is disabled
+			name:                  "limit larger than total logs",
+			eventsPerRequestLimit: 100,
+			numLogs:               50,
+			expectedBatches:       1, // All logs fit in single batch
 		},
 		{
-			name: "small queue size",
-			queueSettings: exporterhelper.QueueBatchConfig{
-				Enabled:      true,
-				QueueSize:    10,
-				NumConsumers: 1,
-			},
-			numLogs:         25,
-			expectedBatches: 3, // Should batch into smaller chunks due to queue size
+			name:                  "limit smaller than total logs",
+			eventsPerRequestLimit: 10,
+			numLogs:               25,
+			expectedBatches:       3, // 25 logs split into batches of 10: [10, 10, 5]
+		},
+		{
+			name:                  "exact division",
+			eventsPerRequestLimit: 5,
+			numLogs:               20,
+			expectedBatches:       4, // 20 logs split into 4 batches of 5 each
+		},
+		{
+			name:                  "single log per batch",
+			eventsPerRequestLimit: 1,
+			numLogs:               3,
+			expectedBatches:       3, // Each log sent separately
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a channel to receive request bodies
-			receivedBodies := make(chan []byte, tc.expectedBatches)
+			receivedBodies := make(chan []byte, tc.expectedBatches+1) // +1 for safety
 
 			// Create test server that captures request bodies
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -607,9 +609,9 @@ func TestLogsDataPusherWithQueueSettings(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: server.URL,
 				},
-				Verb:             POST,
-				ContentType:      "application/json",
-				QueueBatchConfig: tc.queueSettings,
+				Verb:                  POST,
+				ContentType:           "application/json",
+				EventsPerRequestLimit: tc.eventsPerRequestLimit,
 			}
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
 			exp.start(context.Background(), componenttest.NewNopHost())
@@ -635,6 +637,7 @@ func TestLogsDataPusherWithQueueSettings(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
+			totalLogsReceived := 0
 			for i := 0; i < tc.expectedBatches; i++ {
 				select {
 				case body := <-receivedBodies:
@@ -645,51 +648,71 @@ func TestLogsDataPusherWithQueueSettings(t *testing.T) {
 
 					// Verify we received logs
 					require.Greater(t, len(receivedLogs), 0)
+					totalLogsReceived += len(receivedLogs)
 
-					// For small queue size test, verify batch sizes
-					if tc.queueSettings.QueueSize > 0 && int(tc.queueSettings.QueueSize) < tc.numLogs {
-						require.LessOrEqual(t, len(receivedLogs), int(tc.queueSettings.QueueSize))
+					// Verify batch size doesn't exceed limit (except when limit is 0)
+					if tc.eventsPerRequestLimit > 0 {
+						require.LessOrEqual(t, len(receivedLogs), tc.eventsPerRequestLimit)
 					}
 				case <-ctx.Done():
 					t.Fatalf("Timeout waiting for batch %d", i+1)
 				}
 			}
 			require.Equal(t, tc.expectedBatches, receivedCount)
+			require.Equal(t, tc.numLogs, totalLogsReceived)
+
+			// Verify no extra batches were sent
+			select {
+			case <-receivedBodies:
+				t.Fatal("Received more batches than expected")
+			case <-time.After(100 * time.Millisecond):
+				// Expected - no more batches should arrive
+			}
 		})
 	}
 }
 
-func TestLogsDataPusherWithQueueSettingsAndErrors(t *testing.T) {
+func TestLogsDataPusherWithBatchLimitsAndErrors(t *testing.T) {
 	testCases := []struct {
-		name          string
-		queueSettings exporterhelper.QueueBatchConfig
-		serverError   bool
-		expectedError string
+		name                  string
+		eventsPerRequestLimit int
+		numLogs               int
+		serverError           bool
+		expectedError         string
+		expectedBatches       int
 	}{
 		{
-			name: "queue enabled with server error",
-			queueSettings: exporterhelper.QueueBatchConfig{
-				Enabled:      true,
-				QueueSize:    100,
-				NumConsumers: 1,
-			},
-			serverError:   true,
-			expectedError: "failed to send request",
+			name:                  "batching with server error on first batch",
+			eventsPerRequestLimit: 2,
+			numLogs:               4,
+			serverError:           true,
+			expectedError:         "failed to send batch 1",
+			expectedBatches:       1, // Should fail on first batch
 		},
 		{
-			name: "queue disabled with server error",
-			queueSettings: exporterhelper.QueueBatchConfig{
-				Enabled: false,
-			},
-			serverError:   true,
-			expectedError: "failed to send request",
+			name:                  "no batching with server error",
+			eventsPerRequestLimit: 0,
+			numLogs:               3,
+			serverError:           true,
+			expectedError:         "failed to send request",
+			expectedBatches:       1,
+		},
+		{
+			name:                  "batching with successful requests",
+			eventsPerRequestLimit: 2,
+			numLogs:               4,
+			serverError:           false,
+			expectedError:         "",
+			expectedBatches:       2, // Should succeed with 2 batches
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			requestCount := 0
 			// Create test server that returns error if configured
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
 				if tc.serverError {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
@@ -703,13 +726,272 @@ func TestLogsDataPusherWithQueueSettingsAndErrors(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: server.URL,
 				},
+				Verb:                  POST,
+				ContentType:           "application/json",
+				EventsPerRequestLimit: tc.eventsPerRequestLimit,
+			}
+
+			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
+			exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+
+			// Create test logs
+			logs := plog.NewLogs()
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+			for i := 0; i < tc.numLogs; i++ {
+				logRecord := scopeLogs.LogRecords().AppendEmpty()
+				logRecord.Body().SetStr(fmt.Sprintf("test log message %d", i))
+			}
+
+			// Push logs
+			err = exp.logsDataPusher(context.Background(), logs)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				// Verify that we only sent requests up to the point of failure
+				require.LessOrEqual(t, requestCount, tc.expectedBatches)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedBatches, requestCount)
+			}
+		})
+	}
+}
+
+// TestQueueBatchSettings tests the QueueBatch configuration options
+func TestQueueBatchSettings(t *testing.T) {
+	testCases := []struct {
+		name          string
+		queueSettings exporterhelper.QueueBatchConfig
+		numLogs       int
+		expectError   bool
+		description   string
+	}{
+		{
+			name: "default queue settings",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    1000,
+				NumConsumers: 10,
+			},
+			numLogs:     100,
+			expectError: false,
+			description: "Default queue settings should work properly",
+		},
+		{
+			name: "disabled queue",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled: false,
+			},
+			numLogs:     50,
+			expectError: false,
+			description: "Disabled queue should still process logs",
+		},
+		{
+			name: "small queue size",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    10,
+				NumConsumers: 1,
+			},
+			numLogs:     25,
+			expectError: false,
+			description: "Small queue size should handle logs appropriately",
+		},
+		{
+			name: "large queue size",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    10000,
+				NumConsumers: 100,
+			},
+			numLogs:     1000,
+			expectError: false,
+			description: "Large queue size should handle many logs efficiently",
+		},
+		{
+			name: "single consumer",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    100,
+				NumConsumers: 1,
+			},
+			numLogs:     50,
+			expectError: false,
+			description: "Single consumer should process logs sequentially",
+		},
+		{
+			name: "multiple consumers",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    500,
+				NumConsumers: 20,
+			},
+			numLogs:     200,
+			expectError: false,
+			description: "Multiple consumers should process logs concurrently",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			requestCount := 0
+			receivedLogs := make([]string, 0)
+			var requestCountLock = make(chan struct{}, 1)
+			requestCountLock <- struct{}{}
+
+			// Create test server that counts requests and collects logs
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				<-requestCountLock
+				requestCount++
+				requestCountLock <- struct{}{}
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var logs []string
+				err = json.Unmarshal(body, &logs)
+				require.NoError(t, err)
+
+				<-requestCountLock
+				receivedLogs = append(receivedLogs, logs...)
+				requestCountLock <- struct{}{}
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			// Create exporter with queue settings
+			cfg := &SignalConfig{
+				ClientConfig: confighttp.ClientConfig{
+					Endpoint: server.URL,
+				},
 				Verb:             POST,
 				ContentType:      "application/json",
 				QueueBatchConfig: tc.queueSettings,
 			}
 
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
-			exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+			err = exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+
+			// Create test logs
+			logs := plog.NewLogs()
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+
+			expectedLogs := make([]string, tc.numLogs)
+			for i := 0; i < tc.numLogs; i++ {
+				logMessage := fmt.Sprintf("test log %d", i)
+				expectedLogs[i] = logMessage
+
+				logRecord := scopeLogs.LogRecords().AppendEmpty()
+				logRecord.Body().SetStr(logMessage)
+			}
+
+			// Push logs
+			err = exp.logsDataPusher(context.Background(), logs)
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+			} else {
+				require.NoError(t, err, tc.description)
+
+				// Wait a bit for async processing
+				time.Sleep(100 * time.Millisecond)
+
+				<-requestCountLock
+				finalRequestCount := requestCount
+				finalReceivedLogs := make([]string, len(receivedLogs))
+				copy(finalReceivedLogs, receivedLogs)
+				requestCountLock <- struct{}{}
+
+				// Verify that requests were made
+				require.Greater(t, finalRequestCount, 0, "At least one request should have been made")
+
+				// Verify all logs were received (may be in different order due to concurrency)
+				require.Equal(t, tc.numLogs, len(finalReceivedLogs), "All logs should be received")
+				require.ElementsMatch(t, expectedLogs, finalReceivedLogs, "Received logs should match sent logs")
+			}
+
+			// Clean up
+			err = exp.shutdown(context.Background())
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestQueueBatchSettingsWithRetries tests QueueBatch behavior with server errors and retries
+func TestQueueBatchSettingsWithRetries(t *testing.T) {
+	testCases := []struct {
+		name          string
+		queueSettings exporterhelper.QueueBatchConfig
+		serverError   bool
+		expectedError bool
+		description   string
+	}{
+		{
+			name: "queue enabled with server error",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    100,
+				NumConsumers: 1,
+			},
+			serverError:   true,
+			expectedError: true,
+			description:   "Queue should handle server errors appropriately",
+		},
+		{
+			name: "queue disabled with server error",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled: false,
+			},
+			serverError:   true,
+			expectedError: true,
+			description:   "Disabled queue should still handle server errors",
+		},
+		{
+			name: "queue enabled with successful requests",
+			queueSettings: exporterhelper.QueueBatchConfig{
+				Enabled:      true,
+				QueueSize:    50,
+				NumConsumers: 2,
+			},
+			serverError:   false,
+			expectedError: false,
+			description:   "Queue should work correctly with successful requests",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			requestCount := 0
+
+			// Create test server that may return errors
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				if tc.serverError {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			// Create exporter with queue settings
+			cfg := &SignalConfig{
+				ClientConfig: confighttp.ClientConfig{
+					Endpoint: server.URL,
+				},
+				Verb:             POST,
+				ContentType:      "application/json",
+				QueueBatchConfig: tc.queueSettings,
+			}
+
+			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
+			require.NoError(t, err)
+			err = exp.start(context.Background(), componenttest.NewNopHost())
 			require.NoError(t, err)
 
 			// Create test logs
@@ -721,12 +1003,15 @@ func TestLogsDataPusherWithQueueSettingsAndErrors(t *testing.T) {
 
 			// Push logs
 			err = exp.logsDataPusher(context.Background(), logs)
-			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+			if tc.expectedError {
+				require.Error(t, err, tc.description)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, tc.description)
 			}
+
+			// Clean up
+			err = exp.shutdown(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }

--- a/exporter/webhookexporter/factory.go
+++ b/exporter/webhookexporter/factory.go
@@ -56,10 +56,11 @@ func createDefaultConfig(collectorVersion string) func() component.Config {
 						"User-Agent": configopaque.String(userAgent),
 					},
 				},
-				Verb:             POST,
-				ContentType:      "application/json",
-				QueueBatchConfig: exporterhelper.NewDefaultQueueConfig(),
-				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				Verb:                  POST,
+				ContentType:           "application/json",
+				EventsPerRequestLimit: 0,
+				QueueBatchConfig:      exporterhelper.NewDefaultQueueConfig(),
+				BackOffConfig:         configretry.NewDefaultBackOffConfig(),
 			},
 		}
 	}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
We've been mistakenly using the queue size as a limit for the number of logs per request. Create a new config param to configure this value instead. 
Update testing and documentation for this change

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
