### PR TITLE
chore: Remove deprecated SecOps exporter config fields

### DIFF
--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -100,25 +100,6 @@ type Config struct {
 	// This field is used to determine collector ID for Chronicle.
 	LicenseType string `mapstructure:"license_type"`
 
-	// The following fields are deprecated and will be removed in a future release.
-	// They are being kept to ensure backwards compatibility with existing configurations.
-
-	// Deprecated: This field is deprecated - it was added to account for a bug with the SecOps raw logs search, but ultimately caused
-	// performance problems for the SecOps backend. The bug remains, but as long as UDM search is used, this field is not needed.
-	// BatchLogCountLimitGRPC is the maximum number of logs that can be sent in a single batch to Chronicle via the GRPC protocol
-	// This field is defaulted to 1000, as that is the default Chronicle backend limit.
-	// All batched logs beyond the backend limit will not be able to be queryable via the Raw Logs Search, but will be queryable via UDM Search.
-	// Any batches with more logs than this limit will be split into multiple batches
-	BatchLogCountLimitGRPC int `mapstructure:"batch_log_count_limit_grpc"`
-
-	// Deprecated: This field is deprecated - it was added to account for a bug with the SecOps raw logs search, but ultimately caused
-	// performance problems for the SecOps backend. The bug remains, but as long as UDM search is used, this field is not needed.
-	// BatchLogCountLimitHTTP is the maximum number of logs that can be sent in a single batch to Chronicle via the HTTP protocol
-	// This field is defaulted to 1000, as that is the default Chronicle backend limit.
-	// All batched logs beyond the backend limit will not be able to be queryable via the Raw Logs Search, but will be queryable via UDM Search.
-	// Any batches with more logs than this limit will be split into multiple batches
-	BatchLogCountLimitHTTP int `mapstructure:"batch_log_count_limit_http"`
-
 	// LogErroredPayloads is a flag that determines whether or not to log errored payloads.
 	LogErroredPayloads bool `mapstructure:"log_errored_payloads"`
 }
@@ -127,14 +108,6 @@ type Config struct {
 func (cfg *Config) Validate() error {
 	if cfg.CredsFilePath != "" && cfg.Creds != "" {
 		return errors.New("can only specify creds_file_path or creds")
-	}
-
-	if cfg.BatchLogCountLimitGRPC > 0 {
-		return errors.New("batch_log_count_limit_grpc is deprecated - it was added to account for a bug with the SecOps raw logs search, but ultimately caused performance problems for the SecOps backend. The bug remains, but as long as UDM search is used, this field is not needed")
-	}
-
-	if cfg.BatchLogCountLimitHTTP > 0 {
-		return errors.New("batch_log_count_limit_http is deprecated - it was added to account for a bug with the SecOps raw logs search, but ultimately caused performance problems for the SecOps backend. The bug remains, but as long as UDM search is used, this field is not needed")
 	}
 
 	if cfg.RawLogField != "" {

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -418,7 +418,6 @@ func (m *protoMarshaler) constructPayloads(logGrouper *logGrouper) []*api.BatchC
 	return payloads
 }
 
-// deprecated
 func (m *protoMarshaler) enforceMaximumsGRPCRequest(request *api.BatchCreateLogsRequest) []*api.BatchCreateLogsRequest {
 	size := proto.Size(request)
 	entries := request.Batch.Entries
@@ -536,7 +535,6 @@ func (m *protoMarshaler) constructHTTPPayloads(rawLogs map[string][]*api.Log) ma
 	return payloads
 }
 
-// deprecated
 func (m *protoMarshaler) enforceMaximumsHTTPRequest(request *api.ImportLogsRequest) []*api.ImportLogsRequest {
 	size := proto.Size(request)
 	logs := request.GetInlineSource().Logs


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

These fields were supposed to be removed in the v1.77.0 release, but better late than never.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
