### PR TITLE
Revert "chore: Add Franz-Go feature gate for kafka receiver"

### DIFF
--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -31,9 +31,6 @@ func SetFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.mtimeSortType", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
 	}
-	if err := featuregate.GlobalRegistry().Set("receiver.kafkareceiver.UseFranzGo", true); err != nil {
-		return fmt.Errorf("failed to enable receiver.kafkareceiver.UseFranzGo: %w", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
Reverts observIQ/bindplane-otel-collector#2518

Decided to not make this the default for everyone.