### PR TITLE
feat: PIPE-861 add syscall filtering to systemd unit

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -132,6 +132,7 @@ RestrictRealtime=yes
 LockPersonality=yes
 SystemCallArchitectures=native
 KeyringMode=private
+SystemCallFilter=@system-service @network-io
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -57,6 +57,7 @@ RestrictRealtime=yes
 LockPersonality=yes
 SystemCallArchitectures=native
 KeyringMode=private
+SystemCallFilter=@system-service @network-io
 [Install]
 WantedBy=multi-user.target`
 

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -39,5 +39,6 @@ RestrictRealtime=yes
 LockPersonality=yes
 SystemCallArchitectures=native
 KeyringMode=private
+SystemCallFilter=@system-service @network-io
 [Install]
 WantedBy=multi-user.target 

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -355,6 +355,22 @@ func TestGenerateLinuxServiceFiles(t *testing.T) {
 		// Compare the generated files with golden files
 		compareFiles(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), u.installedSystemdUnitPath)
 
+		content, err := os.ReadFile(filepath.Join(installDir, "install", "observiq-otel-collector.service"))
+		require.NoError(t, err)
+		generated := string(content)
+		// Verify user/group from golden file
+		require.Contains(t, generated, "User=bdot")
+		require.Contains(t, generated, "Group=bdot")
+		// Verify install dir is templated correctly
+		require.Contains(t, generated, fmt.Sprintf("WorkingDirectory=%s", installDir))
+		require.Contains(t, generated, fmt.Sprintf("Environment=OIQ_OTEL_COLLECTOR_HOME=%s", installDir))
+		// Verify storage/log dirs read from golden file
+		require.Contains(t, generated, "Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage")
+		require.Contains(t, generated, "Environment=OIQ_OTEL_COLLECTOR_LOGS=/opt/observiq-otel-collector/log")
+		// Verify hardening directives
+		require.Contains(t, generated, "ProtectSystem=strict")
+		require.Contains(t, generated, "NoNewPrivileges=yes")
+		require.Contains(t, generated, "SystemCallFilter=@system-service @network-io")
 		// Check file permissions
 		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), 0640)
 		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector"), 0755)


### PR DESCRIPTION
### Proposed Change
Adds `SystemCallFilter=@system-service @network-io` to the systemd unit, restricting the collector to only the syscall groups needed for normal service operation and network I/O.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed