### PR TITLE
fix: PIPE-873 fix non-standard install directory upgrade support

### DIFF
--- a/updater/internal/path/path_linux.go
+++ b/updater/internal/path/path_linux.go
@@ -67,36 +67,20 @@ func InstallDir(logger *zap.Logger, configOverrides []string) (string, error) {
 // return an error if the file does not exist.
 // If a custom install dir is not found in the config file, it returns an empty string.
 func customInstallDir(logger *zap.Logger, config string) (string, error) {
-	_, err := os.Stat(config)
+	// #nosec G304 -- config is a file path from const DefaultConfigOverrides
+	// Test cases will override configOverrides to test this code path.
+	content, err := os.ReadFile(config)
 	if err != nil {
 		if os.IsNotExist(err) {
+			logger.Debug("config override file does not exist, skipping", zap.String("file", config))
 			return "", nil
 		}
 		return "", fmt.Errorf("read package override file %s: %w", config, err)
 	}
 
-	// Buffer is larger enough to read the entire
-	// user defined config override file.
-	buff := make([]byte, 4000)
+	logger.Debug("reading config override file", zap.String("file", config), zap.Int("bytes", len(content)))
 
-	// #nosec G304 -- config is a file path from const DefaultConfigOverrides
-	// Test cases will override configOverrides to test this code path.
-	file, err := os.Open(config)
-	if err != nil {
-		return "", fmt.Errorf("open package override file %s: %w", config, err)
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			logger.Error("close package override file", zap.String("file", config), zap.Error(err))
-		}
-	}()
-
-	_, err = file.Read(buff)
-	if err != nil {
-		return "", fmt.Errorf("read package override file %s: %w", config, err)
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(string(buff)))
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		// Skip empty lines or comments
@@ -109,6 +93,7 @@ func customInstallDir(logger *zap.Logger, config string) (string, error) {
 			if len(parts) == 2 {
 				value := strings.TrimSpace(parts[1])
 				if value != "" {
+					logger.Debug("found custom install dir", zap.String("file", config), zap.String("dir", value))
 					return value, nil
 				}
 				// If the value is empty, continue to the next line
@@ -120,6 +105,7 @@ func customInstallDir(logger *zap.Logger, config string) (string, error) {
 		return "", fmt.Errorf("error scanning config file %s: %w", config, err)
 	}
 
+	logger.Debug("no custom install dir found in config override file", zap.String("file", config))
 	return "", nil
 }
 

--- a/updater/internal/updater/updater.go
+++ b/updater/internal/updater/updater.go
@@ -157,14 +157,9 @@ func (u *Updater) generateLinuxServiceFiles() error {
 		return fmt.Errorf("read group from systemd file %s: %w", u.installedSystemdUnitPath, err)
 	}
 
-	// Get the install directory from path package. This will default
-	// to /opt/observiq-otel-collector unless BDOT_CONFIG_HOME is set
-	// in a package config file such as /etc/default/observiq-otel-collector
-	// or /etc/sysconfig/observiq-otel-collector.
-	installDir, err := path.InstallDir(u.logger, path.DefaultConfigOverrides)
-	if err != nil {
-		return fmt.Errorf("read working directory from systemd file %s: %w", u.installedSystemdUnitPath, err)
-	}
+	// Use the updater's install directory directly. This was already resolved
+	// from the config override files when the updater was created.
+	installDir := u.installDir
 
 	// Read storage and log directories from the existing systemd unit file,
 	// falling back to defaults relative to the install directory.

--- a/updater/internal/updater/updater_test.go
+++ b/updater/internal/updater/updater_test.go
@@ -346,15 +346,26 @@ func TestGenerateLinuxServiceFiles(t *testing.T) {
 			installedSystemdUnitPath: filepath.Join("testdata", "observiq-otel-collector.service.golden"),
 		}
 
-		// Cleanup the directory after test
 		defer os.RemoveAll(installDir)
 
 		err := u.generateLinuxServiceFiles()
 		require.NoError(t, err)
 
-		// Compare the generated files with golden files
-		compareFiles(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), u.installedSystemdUnitPath)
+		// Verify the generated systemd service file contains expected directives
+		generatedPath := filepath.Join(installDir, "install", "observiq-otel-collector.service")
+		content, err := os.ReadFile(generatedPath)
+		require.NoError(t, err)
 
+		generated := string(content)
+		// Verify user/group from golden file
+		require.Contains(t, generated, "User=bdot")
+		require.Contains(t, generated, "Group=bdot")
+		// Verify install dir is templated correctly
+		require.Contains(t, generated, fmt.Sprintf("WorkingDirectory=%s", installDir))
+		require.Contains(t, generated, fmt.Sprintf("Environment=BINDPLANE_COLLECTOR_HOME=%s", installDir))
+		// Verify storage/log dirs read from golden file
+		require.Contains(t, generated, "Environment=BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage")
+		require.Contains(t, generated, "Environment=BINDPLANE_COLLECTOR_LOGS=/opt/observiq-otel-collector/log")
 		// Check file permissions
 		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector.service"), 0640)
 		checkFilePermissions(t, filepath.Join(installDir, "install", "observiq-otel-collector"), 0755)


### PR DESCRIPTION
### Proposed Change
Fixes non-standard install directory upgrade support by properly resolving paths in the updater. When the collector is installed to a non-default directory, the updater now correctly generates service files and init scripts using the actual install path rather than hardcoded defaults.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed