### PR TITLE
Epic/linux package configuration options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -276,40 +276,40 @@ nfpms:
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/config.yaml
         file_info:
           mode: 0640
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
         type: config|noreplace
       - src: release_deps/logging.yaml
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/logging.yaml
         file_info:
           mode: 0640
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
         type: config|noreplace
       - src: LICENSE
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - src: release_deps/VERSION.txt
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/VERSION.txt
         file_info:
           mode: 0644
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
         file_info:
           mode: 0755
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/plugins
         type: dir
         file_info:
           mode: 0750 # restrict plugins to owner / group only
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       # Note: plugins owner/group/mode is set in the post-install script
       # Attempting to set the permissions here results in the following error:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
@@ -321,14 +321,14 @@ nfpms:
         type: dir
         file_info:
           mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
       - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/log
         type: dir
         file_info:
           mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
+          owner: bdot
+          group: bdot
     scripts:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -27,7 +27,7 @@ elif command -v service > /dev/null 2>&1; then
 fi
 
 # Script Constants
-COLLECTOR_USER="observiq-otel-collector"
+COLLECTOR_USER="bdot"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 MANAGEMENT_YML_PATH="/opt/observiq-otel-collector/manager.yaml"
 PREREQS="curl printf $SVC_PRE sed uname cut"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -15,6 +15,15 @@
 
 set -e
 
+# Reads optional package overrides. Users should deploy the override
+# file before installing BDOT for the first time. The override should
+# not be modified unless uninstalling and re-installing.
+[ -f /etc/default/observiq-otel-collector ] && . /etc/default/observiq-otel-collector
+[ -f /etc/sysconfig/observiq-otel-collector ] && . /etc/sysconfig/observiq-otel-collector
+
+# The collectors installation directory
+: "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
+
 # Agent Constants
 PACKAGE_NAME="observiq-otel-collector"
 DOWNLOAD_BASE="https://github.com/observIQ/bindplane-otel-collector/releases/download"
@@ -29,7 +38,7 @@ fi
 # Script Constants
 COLLECTOR_USER="bdot"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
-MANAGEMENT_YML_PATH="/opt/observiq-otel-collector/manager.yaml"
+MANAGEMENT_YML_PATH="${BDOT_CONFIG_HOME}/manager.yaml"
 PREREQS="curl printf $SVC_PRE sed uname cut"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
@@ -665,7 +674,7 @@ install_package()
   info "Installing package..."
   # if target install directory doesn't exist and we're using dpkg ensure a clean state 
   # by checking for the package and running purge if it exists.
-  if [ ! -d "/opt/observiq-otel-collector" ] && [ "$package_type" = "deb" ]; then
+  if [ ! -d "${BDOT_CONFIG_HOME}" ] && [ "$package_type" = "deb" ]; then
     dpkg -s "observiq-otel-collector" > /dev/null 2>&1 && dpkg --purge "observiq-otel-collector" > /dev/null 2>&1
   fi
 
@@ -756,8 +765,8 @@ display_results()
 {
     banner 'Information'
     increase_indent
-    info "Agent Home:         $(fg_cyan "/opt/observiq-otel-collector")$(reset)"
-    info "Agent Config:       $(fg_cyan "/opt/observiq-otel-collector/config.yaml")$(reset)"
+    info "Agent Home:         $(fg_cyan "${BDOT_CONFIG_HOME}")$(reset)"
+    info "Agent Config:       $(fg_cyan "${BDOT_CONFIG_HOME}/config.yaml")$(reset)"
     if [ "$SVC_PRE" = "systemctl" ]; then
       info "Start Command:      $(fg_cyan "sudo systemctl start observiq-otel-collector")$(reset)"
       info "Stop Command:       $(fg_cyan "sudo systemctl stop observiq-otel-collector")$(reset)"
@@ -767,7 +776,7 @@ display_results()
       info "Stop Command:       $(fg_cyan "sudo service observiq-otel-collector stop")$(reset)"
       info "Status Command:     $(fg_cyan "sudo service observiq-otel-collector status")$(reset)"
     fi
-    info "Logs Command:       $(fg_cyan "sudo tail -F /opt/observiq-otel-collector/log/collector.log")$(reset)"
+    info "Logs Command:       $(fg_cyan "sudo tail -F ${BDOT_CONFIG_HOME}/log/collector.log")$(reset)"
     info "Uninstall Command:  $(fg_cyan "sudo sh -c \"\$(curl -fsSlL https://github.com/observIQ/bindplane-otel-collector/releases/latest/download/install_unix.sh)\" install_unix.sh -r")$(reset)"
     decrease_indent
 

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -24,10 +24,12 @@ set -e
 
 : "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
 
