### PR TITLE
feat(release): Upload Linux packages to Google Artifact Registry

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -70,7 +70,7 @@ jobs:
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.deb
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_amd64.deb
 
       - name: Upload Bindplane Linux AMD64 RPM Package
         run: |
@@ -78,7 +78,7 @@ jobs:
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.rpm
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_amd64.rpm
 
       - name: Upload Bindplane Linux ARM64 Deb Package
         run: |
@@ -86,14 +86,14 @@ jobs:
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.deb
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_arm64.deb
       - name: Upload Bindplane Linux ARM64 RPM Package
         run: |
           gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.rpm
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_arm64.rpm
 
       - name: Upload Bindplane Linux ARM32 Deb Package
         run: |
@@ -101,7 +101,7 @@ jobs:
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.deb
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_arm.deb
 
       - name: Upload Bindplane Linux ARM32 RPM Package
         run: |
@@ -109,7 +109,7 @@ jobs:
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.rpm
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_arm.rpm
 
       - name: Upload Bindplane Linux PPC64LE Deb Package
         run: |
@@ -117,7 +117,7 @@ jobs:
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.deb
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_ppc64le.deb
 
       - name: Upload Bindplane Linux PPC64LE RPM Package
         run: |
@@ -125,7 +125,7 @@ jobs:
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.rpm
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_ppc64le.rpm
 
       - name: Upload Bindplane Linux PPC64 Deb Package
         run: |
@@ -133,7 +133,7 @@ jobs:
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.deb
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_ppc64.deb
 
       - name: Upload Bindplane Linux PPC64 RPM Package
         run: |
@@ -141,4 +141,4 @@ jobs:
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
-            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.rpm
+            --source dist/observiq-otel-collector_${{ env.VERSION }}_linux_ppc64.rpm

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: "v2.8.2"
-          args: release --skip=publish --skip=validate --skip=sign --clean --snapshot
+          args: release --skip=publish --skip=validate --skip=sign --clean
         env:
           GORELEASER_CURRENT_TAG: ${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -52,3 +52,93 @@ jobs:
           name: dist-artifacts
           path: dist/
           retention-days: 1
+
+      # Linux package uploads to Google Artifact Registry
+
+      # google-github-actions/auth@v2 was used above to install
+      # gcloud sdk. google-github-actions/auth was used as well
+      # but we need to re-authenticate to upload packages to the
+      # correct project.
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.ORG_BINDPLANE_PUBLIC_LINUX_REPO_JSON_KEY }}"
+
+      - name: Upload Bindplane Linux AMD64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload devel-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.deb
+
+      - name: Upload Bindplane Linux AMD64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload devel-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.rpm
+
+      - name: Upload Bindplane Linux ARM64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload devel-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.deb
+      - name: Upload Bindplane Linux ARM64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload devel-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.rpm
+
+      - name: Upload Bindplane Linux ARM32 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload devel-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.deb
+
+      - name: Upload Bindplane Linux ARM32 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload devel-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.rpm
+
+      - name: Upload Bindplane Linux PPC64LE Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload devel-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.deb
+
+      - name: Upload Bindplane Linux PPC64LE RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload devel-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.rpm
+
+      - name: Upload Bindplane Linux PPC64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload devel-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.deb
+
+      - name: Upload Bindplane Linux PPC64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload devel-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,3 +189,93 @@ jobs:
           repository: observIQ/otel-collector-installer-testing
           event-type: upstream_prerelease
           client-payload: '{ "version": "${{ github.ref_name }}" }'
+
+      # Linux package uploads to Google Artifact Registry
+
+      # google-github-actions/auth@v2 was used above to install
+      # gcloud sdk. google-github-actions/auth was used as well
+      # but we need to re-authenticate to upload packages to the
+      # correct project.
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.ORG_BINDPLANE_PUBLIC_LINUX_REPO_JSON_KEY }}"
+
+      - name: Upload Bindplane Linux AMD64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload stable-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.deb
+
+      - name: Upload Bindplane Linux AMD64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload stable-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_amd64.rpm
+
+      - name: Upload Bindplane Linux ARM64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload stable-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.deb
+      - name: Upload Bindplane Linux ARM64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload stable-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm64.rpm
+
+      - name: Upload Bindplane Linux ARM32 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload stable-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.deb
+
+      - name: Upload Bindplane Linux ARM32 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload stable-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_arm.rpm
+
+      - name: Upload Bindplane Linux PPC64LE Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload stable-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.deb
+
+      - name: Upload Bindplane Linux PPC64LE RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload stable-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64le.rpm
+
+      - name: Upload Bindplane Linux PPC64 Deb Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts apt upload stable-deb \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.deb
+
+      - name: Upload Bindplane Linux PPC64 RPM Package
+        run: |
+          gcloud \
+            --project bindplane-repository \
+            artifacts yum upload stable-rpm \
+            --location us-central1 \
+            --source dist/observiq-otel-collector_${{ github.ref_name }}_linux_ppc64.rpm


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Uploads Linux packages to our experimental Google Artifact Registry. The deb and rpm repositories are still being tested, and should be avoided by users. 

Once confirmed stable, the Linux repositories can be used by users to install and upgrade BDOT without needing to use an install script or download artifacts from Github or GCS. 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
