### PR TITLE
feat: Add profiles capabilities to the PowerShell support bundle script

### DIFF
--- a/scripts/support/create-support-bundle.ps1
+++ b/scripts/support/create-support-bundle.ps1
@@ -39,6 +39,12 @@ $datestamp = Get-Date -Format "yyyy_MM_dd_HH_mm_ss"
 $output_dir = "Support_Bundle_$datestamp"
 New-Item -ItemType Directory -Force -Path $output_dir
 
+# Grab the collector VERSION.txt file
+if (Test-Path "$collector_dir\VERSION.txt") {
+    Write-Host "Adding $collector_dir\VERSION.txt"
+    Copy-Item "$collector_dir\VERSION.txt" -Destination "$output_dir\" -Force
+}
+
 # Determine whether to copy only the most recent log
 $response = Read-Host -Prompt "Do you want to include only the most recent logs (Y or n)?  "
 if ($response -eq "n") {

--- a/scripts/support/create-support-bundle.ps1
+++ b/scripts/support/create-support-bundle.ps1
@@ -70,9 +70,13 @@ if ($response -ne "n") {
 Get-ComputerInfo | Out-File "$output_dir\systeminfo.txt"
 
 # Capture profiles
-$response = Read-Host -Prompt "Collect go pprof profiles? (Y or n)? "
+$response = Read-Host -Prompt "Collect go pprof profiles [requires PowerShell 6.0.0 or greater]? (Y or n)? "
 
 if ($response -ne "n") {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        Write-Host "PowerShell 6.0.0 or greater is required to collect pprof profiles. Aborting pprof collection."
+        exit
+    }
     $pprof_port = Read-Host -Prompt "Enter the pprof port (default 13133): "
     if ([string]::IsNullOrWhiteSpace($pprof_port)) {
         $pprof_port = 13133

--- a/scripts/support/create-support-bundle.ps1
+++ b/scripts/support/create-support-bundle.ps1
@@ -85,7 +85,7 @@ if ($response -ne "n") {
     $profiles = @("profile", "block", "goroutine", "heap", "mutex", "threadcreate", "trace")
 
     foreach ($profile in $profiles) {
-        $url = "http://localhost:$pprof_port/debug/pprof/$profile?seconds=30"
+        $url = "http://localhost:$pprof_port/debug/pprof/$($profile)?seconds=30"
         $output_file = "$output_dir\$profile.txt"
         Write-Host "Collecting $profile profile from $url"
         try {


### PR DESCRIPTION
### Proposed Change
In order to bring the Windows support bundle in line with the Linux one, I've added the ability to collect the golang profiles (when enabled for the agent)

##### Checklist
- [x] Changes are tested
- [x] CI has passed
