### PR TITLE
chore(v2): Remove linux-arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,12 +27,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
       - ppc64
       - ppc64le
     ignore:
-      - goos: windows
-        goarch: arm
       - goos: windows
         goarch: arm64
       - goos: windows
@@ -55,12 +52,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
       - ppc64
       - ppc64le
     ignore:
-      - goos: windows
-        goarch: arm
       - goos: windows
         goarch: arm64
       - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ reset: kill
 build-all: build-linux build-darwin build-windows
 
 .PHONY: build-linux
-build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-ppc64 build-linux-ppc64le
+build-linux: build-linux-amd64 build-linux-arm64 build-linux-ppc64 build-linux-ppc64le
 
 .PHONY: build-darwin
 build-darwin: build-darwin-amd64 build-darwin-arm64

--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -33,7 +33,7 @@ curl -fL -o "$DOWNLOAD_DIR/opentelemetry-java-contrib-jmx-metrics.jar" \
 # download contrib repo and manually build supervisor repos
 echo "Cloning supervisor repo"
 SUPERVISOR_REPO="https://github.com/open-telemetry/opentelemetry-collector-contrib.git"
-PLATFORMS=("linux/amd64" "linux/arm64" "linux/arm" "linux/ppc64" "linux/ppc64le" "darwin/amd64" "darwin/arm64" "windows/amd64")
+PLATFORMS=("linux/amd64" "linux/arm64" "linux/ppc64" "linux/ppc64le" "darwin/amd64" "darwin/arm64" "windows/amd64")
 
 mkdir "$DOWNLOAD_DIR/supervisor_bin"
 mkdir "$DOWNLOAD_DIR/opentelemetry-collector-contrib"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Removes linux-arm builds from the v2 release. The last release partially failed at the end because we upload a tarball containing all of the release artifacts to Github and it was over 2GB, Github's limit. Removing this binary should be enough to get us under the limit. I just ran a test release [here](https://github.com/observIQ/bindplane-otel-collector/actions/runs/16725721789) and the size of the resulting tarball is 1.7GB. 

I don't believe anyone will be using v2 on linux-arm and if they do we can figure it out when the time comes.



##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
