### PR TITLE
feat: PIPE-858 add capability-based privilege grants to systemd unit

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -112,6 +112,8 @@ StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
 KillMode=process
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -37,6 +37,8 @@ StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
 KillMode=process
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 [Install]
 WantedBy=multi-user.target`
 

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -19,5 +19,7 @@ StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
 KillMode=process
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 [Install]
 WantedBy=multi-user.target 


### PR DESCRIPTION
### Proposed Change
Adds `CapabilityBoundingSet` and `AmbientCapabilities` directives to the systemd unit template, granting only `CAP_NET_BIND_SERVICE` (bind to privileged ports) and `CAP_DAC_READ_SEARCH` (read files regardless of permissions) to the collector process.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed