### PR TITLE
fix: Snowflake v1.16.0 panic

### DIFF
--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/plugindocgen
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.83.1
 	github.com/spf13/pflag v1.0.7
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/azureloganalyticsexporter/go.mod
+++ b/exporter/azureloganalyticsexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/monitor/ingestion/azlogs v1.0.0
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.11.1

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/chronicleforwardere
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/exporter/qradar
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/exporter/snowflakeexporter/go.mod
+++ b/exporter/snowflakeexporter/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/jmoiron/sqlx v1.4.0
-	github.com/snowflakedb/gosnowflake v1.16.0
+	github.com/snowflakedb/gosnowflake v1.15.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0
@@ -124,3 +124,7 @@ require (
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Panic present in gosnowflake v1.16.0 so replace with v1.15.0
+// https://github.com/snowflakedb/gosnowflake/issues/1533
+replace github.com/snowflakedb/gosnowflake => github.com/snowflakedb/gosnowflake v1.15.0

--- a/exporter/snowflakeexporter/go.sum
+++ b/exporter/snowflakeexporter/go.sum
@@ -175,8 +175,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/snowflakedb/gosnowflake v1.16.0 h1:EfrAPVjWcBHzr2oiwEUz0dwFUiFlwftj9/YB6NktY9Q=
-github.com/snowflakedb/gosnowflake v1.16.0/go.mod h1:XJ2z3SckeW+juZzjuYNcAJM7i4ZgIZNmepFm5foO3Vc=
+github.com/snowflakedb/gosnowflake v1.15.0 h1:1V4dG1EmJ9O81Hv8y1LAE9koZebmx4tnRAPKWvDf8xA=
+github.com/snowflakedb/gosnowflake v1.15.0/go.mod h1:+3Eh8swS12G6Fbt/wb5Vcse2Id7VU9HGgKSH8ydiumU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/extension/awss3eventextension/go.mod
+++ b/extension/awss3eventextension/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,8 +4,8 @@ go 1.24.4
 
 require (
 	github.com/golang/snappy v1.0.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.83.1
 	github.com/open-telemetry/opamp-go v0.21.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.133.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1067,3 +1067,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokie
 
 // Keep at v0.132.0 since the Routing processor was removed in v0.133.0
 replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor => github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.132.0
+
+// Panic present in gosnowflake v1.16.0 so replace with v1.15.0
+// https://github.com/snowflakedb/gosnowflake/issues/1533
+replace github.com/snowflakedb/gosnowflake => github.com/snowflakedb/gosnowflake v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -4,44 +4,44 @@ go 1.24.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/exporter/webhookexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.83.0
-	github.com/observiq/bindplane-otel-collector/packagestate v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/randomfailureprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureblobexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/chronicleforwarderexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlecloudstorageexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/googlemanagedprometheusexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/qradar v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/snowflakeexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/exporter/webhookexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/report v1.83.1
+	github.com/observiq/bindplane-otel-collector/packagestate v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/datapointcountprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/logcountprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/lookupprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/maskprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/metricextractprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/metricstatsprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/randomfailureprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/removeemptyvaluesprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/resourceattributetransposerprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/samplingprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/spancountprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/throughputmeasurementprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/unrollprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/awss3eventreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/awss3rehydrationreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/azureblobrehydrationreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/googlecloudstoragerehydrationreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/httpreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/m365receiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/oktareceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/pluginreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/sapnetweaverreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/splunksearchapireceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver v1.83.1
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/open-telemetry/opamp-go v0.21.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.133.0
@@ -212,10 +212,10 @@ require (
 )
 
 require (
-	github.com/observiq/bindplane-otel-collector/exporter/azureloganalyticsexporter v1.83.0
-	github.com/observiq/bindplane-otel-collector/extension/awss3eventextension v1.83.0
-	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.83.0
+	github.com/observiq/bindplane-otel-collector/exporter/azureloganalyticsexporter v1.83.1
+	github.com/observiq/bindplane-otel-collector/extension/awss3eventextension v1.83.1
+	github.com/observiq/bindplane-otel-collector/processor/topologyprocessor v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/bindplaneauditlogs v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.133.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.133.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.133.0
@@ -459,11 +459,11 @@ require (
 	github.com/netsampler/goflow2/v2 v2.2.3 // indirect
 	github.com/nginx/nginx-prometheus-exporter v1.4.1 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/observiq/bindplane-otel-collector/counter v1.83.0 // indirect
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.0 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0 // indirect
+	github.com/observiq/bindplane-otel-collector/counter v1.83.1 // indirect
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.1 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.1 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.133.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2623,8 +2623,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snowflakedb/gosnowflake v1.16.0 h1:EfrAPVjWcBHzr2oiwEUz0dwFUiFlwftj9/YB6NktY9Q=
-github.com/snowflakedb/gosnowflake v1.16.0/go.mod h1:XJ2z3SckeW+juZzjuYNcAJM7i4ZgIZNmepFm5foO3Vc=
+github.com/snowflakedb/gosnowflake v1.15.0 h1:1V4dG1EmJ9O81Hv8y1LAE9koZebmx4tnRAPKWvDf8xA=
+github.com/snowflakedb/gosnowflake v1.15.0/go.mod h1:+3Eh8swS12G6Fbt/wb5Vcse2Id7VU9HGgKSH8ydiumU=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/internal/rehydration
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/consumer v1.39.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.133.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/datapointcountproc
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.83.0
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/counter v1.83.1
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/logcountprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.83.0
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/counter v1.83.1
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-otel-collector/processor/metricextractproce
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.133.0
 	github.com/stretchr/testify v1.11.1

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/samplingprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/report v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/report v1.83.1
 	github.com/open-telemetry/opamp-go v0.21.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.133.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.133.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-otel-collector/processor/spancountprocessor
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/counter v1.83.0
-	github.com/observiq/bindplane-otel-collector/expr v1.83.0
-	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.0
+	github.com/observiq/bindplane-otel-collector/counter v1.83.1
+	github.com/observiq/bindplane-otel-collector/expr v1.83.1
+	github.com/observiq/bindplane-otel-collector/receiver/routereceiver v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/processor/throughputmeasurem
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/measurements v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.133.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.133.0
 	github.com/stretchr/testify v1.11.1

--- a/receiver/awss3eventreceiver/go.mod
+++ b/receiver/awss3eventreceiver/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/aws/smithy-go v1.22.2
 	github.com/google/go-cmp v0.7.0
 	github.com/linkedin/goavro/v2 v2.14.0
-	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/aws v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -5,9 +5,9 @@ go 1.24.4
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/testutils v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0

--- a/receiver/googlecloudstoragerehydrationreceiver/go.mod
+++ b/receiver/googlecloudstoragerehydrationreceiver/go.mod
@@ -4,8 +4,8 @@ go 1.24.4
 
 require (
 	cloud.google.com/go/storage v1.51.0
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.0
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.1
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
 	go.opentelemetry.io/collector/component/componenttest v0.133.0

--- a/receiver/pluginreceiver/go.mod
+++ b/receiver/pluginreceiver/go.mod
@@ -385,3 +385,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )
+
+// Panic present in gosnowflake v1.16.0 so replace with v1.15.0
+// https://github.com/snowflakedb/gosnowflake/issues/1533
+replace github.com/snowflakedb/gosnowflake => github.com/snowflakedb/gosnowflake v1.15.0

--- a/receiver/pluginreceiver/go.sum
+++ b/receiver/pluginreceiver/go.sum
@@ -817,8 +817,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/snowflakedb/gosnowflake v1.16.0 h1:EfrAPVjWcBHzr2oiwEUz0dwFUiFlwftj9/YB6NktY9Q=
-github.com/snowflakedb/gosnowflake v1.16.0/go.mod h1:XJ2z3SckeW+juZzjuYNcAJM7i4ZgIZNmepFm5foO3Vc=
+github.com/snowflakedb/gosnowflake v1.15.0 h1:1V4dG1EmJ9O81Hv8y1LAE9koZebmx4tnRAPKWvDf8xA=
+github.com/snowflakedb/gosnowflake v1.15.0/go.mod h1:+3Eh8swS12G6Fbt/wb5Vcse2Id7VU9HGgKSH8ydiumU=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/receiver/splunksearchapireceiver/go.mod
+++ b/receiver/splunksearchapireceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-otel-collector/receiver/splunksearchapirece
 go 1.24.4
 
 require (
-	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.0
+	github.com/observiq/bindplane-otel-collector/internal/rehydration v1.83.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.133.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.39.0
@@ -44,7 +44,7 @@ require (
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.0 // indirect
+	github.com/observiq/bindplane-otel-collector/internal/storageclient v1.83.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.133.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.83.0
+	github.com/observiq/bindplane-otel-collector/packagestate v1.83.1
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Current release is panicing during QA testing due to the Snowflake update to v1.16.0 ([issue](https://github.com/snowflakedb/gosnowflake/issues/1533)). Revert back to v1.15.0 until this is fixed in a new release. Bump module versions to v1.83.1 for patch.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
