### PR TITLE
feat(linuxpackage): Support configurable username and group

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -276,28 +276,28 @@ nfpms:
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/config.yaml
         file_info:
           mode: 0640
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
         type: config|noreplace
       - src: release_deps/logging.yaml
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/logging.yaml
         file_info:
           mode: 0640
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
         type: config|noreplace
       - src: LICENSE
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
       - src: release_deps/VERSION.txt
         dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/VERSION.txt
         file_info:
           mode: 0644
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
         file_info:
@@ -308,8 +308,8 @@ nfpms:
         type: dir
         file_info:
           mode: 0750 # restrict plugins to owner / group only
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
       # Note: plugins owner/group/mode is set in the post-install script
       # Attempting to set the permissions here results in the following error:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
@@ -321,14 +321,14 @@ nfpms:
         type: dir
         file_info:
           mode: 0750
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
       - dst: /usr/share/observiq-otel-collector/stage/observiq-otel-collector/log
         type: dir
         file_info:
           mode: 0750
-          owner: bdot
-          group: bdot
+          owner: root
+          group: root
     scripts:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -24,6 +24,10 @@ set -e
 # The collectors installation directory
 : "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
 
+# Allow configurable runtime user/group (used for permissions and manager.yaml)
+: "${BDOT_USER:=bdot}"
+: "${BDOT_GROUP:=bdot}"
+
 # Agent Constants
 PACKAGE_NAME="observiq-otel-collector"
 DOWNLOAD_BASE="https://bdot.bindplane.com"
@@ -36,7 +40,8 @@ elif command -v service > /dev/null 2>&1; then
 fi
 
 # Script Constants
-COLLECTOR_USER="bdot"
+COLLECTOR_USER="${BDOT_USER}"
+COLLECTOR_GROUP="${BDOT_GROUP}"
 COLLECTOR_USER_LEGACY="observiq-otel-collector"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 MANAGEMENT_YML_PATH="${BDOT_CONFIG_HOME}/manager.yaml"
@@ -795,7 +800,7 @@ create_manager_yml()
     # file is readable by anyone other than the agent & root
     command printf '' >> "$manager_yml_path"
 
-    chgrp "$COLLECTOR_USER" "$manager_yml_path"
+    chgrp "$COLLECTOR_GROUP" "$manager_yml_path"
     chown "$COLLECTOR_USER" "$manager_yml_path"
     chmod 0640 "$manager_yml_path"
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Updated Linux package scripts and install script to support user defined username and group.

- BDOT_USER: Defaults to `bdot`
- BDOT_GROUP: Defaults to `bdot`

 These options are intended to be used during first install. We do not support modifying these options after initial install.

The updater did not require changes as it already dynamically sets the Systemd group based on the group configured in the install unit file. It does not set the user, nor does it need to. We use a systemd override when running as non root, the updater does not touch this override file.

### Testing

#### Defaults

Local install and Test Kitchen are passing fine. All files that should be owned by `bdot:bdot` were verified successfully.

#### Custom user / group

I configured `/etc/default/observiq-otel-collector`.

```ini
BDOT_USER=otelu
BDOT_GROUP=otelg
BDOT_UNPRIVILEGED=true
```

After installing with the install script, permissions are set correctly:

```bash
$ sudo ls -la /opt/observiq-otel-collector/

total 324120
drwxr-xr-x 5 otelu otelg      4096 Aug 20 15:01 .
drwxr-xr-x 4 root  root       4096 Aug 20 15:01 ..
-rw-r--r-- 1 otelu otelg     11339 Mar  3 13:43 LICENSE
-rw-r--r-- 1 otelu otelg        44 Aug 20 14:59 VERSION.txt
-rw-r----- 1 otelu otelg      1293 Aug 20 14:59 config.yaml
drwxr-x--- 2 otelu otelg      4096 Aug 20 15:01 log
-rw-r----- 1 otelu otelg       232 Aug 20 14:59 logging.yaml
-rwxr-xr-x 1 otelu otelg 323416248 Aug 20 14:59 observiq-otel-collector
drwxr-x--- 2 otelu otelg      4096 Aug 20 15:01 plugins
drwxr-x--- 2 otelu otelg      4096 Aug 20 15:00 storage
-rwxr-xr-x 1 otelu otelg   8429752 Aug 20 14:59 updater
```

The process is running as `otelu` user.

```bash
$ sudo ps aux | grep otelu

otelu       7029  0.0  1.9 1544084 156892 ?      Ssl  15:01   0:00 /opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
```

The systemd unit file and override** look correct:

```
sudo systemctl cat observiq-otel-collector
# /lib/systemd/system/observiq-otel-collector.service
[Unit]
Description=observIQ's distribution of the OpenTelemetry collector
After=network.target
StartLimitIntervalSec=120
StartLimitBurst=5
[Service]
Type=simple
User=root
Group=otelg
....

# /etc/systemd/system/observiq-otel-collector.service.d/10-package-customizations-username.conf
[Service]
User=otelu
```

**The systemd override logic was implemented previously, here https://github.com/observIQ/bindplane-otel-collector/pull/2443. This PR updates the `postinall` script to use the configured user instead of `bdot`.. defaulting to bdot.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
