### PR TITLE
fix(linuxpackage): Fail if BDOT_SKIP_RUNTIME_USER_CREATION is set and user missing

### DIFF
--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -32,7 +32,12 @@ service_name="observiq-otel-collector"
 # multiple times.
 install() {
     if [ "$BDOT_SKIP_RUNTIME_USER_CREATION" = "true" ]; then
-        echo "BDOT_SKIP_RUNTIME_USER_CREATION is set to true, skipping user and group creation"
+        echo "BDOT_SKIP_RUNTIME_USER_CREATION is set to true, checking if ${username} user exists"
+        if ! id "$username" > /dev/null 2>&1; then
+            echo "ERROR: BDOT_SKIP_RUNTIME_USER_CREATION is true but user ${username} does not exist"
+            exit 1
+        fi
+        echo "User ${username} exists, skipping user and group creation"
     else
         echo "Creating ${username} user and group"
         install_user


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When testing `BDOT_SKIP_RUNTIME_USER_CREATION`, I found that the install would proceed even if the username was not created ahead of time. This causes failures later in the install process. Its better to fail fast with a clear error.

### Testing

Now the failure is right away, and clear to the user.

```
BDOT_SKIP_RUNTIME_USER_CREATION is set to true, checking if bdot user exists
ERROR: BDOT_SKIP_RUNTIME_USER_CREATION is true but user bdot does not exist
dpkg: error processing archive /home/jsirianni/observiq-otel-collector_v1.81.0-alpha.1_linux_amd64.deb (--unpack):
```

The failure is similar on RHEL.

If I run the install script instead of installing the package directly (script with `--file` flag), the failure occurs in the script:

<img width="1142" height="577" alt="Screenshot From 2025-07-31 12-20-46" src="https://github.com/user-attachments/assets/ead23ff2-b3ac-442f-98fd-93b1f4e5e86d" />

##### Checklist
- [x] Changes are tested
- [x] CI has passed
