### PR TITLE
chore: v1.79.1 release prep

### DIFF
--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/plugindocgen
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.79.1
 	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/azureloganalyticsexporter/go.mod
+++ b/exporter/azureloganalyticsexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
 	github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs v1.0.0
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwardere
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/qradar
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/extension/awss3eventextension/go.mod
+++ b/extension/awss3eventextension/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/aws v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/aws v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,8 +4,8 @@ go 1.24.4
 
 require (
 	github.com/golang/snappy v1.0.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.79.1
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.128.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -4,43 +4,43 @@ go 1.24.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/exporter/webhookexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.80.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.80.0
-	github.com/observiq/bindplane-otel-collector/packagestate v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/exporter/webhookexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.79.1
+	github.com/observiq/bindplane-otel-collector/internal/report v1.79.1
+	github.com/observiq/bindplane-otel-collector/packagestate v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver v1.79.1
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.128.0
@@ -211,10 +211,10 @@ require (
 )
 
 require (
-	github.com/observiq/bindplane-otel-collector/exporter/azureloganalyticsexporter v1.80.0
-	github.com/observiq/bindplane-otel-collector/extension/awss3eventextension v1.80.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.80.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureloganalyticsexporter v1.79.1
+	github.com/observiq/bindplane-otel-collector/extension/awss3eventextension v1.79.1
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.128.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.128.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension v0.128.0
@@ -1063,3 +1063,5 @@ replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.11.0
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver => github.com/observIQ/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.0.0-20250530122747-d1ad9080b194
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery => github.com/observIQ/opentelemetry-collector-contrib/internal/sqlquery v0.0.0-20250530122747-d1ad9080b194
+
+replace go.opentelemetry.io/collector/service v0.128.0 => go.opentelemetry.io/collector/service v0.127.0

--- a/go.sum
+++ b/go.sum
@@ -3030,8 +3030,8 @@ go.opentelemetry.io/collector/scraper/scrapertest v0.128.0 h1:KEy2Q1lOiQhJDm1JbE
 go.opentelemetry.io/collector/scraper/scrapertest v0.128.0/go.mod h1:skWcfgRLUwlA6ClQWMlQ/rZShHf6MXEKl7eWn7TfVDY=
 go.opentelemetry.io/collector/semconv v0.128.0 h1:MzYOz7Vgb3Kf5D7b49pqqgeUhEmOCuT10bIXb/Cc+k4=
 go.opentelemetry.io/collector/semconv v0.128.0/go.mod h1:OPXer4l43X23cnjLXIZnRj/qQOjSuq4TgBLI76P9hns=
-go.opentelemetry.io/collector/service v0.128.0 h1:q/NbVKevTqlRgj2VKUmFjRhRYgiSA4Bhov5xJnHV4EE=
-go.opentelemetry.io/collector/service v0.128.0/go.mod h1:yjbFqPKhTIfr7qNGIyuQ2lujpSq7QhjkpsfbTea/elo=
+go.opentelemetry.io/collector/service v0.127.0 h1:72JKDcEhTqEsEGrlzX7g459O4HgS8ryczGwIr67T4So=
+go.opentelemetry.io/collector/service v0.127.0/go.mod h1:yL3cVJhbISZZgGOuNFa4inPNS+IeFUfLLJ2FZio5dO8=
 go.opentelemetry.io/collector/service/hostcapabilities v0.128.0 h1:CSHMpQONbEgz5dTW/JKXyAVXd705ufwGJuiJ6gMt7iA=
 go.opentelemetry.io/collector/service/hostcapabilities v0.128.0/go.mod h1:T3XjBe07aHiOD/WUSSSSfEjQAE3WyWHX4NWVM761WxY=
 go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 h1:u2E32P7j1a/gRgZDWhIXC+Shd4rLg70mnE7QLI/Ssnw=

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/internal/rehydration
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/consumer v1.34.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/datapointcountproc
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.80.0
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/counter v1.79.1
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.80.0
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/counter v1.79.1
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/processor/metricextractproce
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0
 	github.com/stretchr/testify v1.10.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/report v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.79.1
 	github.com/open-telemetry/opamp-go v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.128.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.80.0
-	github.com/observiq/bindplane-otel-collector/expr v1.80.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.80.0
+	github.com/observiq/bindplane-otel-collector/counter v1.79.1
+	github.com/observiq/bindplane-otel-collector/expr v1.79.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurem
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0
 	github.com/stretchr/testify v1.10.0

--- a/receiver/awss3eventreceiver/go.mod
+++ b/receiver/awss3eventreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
 	github.com/google/go-cmp v0.7.0
-	github.com/observiq/bindplane-otel-collector/internal/aws v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/aws v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.80.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.79.1
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -5,8 +5,8 @@ go 1.24.4
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.80.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.79.1
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.0

--- a/receiver/googlecloudstoragerehydrationreceiver/go.mod
+++ b/receiver/googlecloudstoragerehydrationreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	cloud.google.com/go/storage v1.51.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.79.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.0

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapirece
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.80.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.79.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.80.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.79.1
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Release prep for 1.79.1 patch.
- Bumps module versions to 1.79.1
- Replace the `go.opentelemetry.io/collector/service` to the v0.127.0 version. This is the last version before the `service.telemetry.metrics.address` field was deprecated. We want this field to be supported so we have a bit more time to implement a long term solution. To test, make the agent and start it with a config that includes that field, should see the agent start up and not fail with the error:
```
{"level":"fatal","ts":"2025-06-24T11:20:40.334-0400","caller":"collector/main.go:121","msg":"RunService returned error","error":"failed to start service: failed while starting collector: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):\n\nerror decoding 'service.telemetry.metrics': decoding failed due to the following error(s):\n\n'' has invalid keys: address","stacktrace":"main.main\n\t/Users/dpaasman/git/bindplane-otel-collector/cmd/collector/main.go:121\nruntime.main\n\t/Users/dpaasman/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.darwin-arm64/src/runtime/proc.go:283"}
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
