### PR TITLE
feat: PIPE-863 harden SysV init script for non-root execution

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -237,13 +237,17 @@ fi
 
 BINARY=observiq-otel-collector
 PROGRAM=${BDOT_CONFIG_HOME}/"\$BINARY"
-START_CMD="nohup ${BDOT_CONFIG_HOME}/\$BINARY > /dev/null 2>&1 &"
 LOCKFILE=/var/lock/"\$BINARY"
 PIDFILE=/var/run/"\$BINARY".pid
+RUNAS_USER=${BDOT_USER}
 
 # Exported variables are used by the collector process.
 export BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 export BINDPLANE_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
+
+# Restrict file creation permissions and raise file descriptor limit
+umask 027
+ulimit -n 65000
 
 RETVAL=0
 start() {
@@ -254,9 +258,7 @@ start() {
 
   # RHEL
   if [ "\$STATUS" ]; then
-    umask 077
-
-    daemon --pidfile="\$PIDFILE" "\$START_CMD"
+    su -s /bin/sh "\$RUNAS_USER" -c "nohup \$PROGRAM --config config.yaml > /dev/null 2>&1 &"
     RETVAL=\$?
     # truncate the pid file, just in case
     : > "\$PIDFILE"
@@ -270,7 +272,7 @@ start() {
 
     # NOTE: startproc return 0, even if service is
     # already running to match LSB spec.
-    nohup "\$PROGRAM" --config config.yaml > /dev/null 2>&1 &
+    su -s /bin/sh "\$RUNAS_USER" -c "nohup \$PROGRAM --config config.yaml > /dev/null 2>&1 &"
 
     # Remember status and be verbose
     rc_status -v

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -127,13 +127,17 @@ fi
 
 BINARY=observiq-otel-collector
 PROGRAM=/opt/observiq-otel-collector/"$BINARY"
-START_CMD="nohup /opt/observiq-otel-collector/$BINARY > /dev/null 2>&1 &"
 LOCKFILE=/var/lock/"$BINARY"
 PIDFILE=/var/run/"$BINARY".pid
+RUNAS_USER=bdot
 
 # Exported variables are used by the collector process.
 export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
 export BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+
+# Restrict file creation permissions and raise file descriptor limit
+umask 027
+ulimit -n 65000
 
 RETVAL=0
 start() {
@@ -144,9 +148,7 @@ start() {
 
   # RHEL
   if [ "$STATUS" ]; then
-    umask 077
-
-    daemon --pidfile="$PIDFILE" "$START_CMD"
+    su -s /bin/sh "$RUNAS_USER" -c "nohup $PROGRAM --config config.yaml > /dev/null 2>&1 &"
     RETVAL=$?
     # truncate the pid file, just in case
     : > "$PIDFILE"
@@ -160,7 +162,7 @@ start() {
 
     # NOTE: startproc return 0, even if service is
     # already running to match LSB spec.
-    nohup "$PROGRAM" --config config.yaml > /dev/null 2>&1 &
+    su -s /bin/sh "$RUNAS_USER" -c "nohup $PROGRAM --config config.yaml > /dev/null 2>&1 &"
 
     # Remember status and be verbose
     rc_status -v


### PR DESCRIPTION
### Proposed Change
Hardens the SysV init script for non-root execution. Uses `su -s /bin/sh` to run the collector as the configured runtime user, adds `umask 027` for restrictive file creation permissions, and raises the file descriptor limit.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed