### PR TITLE
chore: Bump S3 event receiver safety margin to 50% from 80%

### DIFF
--- a/receiver/awss3eventreceiver/internal/worker/worker.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker.go
@@ -410,7 +410,7 @@ func newVisibilityMonitor(logger *zap.Logger, msg types.Message, visibilityTimeo
 }
 
 func getSafetyMargin(timeout time.Duration) time.Duration {
-	return timeout * 80 / 100 // 80% of the timeout
+	return timeout * 50 / 100 // 50% of the timeout
 }
 
 func (vm *visibilityMonitor) stop() {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
After additional testing a 50% safety margin has been performing better

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
