### PR TITLE
[receiver/awss3event]: Detect object region from SQS message

### DIFF
--- a/receiver/awss3eventreceiver/internal/worker/worker.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker.go
@@ -135,15 +135,20 @@ func (w *Worker) consumeLogsFromS3Object(ctx context.Context, record events.S3Ev
 	bucket := record.S3.Bucket.Name
 	key := record.S3.Object.Key
 	size := record.S3.Object.Size
+	opts := []func(o *s3.Options){
+		func(o *s3.Options) {
+			o.Region = record.AWSRegion
+		},
+	}
 
-	logger := w.tel.Logger.With(zap.String("bucket", bucket), zap.String("key", key))
+	logger := w.tel.Logger.With(zap.String("bucket", bucket), zap.String("key", key), zap.String("region", record.AWSRegion))
 
 	logger.Debug("reading S3 object", zap.Int64("size", size))
 
 	resp, err := w.client.S3().GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-	})
+	}, opts...)
 	if err != nil {
 		return fmt.Errorf("get object: %w", err)
 	}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Instead of using the region in the AWS client config (derived from the SQS URL), we can pull the region off the SQS message. This allows the receiver to pull objects from buckets in different regions.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
