### PR TITLE
chore(v2): Rename observiq-otel-collector user to bdot

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -27,6 +27,7 @@ elif command -v service >/dev/null 2>&1; then
 fi
 
 # Script Constants
+COLLECTOR_USER="bindplane-otel-collector"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 INSTALL_DIR="/opt/bindplane-otel-collector"
 SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor.yaml"
@@ -765,7 +766,7 @@ create_supervisor_config() {
   # We do this because the file contains the secret key.
   # We do not want the file readable by anyone other than root/obseriq-otel-collector.
   command printf '' >>"$supervisor_yml_path"
-  chown bindplane-otel-collector:bindplane-otel-collector "$supervisor_yml_path"
+  chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "$supervisor_yml_path"
   chmod 0600 "$supervisor_yml_path"
 
   command printf 'server:\n' >"$supervisor_yml_path"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -27,7 +27,7 @@ elif command -v service >/dev/null 2>&1; then
 fi
 
 # Script Constants
-COLLECTOR_USER="bindplane-otel-collector"
+COLLECTOR_USER="bdot"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 INSTALL_DIR="/opt/bindplane-otel-collector"
 SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor.yaml"

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -27,15 +27,14 @@ set -e
 # Whether or not to run the collector as an unprivileged user.
 : "${BDOT_UNPRIVILEGED:=false}"
 
-# TOOD(jsirianni): Migrate to `bdot` username.
-username="bindplane-otel-collector"
+username="bdot"
 
 install() {
   mkdir -p "${BDOT_CONFIG_HOME}"
   chmod 0755 "${BDOT_CONFIG_HOME}"
-  chown bindplane-otel-collector:bindplane-otel-collector "${BDOT_CONFIG_HOME}"
+  chown "${username}:${username}" "${BDOT_CONFIG_HOME}"
   rm -f "${BDOT_CONFIG_HOME}/bindplane-otel-collector" || true
-  chown -R bindplane-otel-collector:bindplane-otel-collector /usr/share/bindplane-otel-collector/stage/bindplane-otel-collector
+  chown -R "${username}:${username}" /usr/share/bindplane-otel-collector/stage/bindplane-otel-collector
   cp -r --preserve \
     /usr/share/bindplane-otel-collector/stage/bindplane-otel-collector/* \
     "${BDOT_CONFIG_HOME}"
@@ -459,7 +458,7 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to bindplane-otel-collector
-  chown -R bindplane-otel-collector:bindplane-otel-collector ${BDOT_CONFIG_HOME}/bindplane-otel-collector ${BDOT_CONFIG_HOME}/opampsupervisor ${BDOT_CONFIG_HOME}/plugins/*
+  chown -R "${username}:${username}" ${BDOT_CONFIG_HOME}/bindplane-otel-collector ${BDOT_CONFIG_HOME}/opampsupervisor ${BDOT_CONFIG_HOME}/plugins/*
   chmod 0640 ${BDOT_CONFIG_HOME}/plugins/*
 
   # Initialize the log file to ensure it is owned by bindplane-otel-collector.
@@ -468,7 +467,7 @@ finish_permissions() {
   # user for 'non root' installs.
   mkdir -p ${BDOT_CONFIG_HOME}/supervisor_storage
   touch ${BDOT_CONFIG_HOME}/supervisor_storage/agent.log
-  chown bindplane-otel-collector:bindplane-otel-collector ${BDOT_CONFIG_HOME}/supervisor_storage/agent.log
+  chown "${username}:${username}" ${BDOT_CONFIG_HOME}/supervisor_storage/agent.log
 }
 
 install


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

- Updated unix install script to use `bdot` user and group
- Updated Linux package post install script to migrate Linux user `bindplane-otel-collector` to `bdot`

You can reference merged the V1 PR here https://github.com/observIQ/bindplane-otel-collector/pull/2436

### Testing

1. Installed the latest v2 beta agent
2. Confirmed files and dirs in `/opt/bindplane-otel-collector` are owned by `bindplane-otel-collector`
```bash
ls -la /opt/bindplane-otel-collector 
total 361936
drwxr-xr-x   5 bindplane-otel-collector bindplane-otel-collector      4096 Sep 15 13:39 .
drwxr-xr-x. 13 root                     root                          4096 Sep 15 13:39 ..
-rwxr-xr-x   1 bindplane-otel-collector bindplane-otel-collector 339480760 Aug  4 11:51 bindplane-otel-collector
-rw-r--r--   1 bindplane-otel-collector bindplane-otel-collector     11339 Aug  4 11:44 LICENSE
-rwxr-xr-x   1 bindplane-otel-collector bindplane-otel-collector  31086146 Aug  4 11:47 opampsupervisor
drwxr-x---   2 bindplane-otel-collector bindplane-otel-collector      4096 Sep 15 13:39 plugins
drwxr-x---   2 bindplane-otel-collector bindplane-otel-collector      4096 Aug  4 12:04 storage
-rw-r--r--   1 root                     bindplane-otel-collector       610 Sep 15 13:39 supervisor.log
drwxr-x---   2 bindplane-otel-collector bindplane-otel-collector      4096 Sep 15 13:39 supervisor_storage
-rw-------   1 bindplane-otel-collector bindplane-otel-collector       825 Sep 15 13:39 supervisor.yaml
-rw-r--r--   1 bindplane-otel-collector bindplane-otel-collector        14 Aug  4 11:46 VERSION.txt
```
3. Upgraded to a build from this branch
4. Confirmed files and dirs are now owned by `bdot`
```bash
ls -la /opt/bindplane-otel-collector
total 365112
drwxr-xr-x   5 bdot bdot      4096 Sep 15 13:40 .
drwxr-xr-x. 13 root root      4096 Sep 15 13:40 ..
-rwxr-xr-x   1 bdot bdot 339484856 Sep 15 13:35 bindplane-otel-collector
-rw-r--r--   1 bdot bdot     11339 Mar  3  2025 LICENSE
-rwxr-xr-x   1 bdot bdot  34329661 Sep 15 13:35 opampsupervisor
drwxr-x---   2 bdot bdot      4096 Sep 15 13:40 plugins
drwxr-x---   2 bdot bdot      4096 Sep 15 13:36 storage
-rw-r--r--   1 root bdot       610 Sep 15 13:39 supervisor.log
drwxr-x---   2 bdot bdot      4096 Sep 15 13:36 supervisor_storage
-rw-------   1 bdot bdot       825 Sep 15 13:39 supervisor.yaml
-rw-r--r--   1 bdot bdot        15 Sep 15 13:34 VERSION.txt
```
5. Confirmed service is still running and connected to Bindplane (supervisor config was not wiped out)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
