### PR TITLE
feat(updater): Support user configured systemd working directory / collector home

### DIFF
--- a/updater/cmd/updater/main.go
+++ b/updater/cmd/updater/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	// We can't create the zap logger yet, because we don't know the install dir, which is needed
 	// to create the logger. So we pass a Nop logger here.
-	installDir, err := path.InstallDir(zap.NewNop())
+	installDir, err := path.InstallDir(zap.NewNop(), path.DefaultConfigOverrides)
 	if err != nil {
 		// Can't use "fail" here since we don't know the install directory
 		log.Fatalf("Failed to determine install directory: %s", err)

--- a/updater/internal/path/path_darwin.go
+++ b/updater/internal/path/path_darwin.go
@@ -19,7 +19,11 @@ import "go.uber.org/zap"
 // DarwinInstallDir is the path to the install directory on Darwin.
 const DarwinInstallDir = "/opt/observiq-otel-collector"
 
+// DefaultConfigOverrides is not used on Darwin, but is required
+// by InstallDir.
+var DefaultConfigOverrides = []string{}
+
 // InstallDir returns the filepath to the install directory
-func InstallDir(_ *zap.Logger) (string, error) {
+func InstallDir(_ *zap.Logger, _ []string) (string, error) {
 	return DarwinInstallDir, nil
 }

--- a/updater/internal/path/path_linux.go
+++ b/updater/internal/path/path_linux.go
@@ -43,7 +43,7 @@ var DefaultConfigOverrides = []string{
 }
 
 const (
-	configOverrideEnvVar = "BDOT_CONFIG_HOME"
+	configHomeOverrideKey = "BDOT_CONFIG_HOME"
 )
 
 // InstallDir returns the filepath to the install directory
@@ -104,7 +104,7 @@ func customInstallDir(logger *zap.Logger, config string) (string, error) {
 			continue
 		}
 
-		if strings.HasPrefix(line, configOverrideEnvVar+"=") {
+		if strings.HasPrefix(line, configHomeOverrideKey+"=") {
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 2 {
 				value := strings.TrimSpace(parts[1])

--- a/updater/internal/path/path_linux.go
+++ b/updater/internal/path/path_linux.go
@@ -15,14 +15,18 @@
 package path
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
-// LinuxInstallDir is the install directory of the collector on linux.
-const LinuxInstallDir = "/opt/observiq-otel-collector"
+// DefaultLinuxInstallDir is the install directory of the collector on linux.
+const DefaultLinuxInstallDir = "/opt/observiq-otel-collector"
 
 // SystemdFilePath is the path for systemd service
 const SystemdFilePath = "/usr/lib/systemd/system/observiq-otel-collector.service"
@@ -30,9 +34,93 @@ const SystemdFilePath = "/usr/lib/systemd/system/observiq-otel-collector.service
 // SysVFilePath is the path for sysv service
 const SysVFilePath = "/etc/init.d/observiq-otel-collector"
 
+// DefaultConfigOverrides is a list of config files that can be used to override
+// package installation behavior. The updater needs to respect these config
+// options, such as BDOT_CONFIG_HOME
+var DefaultConfigOverrides = []string{
+	"/etc/default/observiq-otel-collector",
+	"/etc/sysconfig/observiq-otel-collector",
+}
+
+const (
+	configOverrideEnvVar = "BDOT_CONFIG_HOME"
+)
+
 // InstallDir returns the filepath to the install directory
-func InstallDir(_ *zap.Logger) (string, error) {
-	return LinuxInstallDir, nil
+func InstallDir(logger *zap.Logger, configOverrides []string) (string, error) {
+	// Check for a custom install directory
+	for _, config := range configOverrides {
+		installDir, err := customInstallDir(logger, config)
+		if err != nil {
+			return "", fmt.Errorf("error checking config file %q: %w", config, err)
+		}
+		if installDir != "" {
+			return installDir, nil
+		}
+	}
+
+	return DefaultLinuxInstallDir, nil
+}
+
+// customInstallDir checks the provided config file for a custom install directory.
+// Returns an error if there is an unexpected issue reading the file. Does not
+// return an error if the file does not exist.
+// If a custom install dir is not found in the config file, it returns an empty string.
+func customInstallDir(logger *zap.Logger, config string) (string, error) {
+	_, err := os.Stat(config)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read package override file %s: %w", config, err)
+	}
+
+	// Buffer is larger enough to read the entire
+	// user defined config override file.
+	buff := make([]byte, 4000)
+
+	// #nosec G304 -- config is a file path from const DefaultConfigOverrides
+	// Test cases will override configOverrides to test this code path.
+	file, err := os.Open(config)
+	if err != nil {
+		return "", fmt.Errorf("open package override file %s: %w", config, err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.Error("close package override file", zap.String("file", config), zap.Error(err))
+		}
+	}()
+
+	_, err = file.Read(buff)
+	if err != nil {
+		return "", fmt.Errorf("read package override file %s: %w", config, err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(buff)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skip empty lines or comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, configOverrideEnvVar+"=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				value := strings.TrimSpace(parts[1])
+				if value != "" {
+					return value, nil
+				}
+				// If the value is empty, continue to the next line
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning config file %s: %w", config, err)
+	}
+
+	return "", nil
 }
 
 // LinuxServiceCmdName returns the filename of the service command available

--- a/updater/internal/path/path_linux_test.go
+++ b/updater/internal/path/path_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestInstallDir(t *testing.T) {
+	tests := []struct {
+		name            string
+		configOverrides []string
+		expectedDir     string
+		errorContains   string
+	}{
+		{
+			name:            "default install dir when no config files exist",
+			configOverrides: []string{"nonexistent1.conf", "nonexistent2.conf"},
+			expectedDir:     "/opt/observiq-otel-collector",
+		},
+		{
+			name:            "custom install dir",
+			configOverrides: []string{"testdata/custom_install_dir.ini"},
+			expectedDir:     "/opt/custom",
+		},
+		{
+			name:            "multi config - one missing",
+			configOverrides: []string{"nonexist.ini", "testdata/custom_install_dir.ini"},
+			expectedDir:     "/opt/custom",
+		},
+		{
+			name:            "multi config - two missing",
+			configOverrides: []string{"testdata/custom_install_dir.ini", "nonexist.ini"},
+			expectedDir:     "/opt/custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := InstallDir(zap.NewNop(), tt.configOverrides)
+
+			if tt.errorContains != "" {
+				require.Error(t, err, "InstallDir should return an error")
+				require.ErrorAs(t, err, &tt.errorContains, "InstallDir should return the expected error")
+				return
+			}
+
+			require.NoError(t, err, "InstallDir should not return an error")
+			require.Equal(t, tt.expectedDir, result, "InstallDir returned unexpected directory")
+
+		})
+	}
+}

--- a/updater/internal/path/path_windows.go
+++ b/updater/internal/path/path_windows.go
@@ -23,6 +23,10 @@ import (
 
 const defaultProductName = "observIQ Distro for OpenTelemetry Collector"
 
+// DefaultConfigOverrides is not used on Windows, but is required
+// by InstallDir.
+var DefaultConfigOverrides = []string{}
+
 // installDirFromRegistry gets the installation dir of the given product from the Windows Registry
 func installDirFromRegistry(logger *zap.Logger, productName string) (string, error) {
 	// this key is created when installing using the MSI installer
@@ -48,6 +52,6 @@ func installDirFromRegistry(logger *zap.Logger, productName string) (string, err
 }
 
 // InstallDir returns the filepath to the install directory
-func InstallDir(logger *zap.Logger) (string, error) {
+func InstallDir(logger *zap.Logger, _ []string) (string, error) {
 	return installDirFromRegistry(logger, defaultProductName)
 }

--- a/updater/internal/path/testdata/custom_install_dir.ini
+++ b/updater/internal/path/testdata/custom_install_dir.ini
@@ -1,0 +1,1 @@
+BDOT_CONFIG_HOME=/opt/custom

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -26,10 +26,10 @@ Type=simple
 User=root
 Group={{.Group}}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
-WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+Environment=OIQ_OTEL_COLLECTOR_HOME={{.InstallDir}}
+Environment=OIQ_OTEL_COLLECTOR_STORAGE={{.InstallDir}}/storage
+WorkingDirectory={{.InstallDir}}
+ExecStart={{.InstallDir}}/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000
 SuccessExitStatus=0
 TimeoutSec=20

--- a/updater/internal/updater/updater.go
+++ b/updater/internal/updater/updater.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"text/template"
 	"time"
 
@@ -94,9 +95,9 @@ func (u *Updater) readGroupFromSystemdFile() (string, error) {
 	return "", errors.New("Group not found in systemd unit file")
 }
 
-// generateServiceFiles writes necessary service files to the install directory
+// generateLinuxServiceFiles writes necessary service files to the install directory
 // to be copied to their final locations by the updater.
-func (u *Updater) generateServiceFiles() error {
+func (u *Updater) generateLinuxServiceFiles() error {
 	systemdServiceFilePath := filepath.Join(u.installDir, "install", "observiq-otel-collector.service")
 	initServiceFilePath := filepath.Join(u.installDir, "install", "observiq-otel-collector")
 
@@ -153,8 +154,10 @@ func (u *Updater) generateServiceFiles() error {
 func (u *Updater) Update() error {
 	// Generate service files before stopping the service. If
 	// this fails, the collector will still be running.
-	if err := u.generateServiceFiles(); err != nil {
-		return fmt.Errorf("failed to generate service files: %w", err)
+	if runtime.GOOS == "linux" {
+		if err := u.generateLinuxServiceFiles(); err != nil {
+			return fmt.Errorf("failed to generate service files: %w", err)
+		}
 	}
 
 	// Stop the service before backing up the install directory;

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -393,15 +393,3 @@ func TestReadGroupFromSystemdFile(t *testing.T) {
 		require.Equal(t, "bdot", group)
 	})
 }
-
-func TestReadWorkingDirectoryFromSystemdFile(t *testing.T) {
-	t.Run("Extract WorkingDirectory from systemd unit file", func(t *testing.T) {
-		u := &Updater{
-			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
-		}
-
-		workingDirectory, err := u.readWorkingDirectoryFromSystemdFile()
-		require.NoError(t, err)
-		require.Equal(t, "/opt/observiq-otel-collector", workingDirectory)
-	})
-}

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -330,7 +330,7 @@ func TestUpdaterUpdate(t *testing.T) {
 	})
 }
 
-func TestGenerateServiceFiles(t *testing.T) {
+func TestGenerateLinuxServiceFiles(t *testing.T) {
 	// Windows does not use the files tested here, and has
 	// different newline characters that fail the test.
 	if runtime.GOOS == "windows" {
@@ -349,7 +349,7 @@ func TestGenerateServiceFiles(t *testing.T) {
 		// Cleanup the directory after test
 		defer os.RemoveAll(installDir)
 
-		err := u.generateServiceFiles()
+		err := u.generateLinuxServiceFiles()
 		require.NoError(t, err)
 
 		// Compare the generated files with golden files

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -393,3 +393,15 @@ func TestReadGroupFromSystemdFile(t *testing.T) {
 		require.Equal(t, "bdot", group)
 	})
 }
+
+func TestReadWorkingDirectoryFromSystemdFile(t *testing.T) {
+	t.Run("Extract WorkingDirectory from systemd unit file", func(t *testing.T) {
+		u := &Updater{
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
+		}
+
+		workingDirectory, err := u.readWorkingDirectoryFromSystemdFile()
+		require.NoError(t, err)
+		require.Equal(t, "/opt/observiq-otel-collector", workingDirectory)
+	})
+}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

We support a user configured install dir. See `scripts/package/postinstall.sh`. This is a follow up change to support the user configured directory when using the updater.

Updated the updater's systemd service file template to include a `.InstallDir` variable. The value used is extracted from the installed systemd service file. This follows the pattern established when detecting the runtime `group`. 

### Testing

Working great when the install dir is not configured.

I tested an install dir override by setting `BDOT_CONFIG_HOME=/opt/collector` and then building this branch with two tags:
```
observiq-otel-collector-v1.81.0-alpha.3
observiq-otel-collector-v1.81.0-alpha.4
```

The builds were identical, and allowed me to test upgrading with the new logic. We cannot upgrade from the latest release because it will fail to execute the updater binary, due to the `/opt/observiq-otel-collector` path being hardcoded in `updater/internal/path/`. This is okay because we will not support linux package customization for existing installs, only **new** installs.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
