### PR TITLE
chore(installscript): Support BDOT_CONFIG_HOME in install script

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-# Read's optional package overrides. Users should deploy the override
+# Reads optional package overrides. Users should deploy the override
 # file before installing BDOT for the first time. The override should
 # not be modified unless uninstalling and re-installing.
 [ -f /etc/default/observiq-otel-collector ] && . /etc/default/observiq-otel-collector


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Updated the Linux install script to source the package override files and use them to determine the collector home, defaulting to `/opt/observiq-otel-collector`. This allows us to use the script to install the agent when a config override is in place. Before it would fail because the collector home was hardcoded to /opt/observiq-otel-collector.

See the Linux package's postinstall script for context. https://github.com/observIQ/bindplane-otel-collector/blob/main/scripts/package/postinstall.sh#L19-L25

### Testing

Tested by building `/etc/default/observiq-otel-collector`:
```ini
BDOT_CONFIG_HOME=/opt/collector
```

And then running the script on a Linux system

```bash
sudo ./install_unix.sh \
  --file observiq-otel-collector_v1.80.1-SNAPSHOT-6899ef8a-SNAPSHOT-6899ef8a_linux_amd64.rpm
```

The script succeeded and the output looked like this:

```
===================================================
| Information
===================================================
  Agent Home:         /opt/collector
  Agent Config:       /opt/collector/config.yaml
  Start Command:      sudo systemctl start observiq-otel-collector
  Stop Command:       sudo systemctl stop observiq-otel-collector
  Status Command:     sudo systemctl status observiq-otel-collector
  Logs Command:       sudo tail -F /opt/collector/log/collector.log
```


##### Checklist
- [x] Changes are tested
- [x] CI has passed