+username="bdot"
+
 install() {
     mkdir -p "${BDOT_CONFIG_HOME}"
     chmod 0755 "${BDOT_CONFIG_HOME}"
-    chown observiq-otel-collector:observiq-otel-collector "${BDOT_CONFIG_HOME}"
+    chown "$username:$username" "${BDOT_CONFIG_HOME}"
     rm -f "${BDOT_CONFIG_HOME}/observiq-otel-collector" || true
     cp -r --preserve \
       /usr/share/observiq-otel-collector/stage/observiq-otel-collector/* \
@@ -64,7 +66,7 @@ StartLimitBurst=5
 [Service]
 Type=simple
 User=root
-Group=observiq-otel-collector
+Group=${username}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
@@ -432,7 +434,7 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to observiq-otel-collector
-  chown -R observiq-otel-collector:observiq-otel-collector ${BDOT_CONFIG_HOME}/observiq-otel-collector ${BDOT_CONFIG_HOME}/plugins/*
+  chown -R "$username:$username" ${BDOT_CONFIG_HOME}/observiq-otel-collector ${BDOT_CONFIG_HOME}/plugins/*
   chmod 0640 ${BDOT_CONFIG_HOME}/plugins/*
 
   # Initialize the log file to ensure it is owned by observiq-otel-collector.
@@ -440,7 +442,7 @@ finish_permissions() {
   # the root user. By doing so, we allow the user to switch to observiq-otel-collector
   # user for 'non root' installs.
   touch ${BDOT_CONFIG_HOME}/log/collector.log
-  chown observiq-otel-collector:observiq-otel-collector ${BDOT_CONFIG_HOME}/log/collector.log
+  chown "$username:$username" ${BDOT_CONFIG_HOME}/log/collector.log
 }
 
 install

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -16,18 +16,73 @@
 
 set -e
 
-username="observiq-otel-collector"
+username="bdot"
+legacy_username="observiq-otel-collector"
 
-if getent group "$username" > /dev/null 2>&1; then
-    echo "Group ${username} already exists."
-else
-    groupadd "$username"
-fi
+# Install creates the user and group for the collector
+# service. This function is idempotent and safe to call
+# multiple times.
+install() {
+    # Return early without output if the user and group already exist.
+    # This will help avoid confusion with the output in migrate_user().
+    if id "$username" > /dev/null 2>&1 && getent group "$username" > /dev/null 2>&1; then
+        return
+    fi
 
-if id "$username" > /dev/null 2>&1; then
-    echo "User ${username} already exists"
-    exit 0
-else
-    useradd --shell /sbin/nologin --system "$username" -g "$username"
-fi
+    if getent group "$username" > /dev/null 2>&1; then
+        echo "Group ${username} already exists."
+    else
+        groupadd "$username"
+    fi
 
+    if id "$username" > /dev/null 2>&1; then
+        echo "User ${username} already exists"
+        exit 0
+    else
+        useradd --shell /sbin/nologin --system "$username" -g "$username"
+    fi
+}
+
+# migrate_user migrates the legacy user to the new username.
+migrate_user() {
+    _migrate_user
+    _migrate_group
+
+    echo "User migration complete."
+}
+
+_migrate_user() {
+    if ! id "$legacy_username" > /dev/null 2>&1; then
+        echo "Skipping user migration: Legacy user ${legacy_username} does not exist."
+        return
+    fi
+
+    if id "$username" > /dev/null 2>&1; then
+        echo "Skipping user migration: User ${username} already exists."
+        return
+    fi
+
+    echo "Renaming user ${legacy_username} to ${username}"
+    usermod -l "$username" "$legacy_username"
+}
+
+_migrate_group() {
+    if ! getent group "$legacy_username" > /dev/null 2>&1; then
+        echo "Skipping group migration: Legacy group ${legacy_username} does not exist."
+        return
+    fi
+
+    if getent group "$username" > /dev/null 2>&1; then
+        echo "Skipping group migration: Group ${username} already exists."
+        return
+    fi
+
+    echo "Renaming group ${legacy_username} to ${username}"
+
+    # TODO(jsirianni /  Dylan-M): Groupmod will not work on AIX
+    # Discussion: https://github.com/observIQ/bindplane-otel-collector/pull/2436
+    groupmod -n "$username" "$legacy_username"
+}
+
+migrate_user
+install

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -32,7 +32,12 @@ service_name="observiq-otel-collector"
 # multiple times.
 install() {
     if [ "$BDOT_SKIP_RUNTIME_USER_CREATION" = "true" ]; then
-        echo "BDOT_SKIP_RUNTIME_USER_CREATION is set to true, skipping user and group creation"
+        echo "BDOT_SKIP_RUNTIME_USER_CREATION is set to true, checking if ${username} user exists"
+        if ! id "$username" > /dev/null 2>&1; then
+            echo "ERROR: BDOT_SKIP_RUNTIME_USER_CREATION is true but user ${username} does not exist"
+            exit 1
+        fi
+        echo "User ${username} exists, skipping user and group creation"
     else
         echo "Creating ${username} user and group"
         install_user

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -25,6 +25,7 @@ set -e
 
 username="bdot"
 legacy_username="observiq-otel-collector"
+service_name="observiq-otel-collector"
 
 # Install creates the user and group for the collector
 # service. This function is idempotent and safe to call
@@ -78,8 +79,35 @@ _migrate_user() {
         return
     fi
 
+    # Initialize service_requires_restart to false
+    service_requires_restart=false
+
+    # Check if the service is running
+    if systemctl is-active --quiet "$service_name"; then
+        echo "Service $service_name is running"
+
+        # Check if the service is running as the legacy user
+        service_user=$(ps -o user= -p "$(systemctl show -p MainPID --value "$service_name")" 2>/dev/null || echo "")
+        echo "Service is running as user: $service_user"
+        if [ "$service_user" = "$legacy_username" ]; then
+            echo "Service is running as user ${legacy_username}, stopping service before user migration"
+            systemctl stop "$service_name"
+            service_requires_restart=true
+        else
+            echo "Service is running but not as user ${legacy_username}, proceeding with user migration"
+        fi
+    else
+        echo "Service $service_name is not running"
+    fi
+
     echo "Renaming user ${legacy_username} to ${username}"
     usermod -l "$username" "$legacy_username"
+
+    # Restart the service if it was running before
+    if [ "$service_requires_restart" = "true" ]; then
+        echo "Restarting service $service_name"
+        systemctl start "$service_name"
+    fi
 }
 
 _migrate_group() {

--- a/updater/cmd/updater/main.go
+++ b/updater/cmd/updater/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	// We can't create the zap logger yet, because we don't know the install dir, which is needed
 	// to create the logger. So we pass a Nop logger here.
-	installDir, err := path.InstallDir(zap.NewNop())
+	installDir, err := path.InstallDir(zap.NewNop(), path.DefaultConfigOverrides)
 	if err != nil {
 		// Can't use "fail" here since we don't know the install directory
 		log.Fatalf("Failed to determine install directory: %s", err)

--- a/updater/internal/path/path_darwin.go
+++ b/updater/internal/path/path_darwin.go
@@ -19,7 +19,11 @@ import "go.uber.org/zap"
 // DarwinInstallDir is the path to the install directory on Darwin.
 const DarwinInstallDir = "/opt/observiq-otel-collector"
 
+// DefaultConfigOverrides is not used on Darwin, but is required
+// by InstallDir.
+var DefaultConfigOverrides = []string{}
+
 // InstallDir returns the filepath to the install directory
-func InstallDir(_ *zap.Logger) (string, error) {
+func InstallDir(_ *zap.Logger, _ []string) (string, error) {
 	return DarwinInstallDir, nil
 }

--- a/updater/internal/path/path_linux.go
+++ b/updater/internal/path/path_linux.go
@@ -15,14 +15,18 @@
 package path
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
-// LinuxInstallDir is the install directory of the collector on linux.
-const LinuxInstallDir = "/opt/observiq-otel-collector"
+// DefaultLinuxInstallDir is the install directory of the collector on linux.
+const DefaultLinuxInstallDir = "/opt/observiq-otel-collector"
 
 // SystemdFilePath is the path for systemd service
 const SystemdFilePath = "/usr/lib/systemd/system/observiq-otel-collector.service"
@@ -30,9 +34,93 @@ const SystemdFilePath = "/usr/lib/systemd/system/observiq-otel-collector.service
 // SysVFilePath is the path for sysv service
 const SysVFilePath = "/etc/init.d/observiq-otel-collector"
 
+// DefaultConfigOverrides is a list of config files that can be used to override
+// package installation behavior. The updater needs to respect these config
+// options, such as BDOT_CONFIG_HOME
+var DefaultConfigOverrides = []string{
+	"/etc/default/observiq-otel-collector",
+	"/etc/sysconfig/observiq-otel-collector",
+}
+
+const (
+	configHomeOverrideKey = "BDOT_CONFIG_HOME"
+)
+
 // InstallDir returns the filepath to the install directory
-func InstallDir(_ *zap.Logger) (string, error) {
-	return LinuxInstallDir, nil
+func InstallDir(logger *zap.Logger, configOverrides []string) (string, error) {
+	// Check for a custom install directory
+	for _, config := range configOverrides {
+		installDir, err := customInstallDir(logger, config)
+		if err != nil {
+			return "", fmt.Errorf("error checking config file %q: %w", config, err)
+		}
+		if installDir != "" {
+			return installDir, nil
+		}
+	}
+
+	return DefaultLinuxInstallDir, nil
+}
+
+// customInstallDir checks the provided config file for a custom install directory.
+// Returns an error if there is an unexpected issue reading the file. Does not
+// return an error if the file does not exist.
+// If a custom install dir is not found in the config file, it returns an empty string.
+func customInstallDir(logger *zap.Logger, config string) (string, error) {
+	_, err := os.Stat(config)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read package override file %s: %w", config, err)
+	}
+
+	// Buffer is larger enough to read the entire
+	// user defined config override file.
+	buff := make([]byte, 4000)
+
+	// #nosec G304 -- config is a file path from const DefaultConfigOverrides
+	// Test cases will override configOverrides to test this code path.
+	file, err := os.Open(config)
+	if err != nil {
+		return "", fmt.Errorf("open package override file %s: %w", config, err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.Error("close package override file", zap.String("file", config), zap.Error(err))
+		}
+	}()
+
+	_, err = file.Read(buff)
+	if err != nil {
+		return "", fmt.Errorf("read package override file %s: %w", config, err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(buff)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skip empty lines or comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, configHomeOverrideKey+"=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				value := strings.TrimSpace(parts[1])
+				if value != "" {
+					return value, nil
+				}
+				// If the value is empty, continue to the next line
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning config file %s: %w", config, err)
+	}
+
+	return "", nil
 }
 
 // LinuxServiceCmdName returns the filename of the service command available

--- a/updater/internal/path/path_linux_test.go
+++ b/updater/internal/path/path_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestInstallDir(t *testing.T) {
+	tests := []struct {
+		name            string
+		configOverrides []string
+		expectedDir     string
+		errorContains   string
+	}{
+		{
+			name:            "default install dir when no config files exist",
+			configOverrides: []string{"nonexistent1.conf", "nonexistent2.conf"},
+			expectedDir:     "/opt/observiq-otel-collector",
+		},
+		{
+			name:            "custom install dir",
+			configOverrides: []string{"testdata/custom_install_dir.ini"},
+			expectedDir:     "/opt/custom",
+		},
+		{
+			name:            "multi config - one missing",
+			configOverrides: []string{"nonexist.ini", "testdata/custom_install_dir.ini"},
+			expectedDir:     "/opt/custom",
+		},
+		{
+			name:            "multi config - two missing",
+			configOverrides: []string{"testdata/custom_install_dir.ini", "nonexist.ini"},
+			expectedDir:     "/opt/custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := InstallDir(zap.NewNop(), tt.configOverrides)
+
+			if tt.errorContains != "" {
+				require.Error(t, err, "InstallDir should return an error")
+				require.ErrorAs(t, err, &tt.errorContains, "InstallDir should return the expected error")
+				return
+			}
+
+			require.NoError(t, err, "InstallDir should not return an error")
+			require.Equal(t, tt.expectedDir, result, "InstallDir returned unexpected directory")
+
+		})
+	}
+}

--- a/updater/internal/path/path_windows.go
+++ b/updater/internal/path/path_windows.go
@@ -23,6 +23,10 @@ import (
 
 const defaultProductName = "observIQ Distro for OpenTelemetry Collector"
 
+// DefaultConfigOverrides is not used on Windows, but is required
+// by InstallDir.
+var DefaultConfigOverrides = []string{}
+
 // installDirFromRegistry gets the installation dir of the given product from the Windows Registry
 func installDirFromRegistry(logger *zap.Logger, productName string) (string, error) {
 	// this key is created when installing using the MSI installer
@@ -48,6 +52,6 @@ func installDirFromRegistry(logger *zap.Logger, productName string) (string, err
 }
 
 // InstallDir returns the filepath to the install directory
-func InstallDir(logger *zap.Logger) (string, error) {
+func InstallDir(logger *zap.Logger, _ []string) (string, error) {
 	return installDirFromRegistry(logger, defaultProductName)
 }

--- a/updater/internal/path/testdata/custom_install_dir.ini
+++ b/updater/internal/path/testdata/custom_install_dir.ini
@@ -1,0 +1,1 @@
+BDOT_CONFIG_HOME=/opt/custom

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -26,10 +26,10 @@ Type=simple
 User=root
 Group={{.Group}}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
-WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+Environment=OIQ_OTEL_COLLECTOR_HOME={{.InstallDir}}
+Environment=OIQ_OTEL_COLLECTOR_STORAGE={{.InstallDir}}/storage
+WorkingDirectory={{.InstallDir}}
+ExecStart={{.InstallDir}}/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000
 SuccessExitStatus=0
 TimeoutSec=20

--- a/updater/internal/updater/testdata/observiq-otel-collector.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.golden
@@ -1,46 +1,4 @@
-// Copyright observIQ, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Package updater provides templates for service files.
-package updater
-
-// Constants for service file templates
-const systemdServiceTemplate = `[Unit]
-Description=observIQ's distribution of the OpenTelemetry collector
-After=network.target
-StartLimitIntervalSec=120
-StartLimitBurst=5
-[Service]
-Type=simple
-User=root
-Group={{.Group}}
-Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
-WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
-LimitNOFILE=65000
-SuccessExitStatus=0
-TimeoutSec=20
-StandardOutput=journal
-Restart=on-failure
-RestartSec=5s
-KillMode=process
-[Install]
-WantedBy=multi-user.target`
-
-const initScriptTemplate = `#!/bin/sh
+#!/bin/sh
 # observIQ OTEL daemon
 # chkconfig: 2345 99 05
 # description: observIQ's distribution of the OpenTelemetry collector
@@ -293,4 +251,4 @@ if [ "$RCSTATUS" ]; then
   rc_exit
 fi
 
-exit "$RETVAL"`
+exit "$RETVAL" 

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -1,0 +1,23 @@
+[Unit]
+Description=observIQ's distribution of the OpenTelemetry collector
+After=network.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
+[Service]
+Type=simple
+User=root
+Group=bdot
+Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+WorkingDirectory=/opt/observiq-otel-collector
+ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+LimitNOFILE=65000
+SuccessExitStatus=0
+TimeoutSec=20
+StandardOutput=journal
+Restart=on-failure
+RestartSec=5s
+KillMode=process
+[Install]
+WantedBy=multi-user.target 

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -330,7 +330,7 @@ func TestUpdaterUpdate(t *testing.T) {
 	})
 }
 
-func TestGenerateServiceFiles(t *testing.T) {
+func TestGenerateLinuxServiceFiles(t *testing.T) {
 	// Windows does not use the files tested here, and has
 	// different newline characters that fail the test.
 	if runtime.GOOS == "windows" {
@@ -349,7 +349,7 @@ func TestGenerateServiceFiles(t *testing.T) {
 		// Cleanup the directory after test
 		defer os.RemoveAll(installDir)
 
-		err := u.generateServiceFiles()
+		err := u.generateLinuxServiceFiles()
 		require.NoError(t, err)
 
 		// Compare the generated files with golden files

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -15,7 +15,12 @@
 package updater
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/observiq/bindplane-otel-collector/packagestate"
@@ -44,7 +49,7 @@ func TestNewUpdater(t *testing.T) {
 		assert.NotNil(t, updater.rollbacker)
 		assert.NotNil(t, updater.monitor)
 		assert.NotNil(t, updater.logger)
-		assert.Equal(t, installDir, updater.installDir)
+		require.Equal(t, installDir, updater.installDir)
 	})
 
 	t.Run("New updater fails due to missing package statuses", func(t *testing.T) {
@@ -66,12 +71,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(nil)
@@ -93,12 +99,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(errors.New("insufficient permissions"))
@@ -116,12 +123,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -145,12 +153,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -174,12 +183,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -204,12 +214,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -234,12 +245,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -265,12 +277,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		err := errors.New("insufficient permissions")
@@ -296,12 +309,13 @@ func TestUpdaterUpdate(t *testing.T) {
 		monitor := state_mocks.NewMockMonitor(t)
 
 		updater := &Updater{
-			installDir: installDir,
-			installer:  installer,
-			svc:        svc,
-			rollbacker: rollbacker,
-			monitor:    monitor,
-			logger:     zaptest.NewLogger(t),
+			installDir:               installDir,
+			installer:                installer,
+			svc:                      svc,
+			rollbacker:               rollbacker,
+			monitor:                  monitor,
+			logger:                   zaptest.NewLogger(t),
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
 		}
 
 		svc.On("Stop").Times(1).Return(nil)
@@ -313,5 +327,69 @@ func TestUpdaterUpdate(t *testing.T) {
 
 		err := updater.Update()
 		require.ErrorContains(t, err, "failed while monitoring for success")
+	})
+}
+
+func TestGenerateServiceFiles(t *testing.T) {
+	// Windows does not use the files tested here, and has
+	// different newline characters that fail the test.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows as it is not applicable")
+		return
+	}
+	t.Run("Generate service files successfully", func(t *testing.T) {
+		installDir := t.TempDir()
+		logger := zaptest.NewLogger(t)
+		u := &Updater{
+			installDir:               installDir,
+			logger:                   logger,
+			installedSystemdUnitPath: filepath.Join("testdata", "observiq-otel-collector.service.golden"),
+		}
+
+		// Cleanup the directory after test
+		defer os.RemoveAll(installDir)
+
+		err := u.generateServiceFiles()
+		require.NoError(t, err)
+
+		// Compare the generated files with golden files
+		compareFiles(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), u.installedSystemdUnitPath)
+
+		// Check file permissions
+		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), 0640)
+		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector"), 0755)
+	})
+}
+
+func compareFiles(t *testing.T, generatedFile, goldenFile string) {
+	generated, err := os.ReadFile(generatedFile)
+	require.NoError(t, err, fmt.Sprintf("file: %s", generatedFile))
+
+	golden, err := os.ReadFile(goldenFile)
+	require.NoError(t, err, fmt.Sprintf("file: %s", goldenFile))
+
+	// Trim the contents to ignore trailing newlines or spaces
+	generated = bytes.TrimSpace(generated)
+	golden = bytes.TrimSpace(golden)
+
+	require.Equal(t, string(golden), string(generated))
+}
+
+func checkFilePermissions(t *testing.T, filePath string, expectedPerm os.FileMode) {
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedPerm, info.Mode().Perm())
+}
+
+func TestReadGroupFromSystemdFile(t *testing.T) {
+	t.Run("Extract Group from systemd unit file", func(t *testing.T) {
+		u := &Updater{
+			installedSystemdUnitPath: "testdata/observiq-otel-collector.service.golden",
+		}
+
+		group, err := u.readGroupFromSystemdFile()
+		require.NoError(t, err)
+		require.Equal(t, "bdot", group)
 	})
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR merges the following approved changes into main.
- Migrate `observiq-otel-collector` user to `bdot` (Linux)
- Support running as non root user by default (Linux)
- Support skipping Linux user creation
- Support configurable install directory

All changes have been previously approved in their respective PRs.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
