### PR TITLE
feat: Run time configurable FeatureGates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ For more installation information, and how to configure OpAMP, see [installing o
 
 With the BDOT Collector installed, it will start collecting basic metrics about the host machine printing them to the log. To further configure your collector edit the `config.yaml` file just like you would an OpenTelemetry Collector. To find your `config.yaml` file based on your operating system, reference the table below:
 
-| OS      | Default Location                                              |
-|:--------|:--------------------------------------------------------------|
+| OS      | Default Location                                                |
+| :------ | :-------------------------------------------------------------- |
 | Linux   | `/opt/observiq-otel-collector/config.yaml`                      |
 | Windows | `C:\Program Files\observIQ OpenTelemetry Collector\config.yaml` |
 | macOS   | `/opt/observiq-otel-collector/config.yaml`                      |
@@ -197,7 +197,7 @@ receivers:
       processes:
 
 # Exporters send the data to a destination, in this case GCP.
-exporters: 
+exporters:
   googlecloud:
 
 # Service specifies how to construct the data pipelines using the configurations above.
@@ -207,6 +207,28 @@ service:
       receivers: [hostmetrics]
       exporters: [googlecloud]
 ```
+
+### Feature Gates
+
+Starting in v1.80.2 of the BDOT collector, OpenTelemetry feature gates can be configured at run time using a program argument or environment variable. To configure via a run time argument, you can do the following:
+
+```sh
+./observiq-otel-collector --config ./path/to/config.yaml --feature-gates otel.SomeFeature,-otel.OtherFeature
+```
+
+This would enable the `otel.SomeFeature` feature gate and disable the `otel.OtherFeature` feature gate.
+
+Use the environment variable `COLLECTOR_FEATURE_GATES` to achieve the same result. The following is an example:
+
+```env
+COLLECTOR_FEATURE_GATES=otel.SomeFeature,-otel.OtherFeature
+```
+
+By default the following feature gates are enabled in BDOT:
+
+- filelog.allowFileDeletion
+- filelog.allowHeaderMetadataParsing
+- filelog.mtimeSortType
 
 ## Connecting to Bindplane Telemetry Pipeline with OpAMP
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -84,7 +84,7 @@ func main() {
 	var runnableService service.RunnableService
 
 	// Set feature flags
-	if err := collector.SetFeatureFlags(*featureGates); err != nil {
+	if err := collector.SetFeatureFlags(*featureGates, logger); err != nil {
 		logger.Fatal("Failed to set feature flags.", zap.Error(err))
 	}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	_ "time/tzdata"
 
 	"github.com/google/uuid"
@@ -49,12 +50,14 @@ const (
 	configPathENV    = "CONFIG_YAML_PATH"
 	managerPathENV   = "MANAGER_YAML_PATH"
 	loggingPathENV   = "LOGGING_YAML_PATH"
+	featureGatesENV  = "COLLECTOR_FEATURE_GATES"
 )
 
 func main() {
 	collectorConfigPaths := pflag.StringSlice("config", getDefaultCollectorConfigPaths(), "the collector config path")
 	managerConfigPath := pflag.String("manager", getDefaultManagerConfigPath(), "The configuration for remote management")
 	loggingConfigPath := pflag.String("logging", getDefaultLoggingConfigPath(), "the collector logging config path")
+	featureGates := pflag.StringSlice("feature-gates", getDefaultFeatureGates(), "the collector feature gates")
 
 	_ = pflag.String("log-level", "", "not implemented") // TEMP(jsirianni): Required for OTEL k8s operator
 	var showVersion = pflag.BoolP("version", "v", false, "prints the version of the collector")
@@ -81,7 +84,7 @@ func main() {
 	var runnableService service.RunnableService
 
 	// Set feature flags
-	if err := collector.SetFeatureFlags(); err != nil {
+	if err := collector.SetFeatureFlags(*featureGates); err != nil {
 		logger.Fatal("Failed to set feature flags.", zap.Error(err))
 	}
 
@@ -145,6 +148,14 @@ func getDefaultLoggingConfigPath() string {
 		return lp
 	}
 	return logging.DefaultConfigPath
+}
+
+func getDefaultFeatureGates() []string {
+	fg, ok := os.LookupEnv(featureGatesENV)
+	if ok {
+		return strings.Split(fg, ",")
+	}
+	return []string{}
 }
 
 func logOptions(loggingConfigPath *string) ([]zap.Option, error) {

--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -16,12 +16,14 @@ package collector
 
 import (
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/collector/featuregate"
+	"go.uber.org/zap"
 )
 
 // SetFeatureFlags sets hardcoded collector feature flags
-func SetFeatureFlags(featureGates []string) error {
+func SetFeatureFlags(featureGates []string, logger *zap.Logger) error {
 	// set hardcoded feature flags first to allow for user overrides
 	if err := setHardcodedFeatureFlags(); err != nil {
 		return fmt.Errorf("failed to set hardcoded feature flags: %w", err)
@@ -30,6 +32,10 @@ func SetFeatureFlags(featureGates []string) error {
 	// set user feature flags
 	if err := setUserFeatureFlags(featureGates); err != nil {
 		return fmt.Errorf("failed to set user feature flags: %w", err)
+	}
+
+	if len(featureGates) > 0 {
+		logger.Info("Feature gates successfully set", zap.String("featureGates", strings.Join(featureGates, ",")))
 	}
 
 	return nil

--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -21,7 +21,22 @@ import (
 )
 
 // SetFeatureFlags sets hardcoded collector feature flags
-func SetFeatureFlags() error {
+func SetFeatureFlags(featureGates []string) error {
+	// set hardcoded feature flags first to allow for user overrides
+	if err := setHardcodedFeatureFlags(); err != nil {
+		return fmt.Errorf("failed to set hardcoded feature flags: %w", err)
+	}
+
+	// set user feature flags
+	if err := setUserFeatureFlags(featureGates); err != nil {
+		return fmt.Errorf("failed to set user feature flags: %w", err)
+	}
+
+	return nil
+}
+
+// setHardcodedFeatureFlags sets hardcoded feature flags
+func setHardcodedFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.allowFileDeletion", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.allowFileDeletion: %w", err)
 	}
@@ -32,5 +47,25 @@ func SetFeatureFlags() error {
 		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
 	}
 
+	return nil
+}
+
+// setUserFeatureFlags sets user feature flags
+// checks for - and + prefixes to indicate negation and enablement of the feature gate
+func setUserFeatureFlags(featureGates []string) error {
+	for _, fg := range featureGates {
+		val := true
+		switch fg[0] {
+		case '-':
+			fg = fg[1:]
+			val = false
+		case '+':
+			fg = fg[1:]
+		}
+
+		if err := featuregate.GlobalRegistry().Set(fg, val); err != nil {
+			return fmt.Errorf("failed to set feature gate %s: %w", fg, err)
+		}
+	}
 	return nil
 }

--- a/collector/featuregates_test.go
+++ b/collector/featuregates_test.go
@@ -19,27 +19,28 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/featuregate"
+	"go.uber.org/zap"
 )
 
 func TestSetFeatureFlags(t *testing.T) {
 	t.Run("no additional feature gates", func(t *testing.T) {
-		require.NoError(t, SetFeatureFlags([]string{}))
+		require.NoError(t, SetFeatureFlags([]string{}, zap.NewNop()))
 	})
 	t.Run("override hardcoded feature gates", func(t *testing.T) {
-		require.NoError(t, SetFeatureFlags([]string{"-filelog.allowFileDeletion"}))
+		require.NoError(t, SetFeatureFlags([]string{"-filelog.allowFileDeletion"}, zap.NewNop()))
 	})
 
 	t.Run("custom feature gates", func(t *testing.T) {
 		testFG, err := featuregate.GlobalRegistry().Register("test.feature", featuregate.StageAlpha)
 		require.NoError(t, err)
 
-		require.NoError(t, SetFeatureFlags([]string{"+test.feature"}))
+		require.NoError(t, SetFeatureFlags([]string{"+test.feature"}, zap.NewNop()))
 		require.True(t, testFG.IsEnabled())
 
-		require.NoError(t, SetFeatureFlags([]string{"-test.feature"}))
+		require.NoError(t, SetFeatureFlags([]string{"-test.feature"}, zap.NewNop()))
 		require.False(t, testFG.IsEnabled())
 
-		require.NoError(t, SetFeatureFlags([]string{"test.feature"}))
+		require.NoError(t, SetFeatureFlags([]string{"test.feature"}, zap.NewNop()))
 		require.True(t, testFG.IsEnabled())
 	})
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Enables run time configurable feature gates so that users can experiment with them without requiring us to provide a new release.

Can test pretty easily with the feature gate `receiver.kafkareceiver.UseFranzGo`. You can enable it no problem using the cli argument or env var, and if you try providing a bad feature gate you get an error from the collector.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
