### PR TITLE
fix: Improve install script package type detection (PIPE-901)

### DIFF
--- a/scripts/generic-install/install_unix.sh
+++ b/scripts/generic-install/install_unix.sh
@@ -205,14 +205,80 @@ download_and_install() {
     fi
 }
 
-detect_package_type() {
-    if command -v dpkg >/dev/null 2>&1; then
-        pkg_type="deb"
-    elif command -v rpm >/dev/null 2>&1; then
-        pkg_type="rpm"
-    else
-        pkg_type="tar.gz"
+# detect_distro_package_type prints the native package type ("deb" or "rpm") for
+# this system. It uses a multi-layer fallback chain so that the presence of a
+# cross-packaging tool (e.g. dpkg installed on Fedora) does not cause a wrong result.
+#
+# Fallback order:
+#   1. /etc/os-release ID and ID_LIKE  (RHEL 7+, SLES 12+, all modern distros)
+#   2. Distro-specific files           (RHEL 5, SLES 11, older CentOS/Fedora)
+#   3. High-level package managers     (apt-get, dnf, yum, zypper)
+#   4. Low-level packaging tools       (dpkg, rpm — least reliable)
+#
+# Prints nothing and returns 1 if detection fails.
+detect_distro_package_type() {
+    # 1. /etc/os-release — most reliable on modern systems
+    if [ -f /etc/os-release ]; then
+        _os_id=$(. /etc/os-release && echo "$ID")
+        _os_id_like=$(. /etc/os-release && echo "${ID_LIKE:-}")
+
+        _os_ids="$_os_id $_os_id_like"
+        case "$_os_ids" in
+            *debian*|*ubuntu*|*raspbian*|*linuxmint*)
+                echo "deb"
+                return 0
+                ;;
+            *rhel*|*centos*|*fedora*|*rocky*|*almalinux*|*amzn*|*sles*|*suse*|*opensuse*)
+                echo "rpm"
+                return 0
+                ;;
+        esac
     fi
+
+    # 2. Distro-specific files (covers RHEL 5, SLES 11 SP4, and similar legacy systems)
+    if [ -f /etc/debian_version ]; then
+        echo "deb"
+        return 0
+    fi
+
+    if [ -f /etc/redhat-release ] || [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
+        echo "rpm"
+        return 0
+    fi
+
+    if [ -f /etc/SuSE-release ]; then
+        echo "rpm"
+        return 0
+    fi
+
+    # 3. High-level package managers (stronger signal than the low-level tools)
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "deb"
+        return 0
+    fi
+
+    if command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1 || command -v zypper >/dev/null 2>&1; then
+        echo "rpm"
+        return 0
+    fi
+
+    # 4. Last resort: low-level tools. These are the least reliable because
+    # cross-packaging tools (e.g. dpkg on an RPM system) can cause false positives.
+    if command -v dpkg >/dev/null 2>&1; then
+        echo "deb"
+        return 0
+    fi
+
+    if command -v rpm >/dev/null 2>&1; then
+        echo "rpm"
+        return 0
+    fi
+
+    return 1
+}
+
+detect_package_type() {
+    pkg_type=$(detect_distro_package_type) || pkg_type="tar.gz"
     echo "Auto-detected package type: $pkg_type"
 }
 
@@ -256,11 +322,11 @@ uninstall() {
     fi
 
     # Remove package if it was installed via package manager
-    if command -v dpkg >/dev/null 2>&1; then
-        dpkg -r "$DISTRIBUTION" >/dev/null 2>&1 || true
-    elif command -v rpm >/dev/null 2>&1; then
-        rpm -e "$DISTRIBUTION" >/dev/null 2>&1 || true
-    fi
+    _uninstall_pkg_type=$(detect_distro_package_type) || true
+    case "$_uninstall_pkg_type" in
+        deb) dpkg -r "$DISTRIBUTION" >/dev/null 2>&1 || true ;;
+        rpm) rpm -e "$DISTRIBUTION" >/dev/null 2>&1 || true ;;
+    esac
 
     rm -rf "$INSTALL_DIR"
     echo "Uninstallation complete"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -482,6 +482,82 @@ set_os_arch()
   esac
 }
 
