### PR TITLE
feat: PIPE-859 add filesystem sandboxing to systemd unit

### DIFF
--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,9 +1,9 @@
-# File logging configuration assumes OIQ_OTEL_COLLECTOR_HOME
-# is set in the agent's environment. 
+# File logging configuration assumes OIQ_OTEL_COLLECTOR_LOGS
+# is set in the agent's environment.
 output: file
 level: info
 file:
-  filename: "${OIQ_OTEL_COLLECTOR_HOME}/log/collector.log"
+  filename: "${OIQ_OTEL_COLLECTOR_LOGS}/collector.log"
   maxbackups: 5
   maxsize: 100
   maxage: 7

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -114,6 +114,11 @@ RestartSec=5s
 KillMode=process
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ReadWritePaths=${BDOT_CONFIG_HOME}
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -39,6 +39,11 @@ RestartSec=5s
 KillMode=process
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ReadWritePaths={{.InstallDir}}
 [Install]
 WantedBy=multi-user.target`
 

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -21,5 +21,10 @@ RestartSec=5s
 KillMode=process
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ReadWritePaths=/opt/observiq-otel-collector
 [Install]
 WantedBy=multi-user.target 


### PR DESCRIPTION
### Proposed Change
Adds filesystem sandboxing directives to the systemd unit: `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`, `PrivateDevices=true`, and `ReadWritePaths` scoped to the install, storage, and log directories.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed