### PR TITLE
chore(package): Update Collector binary using atomic move

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -37,10 +37,13 @@ install() {
     mkdir -p "${BDOT_CONFIG_HOME}"
     chmod 0755 "${BDOT_CONFIG_HOME}"
     chown "$BDOT_USER:$BDOT_GROUP" "${BDOT_CONFIG_HOME}"
-    rm -f "${BDOT_CONFIG_HOME}/observiq-otel-collector" || true
 
     share_dir="/usr/share/observiq-otel-collector"
     stage_dir="${share_dir}/stage/observiq-otel-collector"
+
+    # Rename binaries in staging directory to avoid Linux binary locking issues
+    # during copy operation
+    mv "${stage_dir}/observiq-otel-collector" "${stage_dir}/observiq-otel-collector.new"
 
     # Prepare staged files with runtime ownership so destination does not need
     # post-copy ownership changes. This helps to ensure permissions do not flap
@@ -53,6 +56,9 @@ install() {
     cp -r --preserve \
       "$stage_dir"/* \
       "${BDOT_CONFIG_HOME}"
+
+    # Perform atomic moves for binary files to replace running binaries
+    mv "${BDOT_CONFIG_HOME}/observiq-otel-collector.new" "${BDOT_CONFIG_HOME}/observiq-otel-collector"
 
     rm -rf "$share_dir"
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

While working on this v2 PR https://github.com/observIQ/bindplane-otel-collector/pull/2652, I realized we can more safely move the new binary into place using an atomic operation.

This will prevent an edge case issue where the service could restart (due to a crash / some other issue) during a package upgrade. If the binary was deleted and `cp` has not finished, the binary could be missing.

### Testing

I deployed the latest collector to my Linux test system. I then upgraded to the RPM from this branch. The binary was moved successfully without error.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
