### PR TITLE
chore: namespace.so github runners

### DIFF
--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_linux:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: nscloud-ubuntu-22.04-amd64-8x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: nscloud-ubuntu-22.04-amd64-8x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_linux:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-22.04-amd64-8x16
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-8x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-22.04-amd64-8x16
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-8x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_linux:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-8x16
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-4x8
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-8x16
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-4x8
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_linux:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest-4-cores
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest-4-cores
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-test:
-    runs-on: nscloud-ubuntu-22.04-amd64-16x32
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-16x32
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: nscloud-ubuntu-22.04-amd64-16x32
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-test:
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-16x32
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-32x64
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
   release:
     needs: [build-64bit-msi]
-    runs-on: nscloud-ubuntu-22.04-amd64-16x32
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-16x32
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
   release:
     needs: [build-64bit-msi]
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-16x32
+    runs-on: nscloud-ubuntu-24.04-systemd-amd64-32x64
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
   release:
     needs: [build-64bit-msi]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: nscloud-ubuntu-22.04-amd64-16x32
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest-4-cores, macos-13, windows-2022-8-cores]
+        os: [nscloud-ubuntu-22.04-amd64-4x16, macos-13, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources
@@ -23,8 +23,8 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)
-        if: matrix.os != 'ubuntu-latest-4-cores'
+        if: matrix.os != 'nscloud-ubuntu-22.04-amd64-4x16'
         run: make test-updater-integration
       - name: Run Updater Integration Tests (linux)
-        if: matrix.os == 'ubuntu-latest-4-cores'
+        if: matrix.os == 'nscloud-ubuntu-22.04-amd64-4x16'
         run: sudo make test-updater-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [nscloud-ubuntu-24.04-systemd-amd64-8x16, macos-13, windows-2022-8-cores]
+        os: [nscloud-ubuntu-24.04-systemd-amd64-4x8, macos-13, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources
@@ -23,8 +23,8 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)
-        if: matrix.os != 'nscloud-ubuntu-24.04-systemd-amd64-8x16'
+        if: matrix.os != 'nscloud-ubuntu-24.04-systemd-amd64-4x8'
         run: make test-updater-integration
       - name: Run Updater Integration Tests (linux)
-        if: matrix.os == 'nscloud-ubuntu-24.04-systemd-amd64-8x16'
+        if: matrix.os == 'nscloud-ubuntu-24.04-systemd-amd64-4x8'
         run: sudo make test-updater-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [nscloud-ubuntu-22.04-amd64-8x16, macos-13, windows-2022-8-cores]
+        os: [nscloud-ubuntu-24.04-systemd-amd64-8x16, macos-13, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources
@@ -23,8 +23,8 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)
-        if: matrix.os != 'nscloud-ubuntu-22.04-amd64-8x16'
+        if: matrix.os != 'nscloud-ubuntu-24.04-systemd-amd64-8x16'
         run: make test-updater-integration
       - name: Run Updater Integration Tests (linux)
-        if: matrix.os == 'nscloud-ubuntu-22.04-amd64-8x16'
+        if: matrix.os == 'nscloud-ubuntu-24.04-systemd-amd64-8x16'
         run: sudo make test-updater-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [nscloud-ubuntu-22.04-amd64-4x16, macos-13, windows-2022-8-cores]
+        os: [nscloud-ubuntu-22.04-amd64-8x16, macos-13, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources
@@ -23,8 +23,8 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)
-        if: matrix.os != 'nscloud-ubuntu-22.04-amd64-4x16'
+        if: matrix.os != 'nscloud-ubuntu-22.04-amd64-8x16'
         run: make test-updater-integration
       - name: Run Updater Integration Tests (linux)
-        if: matrix.os == 'nscloud-ubuntu-22.04-amd64-4x16'
+        if: matrix.os == 'nscloud-ubuntu-22.04-amd64-8x16'
         run: sudo make test-updater-integration


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Replaced Github large runners with namespace.so runners. I expect the release workflow to finish significantly faster. We can evaluate their macos and windows runners in the future.

The required test "unit-tests (ubuntu-latest-4-cores" will be replaced by "unit-tests (nscloud-ubuntu-24.04-systemd-amd64-4x8".



##### Checklist
- [x] Changes are tested
- [x] CI has passed