+# detect_distro_package_type prints the native package type ("deb" or "rpm") for
+# this system. It uses a multi-layer fallback chain so that the presence of a
+# cross-packaging tool (e.g. dpkg installed on Fedora) does not cause a wrong result.
+#
+# Fallback order:
+#   1. /etc/os-release ID and ID_LIKE  (RHEL 7+, SLES 12+, all modern distros)
+#   2. Distro-specific files           (RHEL 5, SLES 11, older CentOS/Fedora)
+#   3. High-level package managers     (apt-get, dnf, yum, zypper)
+#   4. Low-level packaging tools       (dpkg, rpm — least reliable)
+#
+# Prints nothing and returns 1 if detection fails.
+detect_distro_package_type()
+{
+  # 1. /etc/os-release — most reliable on modern systems
+  if [ -f /etc/os-release ]; then
+    # Source in a subshell to avoid polluting the current environment
+    _os_id=$(. /etc/os-release && echo "$ID")
+    _os_id_like=$(. /etc/os-release && echo "${ID_LIKE:-}")
+
+    # Combine ID and ID_LIKE for matching (ID_LIKE can contain multiple values)
+    _os_ids="$_os_id $_os_id_like"
+    case "$_os_ids" in
+      *debian*|*ubuntu*|*raspbian*|*linuxmint*)
+        echo "deb"
+        return 0
+        ;;
+      *rhel*|*centos*|*fedora*|*rocky*|*almalinux*|*amzn*|*sles*|*suse*|*opensuse*)
+        echo "rpm"
+        return 0
+        ;;
+    esac
+  fi
+
+  # 2. Distro-specific files (covers RHEL 5, SLES 11 SP4, and similar legacy systems)
+  if [ -f /etc/debian_version ]; then
+    echo "deb"
+    return 0
+  fi
+
+  if [ -f /etc/redhat-release ] || [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
+    echo "rpm"
+    return 0
+  fi
+
+  # SuSE-release was used through SLES 11; removed in SLES 12+
+  if [ -f /etc/SuSE-release ]; then
+    echo "rpm"
+    return 0
+  fi
+
+  # 3. High-level package managers (stronger signal than the low-level tools)
+  if command -v apt-get > /dev/null 2>&1; then
+    echo "deb"
+    return 0
+  fi
+
+  if command -v dnf > /dev/null 2>&1 || command -v yum > /dev/null 2>&1 || command -v zypper > /dev/null 2>&1; then
+    echo "rpm"
+    return 0
+  fi
+
+  # 4. Last resort: low-level tools. These are the least reliable because
+  # cross-packaging tools (e.g. dpkg on an RPM system) can cause false positives.
+  if command -v dpkg > /dev/null 2>&1; then
+    echo "deb"
+    return 0
+  fi
+
+  if command -v rpm > /dev/null 2>&1; then
+    echo "rpm"
+    return 0
+  fi
+
+  return 1
+}
+
 # Set the package type before install
 set_package_type()
 {
@@ -499,13 +575,7 @@ set_package_type()
         ;;
     esac
   else
-    if command -v dpkg > /dev/null 2>&1; then
-        package_type="deb"
-    elif command -v rpm > /dev/null 2>&1; then
-        package_type="rpm"
-    else
-        error_exit "$LINENO" "Could not find dpkg or rpm on the system"
-    fi
+    package_type=$(detect_distro_package_type) || error_exit "$LINENO" "Could not detect a supported package manager (deb or rpm) on this system"
   fi
 
 }
@@ -753,17 +823,15 @@ user_check()
   succeeded
 }
 
-# This will check to ensure either dpkg or rpm is installedon the system
+# This will check to ensure either dpkg or rpm is installed on the system
 package_type_check()
 {
   info "Checking for package manager..."
-  if command -v dpkg > /dev/null 2>&1; then
-      succeeded
-  elif command -v rpm > /dev/null 2>&1; then
+  if detect_distro_package_type > /dev/null; then
       succeeded
   else
       failed
-      error_exit "$LINENO" "Could not find dpkg or rpm on the system"
+      error_exit "$LINENO" "Could not detect a supported package manager (deb or rpm) on this system"
   fi
 }
 


### PR DESCRIPTION
### Proposed Change

Replace the fragile `command -v dpkg` / `command -v rpm` package type detection in both install scripts with a robust multi-layer fallback:

1. `/etc/os-release` `ID`/`ID_LIKE` — covers all modern distros (RHEL 7+, SLES 12+, Ubuntu, Fedora, etc.)
2. Distro-specific files (`/etc/debian_version`, `/etc/redhat-release`, `/etc/SuSE-release`) — covers legacy systems (RHEL 5, SLES 11 SP4)
3. High-level package managers (`apt-get`, `dnf`, `yum`, `zypper`) — stronger signal than low-level tools
4. Low-level tools (`dpkg`, `rpm`) — kept as last resort for edge cases

This fixes the issue where cross-packaging tools (e.g. `dpkg` installed on Fedora for building debian packages) cause the script to select the wrong package type.

**Files changed:**
- `scripts/install/install_unix.sh` — `set_package_type()` and `package_type_check()` now delegate to new `detect_distro_package_type()`
- `scripts/generic-install/install_unix.sh` — `detect_package_type()` and `uninstall()` now delegate to new `detect_distro_package_type()`

Linear: PIPE-901

##### Checklist
- [x] Changes are tested
- [ ] CI has passed