### PR TITLE
feat: PIPE-871 implement opt-in migration for hardened non-root mode

### DIFF
--- a/scripts/migrate/bdot-harden.sh
+++ b/scripts/migrate/bdot-harden.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Copyright  observIQ, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Idempotent migration script to enable hardened non-root mode for
+# an existing observIQ OpenTelemetry Collector installation.
+#
+# This script:
+#   1. Sets BDOT_HARDENED=true in the package override file
+#   2. Changes ownership of the install directory to bdot:bdot
+#   3. Updates the systemd unit or SysV init script to use the bdot user
+#   4. Reloads the init system and restarts the service
+#
+# Usage: sudo ./bdot-harden.sh
+#
+# This script is safe to run multiple times.
+
+set -e
+
+# Must run as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root (or with sudo)." >&2
+  exit 1
+fi
+
+# Load existing overrides
+[ -f /etc/default/observiq-otel-collector ] && . /etc/default/observiq-otel-collector
+[ -f /etc/sysconfig/observiq-otel-collector ] && . /etc/sysconfig/observiq-otel-collector
+
+: "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
+: "${BDOT_USER:=bdot}"
+: "${BDOT_GROUP:=bdot}"
+
+# Determine the override file location
+if [ -d /etc/sysconfig ]; then
+  OVERRIDE_FILE="/etc/sysconfig/observiq-otel-collector"
+elif [ -d /etc/default ]; then
+  OVERRIDE_FILE="/etc/default/observiq-otel-collector"
+else
+  OVERRIDE_FILE="/etc/default/observiq-otel-collector"
+  mkdir -p /etc/default
+fi
+
+# Step 1: Enable BDOT_HARDENED in the override file
+if [ -f "$OVERRIDE_FILE" ] && grep -q "^BDOT_HARDENED=" "$OVERRIDE_FILE"; then
+  sed -i 's/^BDOT_HARDENED=.*/BDOT_HARDENED=true/' "$OVERRIDE_FILE"
+  echo "Updated BDOT_HARDENED=true in $OVERRIDE_FILE"
+else
+  echo "BDOT_HARDENED=true" >> "$OVERRIDE_FILE"
+  echo "Added BDOT_HARDENED=true to $OVERRIDE_FILE"
+fi
+
+# Step 2: Change ownership of the install directory
+echo "Changing ownership of ${BDOT_CONFIG_HOME} to ${BDOT_USER}:${BDOT_GROUP}"
+chown -R "${BDOT_USER}:${BDOT_GROUP}" "${BDOT_CONFIG_HOME}"
+
+# Step 3: Update service files
+UNIT_FILE="/usr/lib/systemd/system/observiq-otel-collector.service"
+INITD_FILE="/etc/init.d/observiq-otel-collector"
+
+if [ -f "$UNIT_FILE" ]; then
+  # Update systemd unit User= line
+  if grep -q "^User=root" "$UNIT_FILE"; then
+    sed -i "s/^User=root/User=${BDOT_USER}/" "$UNIT_FILE"
+    echo "Updated User= in $UNIT_FILE to ${BDOT_USER}"
+  elif grep -q "^User=${BDOT_USER}" "$UNIT_FILE"; then
+    echo "User= already set to ${BDOT_USER} in $UNIT_FILE"
+  else
+    echo "WARNING: Unexpected User= value in $UNIT_FILE, updating to ${BDOT_USER}"
+    sed -i "s/^User=.*/User=${BDOT_USER}/" "$UNIT_FILE"
+  fi
+fi
+
+if [ -f "$INITD_FILE" ]; then
+  # Update SysV init script RUNAS_USER variable
+  if grep -q "^RUNAS_USER=" "$INITD_FILE"; then
+    sed -i "s/^RUNAS_USER=.*/RUNAS_USER=${BDOT_USER}/" "$INITD_FILE"
+    echo "Updated RUNAS_USER in $INITD_FILE to ${BDOT_USER}"
+  else
+    echo "WARNING: RUNAS_USER not found in $INITD_FILE, init script may need manual update"
+  fi
+fi
+
+# Step 4: Clean up legacy BDOT_UNPRIVILEGED drop-in
+LEGACY_OVERRIDE="/etc/systemd/system/observiq-otel-collector.service.d/10-package-customizations-username.conf"
+if [ -f "$LEGACY_OVERRIDE" ]; then
+  rm -f "$LEGACY_OVERRIDE"
+  echo "Removed legacy unprivileged override at $LEGACY_OVERRIDE"
+fi
+
+# Step 5: Reload and restart
+if command -v systemctl > /dev/null 2>&1 && [ -f "$UNIT_FILE" ]; then
+  systemctl daemon-reload
+  echo "Reloaded systemd daemon"
+
+  if systemctl is-active --quiet observiq-otel-collector 2>/dev/null; then
+    systemctl restart observiq-otel-collector
+    echo "Restarted observiq-otel-collector service"
+  else
+    echo "Service not running, skipping restart"
+  fi
+elif command -v service > /dev/null 2>&1 && [ -f "$INITD_FILE" ]; then
+  service observiq-otel-collector restart 2>/dev/null && \
+    echo "Restarted observiq-otel-collector service via init.d" || \
+    echo "Service not running or restart failed, skipping"
+else
+  echo "WARNING: Could not detect init system, please restart the service manually"
+fi
+
+echo ""
+echo "Migration complete. The collector is now configured to run as ${BDOT_USER}."
+if command -v systemctl > /dev/null 2>&1 && [ -f "$UNIT_FILE" ]; then
+  echo "To verify: systemctl show -p User observiq-otel-collector"
+else
+  echo "To verify: check the running process user with 'ps aux | grep observiq-otel-collector'"
+fi

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -25,8 +25,23 @@ set -e
 # The collectors installation directory
 : "${BDOT_CONFIG_HOME:=/opt/observiq-otel-collector}"
 
-# Whether or not to run the collector as an unprivileged user.
-: "${BDOT_UNPRIVILEGED:=false}"
+# Whether to run the collector as a non-root hardened service.
+# New installs default to hardened. Upgrades preserve existing behavior.
+# Can be overridden in /etc/default/observiq-otel-collector or
+# /etc/sysconfig/observiq-otel-collector.
+# Replaces the legacy BDOT_UNPRIVILEGED variable.
+if [ -z "${BDOT_HARDENED+x}" ]; then
+  if [ -n "${BDOT_UNPRIVILEGED+x}" ]; then
+    # Legacy variable set explicitly — honor it
+    BDOT_HARDENED="${BDOT_UNPRIVILEGED}"
+  elif [ -f "/usr/lib/systemd/system/observiq-otel-collector.service" ] || [ -f "/etc/init.d/observiq-otel-collector" ]; then
+    # Existing service file means upgrade — default to unhardened
+    BDOT_HARDENED="false"
+  else
+    # New install — default to hardened
+    BDOT_HARDENED="true"
+  fi
+fi
 
 # Configurable runtime user/group
 : "${BDOT_USER:=bdot}"
@@ -90,6 +105,14 @@ install_systemd_service() {
 
   mkdir -p "$(dirname "$config_file")"
 
+  # Determine runtime user based on hardening opt-in
+  if [ "${BDOT_HARDENED}" = "true" ]; then
+    BDOT_RUNTIME_USER="${BDOT_USER}"
+  else
+    BDOT_RUNTIME_USER="root"
+  fi
+
+  # Build the service file, conditionally including hardening directives
   cat << EOF > "$config_file"
 [Unit]
 Description=observIQ's distribution of the OpenTelemetry collector
@@ -98,7 +121,7 @@ StartLimitIntervalSec=120
 StartLimitBurst=5
 [Service]
 Type=simple
-User=root
+User=${BDOT_RUNTIME_USER}
 Group=${BDOT_GROUP}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
@@ -112,6 +135,13 @@ StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
 KillMode=process
+EOF
+
+  # Hardening directives are only applied when running as non-root.
+  # Applying them to root breaks normal root behavior (e.g. CAP_DAC_OVERRIDE
+  # is stripped, preventing writes to non-root-owned directories).
+  if [ "${BDOT_HARDENED}" = "true" ]; then
+    cat << EOF >> "$config_file"
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
 ProtectSystem=strict
@@ -133,6 +163,10 @@ LockPersonality=yes
 SystemCallArchitectures=native
 KeyringMode=private
 SystemCallFilter=@system-service @network-io
+EOF
+  fi
+
+  cat << EOF >> "$config_file"
 [Install]
 WantedBy=multi-user.target
 EOF
@@ -147,15 +181,11 @@ EOF
     echo "Created systemd override directory at $override_dir"
   fi
 
-  # If BDOT_UNPRIVILEGED is true, add an override to run the service as the
-  # unprivileged user.
-  override_user_path="${override_dir}/10-package-customizations-username.conf"
-  if [ "${BDOT_UNPRIVILEGED}" = "true" ]; then
-    cat << EOF > "${override_user_path}"
-[Service]
-User=${BDOT_USER}
-EOF
-    echo "Configured systemd service to run as ${BDOT_USER} user in ${override_user_path}"
+  # Clean up legacy BDOT_UNPRIVILEGED drop-in if it exists
+  legacy_override="${override_dir}/10-package-customizations-username.conf"
+  if [ -f "${legacy_override}" ]; then
+    rm -f "${legacy_override}"
+    echo "Removed legacy unprivileged user override at ${legacy_override}"
   fi
 }
 


### PR DESCRIPTION
### Proposed Change
Implements the opt-in migration for hardened non-root mode. New installs default to hardened (`BDOT_HARDENED=true`), while upgrades preserve existing behavior unless explicitly opted in. When hardened, the service runs as `bdot` with all security directives applied. Includes a standalone migration script at `scripts/migrate/bdot-harden.sh` for manual opt-in.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed