### PR TITLE
feat(generic-install): add install_windows.ps1

### DIFF
--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -17,13 +17,15 @@
     Installs or uninstalls an OTel Distro Builder distribution on Windows.
 
 .DESCRIPTION
-    Downloads and installs the appropriate MSI (amd64 or arm64) for the current
-    machine architecture. The MSI is resolved from a GitHub releases page unless
-    overridden. Pass -Uninstall to remove an existing installation.
+    Downloads the appropriate MSI (amd64 or arm64) for the current machine
+    architecture and hands it to msiexec. The MSI is resolved from a GitHub
+    releases page unless overridden. Pass -Uninstall to run msiexec /x against
+    the same MSI; the MSI must still be resolvable via -Url/-Version, -MsiUrl,
+    or -MsiFile, and must match the installed version.
 
 .PARAMETER Distribution
-    Name of the distribution to install (e.g. "mydistribution"). This value is
-    used to construct the MSI filename and to locate the product during uninstall.
+    Name of the distribution (e.g. "mydistribution"). Used to construct the MSI
+    filename and the install/uninstall log filename.
 
 .PARAMETER Url
     GitHub repository URL (e.g. "https://github.com/org/repo"). Required unless
@@ -51,18 +53,15 @@
     ignored.
 
 .PARAMETER MsiFile
-    Path to a local MSI file to install. Skips all download and version
-    resolution steps.
-
-.PARAMETER ProductName
-    Display name used to locate the installed product during uninstall. Defaults
-    to the value of -Distribution.
+    Path to a local MSI file. Skips all download and version resolution steps.
 
 .PARAMETER Interactive
     Show the installer UI instead of running silently.
 
 .PARAMETER Uninstall
-    Uninstall the distribution instead of installing it.
+    Uninstall the distribution instead of installing it. Resolves the MSI the
+    same way as install (-Url/-Version, -MsiUrl, or -MsiFile) and runs
+    msiexec /x against it.
 
 .PARAMETER SkipSignatureCheck
     Skip MSI Authenticode signature verification.
@@ -79,7 +78,9 @@
         -Version "1.2.3"
 
 .EXAMPLE
-    .\install_windows.ps1 -Distribution "mydistribution" -Uninstall
+    .\install_windows.ps1 -Distribution "mydistribution" `
+        -Url "https://github.com/org/repo" `
+        -Version "1.2.3" -Uninstall
 #>
 
 [CmdletBinding()]
@@ -110,9 +111,6 @@ param(
 
     [Parameter(Mandatory = $false)]
     [string]$MsiFile,
-
-    [Parameter(Mandatory = $false)]
-    [string]$ProductName,
 
     [Parameter(Mandatory = $false)]
     [switch]$Interactive,
@@ -250,61 +248,18 @@ function Build-MsiexecArgs {
     return $msiArgs
 }
 
-# ---- Uninstall ---------------------------------------------------------------
-
-function Get-ProductCode {
-    param([string]$Name)
-    $paths = @(
-        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
-        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-    )
-    return Get-ItemProperty $paths -ErrorAction SilentlyContinue |
-        Where-Object { $_.DisplayName -like "*$Name*" } |
-        Select-Object -First 1 -ExpandProperty PSChildName
-}
-
-function Invoke-Uninstall {
-    $searchName = if ($ProductName) { $ProductName } else { $Distribution }
-    Write-Info "Searching for installed product matching '$searchName'..."
-
-    $productCode = Get-ProductCode -Name $searchName
-    if (-not $productCode) {
-        Fail "No installed product found matching '$searchName'."
-    }
-
-    Write-Info "Found product code: $productCode"
-
-    $msiArgs = @("/x", $productCode)
-    if (-not $Interactive) {
-        $msiArgs += "/quiet"
-    }
-
-    Write-Info "Running: msiexec $($msiArgs -join ' ')"
-
-    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
-    switch ($proc.ExitCode) {
-        0    { Write-Info "Uninstallation completed successfully." }
-        3010 { Write-Warn "Uninstallation succeeded. A reboot is required to complete removal." }
-        default { Fail "msiexec exited with code $($proc.ExitCode). See Windows Event Log for details." }
-    }
-}
-
 # ---- Main --------------------------------------------------------------------
 
 function Main {
     Assert-Administrator
-
-    if ($Uninstall) {
-        Invoke-Uninstall
-        return
-    }
 
     if (-not $MsiFile -and -not $MsiUrl -and -not $Url) {
         Fail "Either -Url, -MsiUrl, or -MsiFile must be provided."
     }
 
     $tmpDir = [System.IO.Path]::GetTempPath()
-    $logPath = Join-Path $tmpDir "$Distribution-install.log"
+    $action = if ($Uninstall) { "uninstall" } else { "install" }
+    $logPath = Join-Path $tmpDir "$Distribution-$action.log"
     $cleanupMsi = $false
 
     if ($MsiFile) {
@@ -350,7 +305,16 @@ function Main {
         Write-Info "MSI signature verification successful."
     }
 
-    $msiArgs = Build-MsiexecArgs -MsiPath $msiPath -LogPath $logPath
+    if ($Uninstall) {
+        $msiArgs = @("/x", "`"$msiPath`"", "/l*v", "`"$logPath`"")
+        if (-not $Interactive) {
+            $msiArgs += "/quiet"
+        }
+    }
+    else {
+        $msiArgs = Build-MsiexecArgs -MsiPath $msiPath -LogPath $logPath
+    }
+
     Write-Info "Running: msiexec $($msiArgs -join ' ')"
 
     $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
@@ -365,12 +329,22 @@ function Main {
         }
     }
 
-    switch ($exitCode) {
-        0    { Write-Info "Installation completed successfully." }
-        1603 { Fail "Installation failed. See the install log for details: $logPath" }
-        1638 { Write-Info "$Distribution is already installed at this version. No changes made." }
-        3010 { Write-Warn "Installation succeeded. A reboot is required to complete setup." }
-        default { Fail "msiexec exited with code $exitCode. See the install log for details: $logPath" }
+    if ($Uninstall) {
+        switch ($exitCode) {
+            0    { Write-Info "Uninstallation completed successfully." }
+            1605 { Fail "Product is not installed (msiexec 1605). See the log for details: $logPath" }
+            3010 { Write-Warn "Uninstallation succeeded. A reboot is required to complete removal." }
+            default { Fail "msiexec exited with code $exitCode. See the log for details: $logPath" }
+        }
+    }
+    else {
+        switch ($exitCode) {
+            0    { Write-Info "Installation completed successfully." }
+            1603 { Fail "Installation failed. See the install log for details: $logPath" }
+            1638 { Write-Info "$Distribution is already installed at this version. No changes made." }
+            3010 { Write-Warn "Installation succeeded. A reboot is required to complete setup." }
+            default { Fail "msiexec exited with code $exitCode. See the install log for details: $logPath" }
+        }
     }
 }
 

--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -179,8 +179,12 @@ function Get-LatestVersion {
         $req.AllowAutoRedirect = $false
         $req.Method = "HEAD"
         $resp = $req.GetResponse()
-        $location = $resp.Headers["Location"]
-        $resp.Close()
+        try {
+            $location = $resp.Headers["Location"]
+        }
+        finally {
+            $resp.Close()
+        }
         if (-not $location) {
             Fail "No redirect received from $RepositoryUrl/releases/latest; cannot determine latest version."
         }
@@ -250,14 +254,13 @@ function Build-MsiexecArgs {
 
 function Get-ProductCode {
     param([string]$Name)
-    $product = Get-CimInstance -ClassName Win32_Product `
-        -Filter "Name LIKE '%$Name%'" `
-        -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-    if ($product) {
-        return $product.IdentifyingNumber
-    }
-    return $null
+    $paths = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+    return Get-ItemProperty $paths -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like "*$Name*" } |
+        Select-Object -First 1 -ExpandProperty PSChildName
 }
 
 function Invoke-Uninstall {
@@ -325,7 +328,12 @@ function Main {
             else {
                 $resolvedVersion = $Version.TrimStart('v')
             }
-            $msiFileName = "${Distribution}_v${resolvedVersion}_windows_${arch}.msi"
+            if ($arch -eq "arm64") {
+                $msiFileName = "${Distribution}-arm64.msi"
+            }
+            else {
+                $msiFileName = "${Distribution}.msi"
+            }
             $resolvedUrl = "$($Url.TrimEnd('/'))/releases/download/v${resolvedVersion}/${msiFileName}"
         }
 

--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -1,0 +1,369 @@
+# Copyright observIQ, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+<#
+.SYNOPSIS
+    Installs or uninstalls an OTel Distro Builder distribution on Windows.
+
+.DESCRIPTION
+    Downloads and installs the appropriate MSI (amd64 or arm64) for the current
+    machine architecture. The MSI is resolved from a GitHub releases page unless
+    overridden. Pass -Uninstall to remove an existing installation.
+
+.PARAMETER Distribution
+    Name of the distribution to install (e.g. "mydistribution"). This value is
+    used to construct the MSI filename and to locate the product during uninstall.
+
+.PARAMETER Url
+    GitHub repository URL (e.g. "https://github.com/org/repo"). Required unless
+    -MsiUrl or -MsiFile is provided.
+
+.PARAMETER Version
+    The version to install (e.g. "1.2.3"). Omit or pass "latest" to install the
+    latest release.
+
+.PARAMETER Endpoint
+    OpAMP server endpoint URL (e.g. "wss://app.bindplane.com/v1/opamp").
+    When provided, managed mode is enabled automatically.
+
+.PARAMETER SecretKey
+    Secret key for OpAMP authentication.
+
+.PARAMETER Labels
+    Comma-separated key=value labels for OpAMP (e.g. "env=prod,region=us-west").
+
+.PARAMETER InstallDir
+    Custom installation directory. Defaults to the MSI default.
+
+.PARAMETER MsiUrl
+    Override the full MSI download URL. If set, -Version and arch detection are
+    ignored.
+
+.PARAMETER MsiFile
+    Path to a local MSI file to install. Skips all download and version
+    resolution steps.
+
+.PARAMETER ProductName
+    Display name used to locate the installed product during uninstall. Defaults
+    to the value of -Distribution.
+
+.PARAMETER Interactive
+    Show the installer UI instead of running silently.
+
+.PARAMETER Uninstall
+    Uninstall the distribution instead of installing it.
+
+.PARAMETER SkipSignatureCheck
+    Skip MSI Authenticode signature verification.
+
+.EXAMPLE
+    .\install_windows.ps1 -Distribution "mydistribution" `
+        -Url "https://github.com/org/repo" `
+        -Endpoint "wss://app.bindplane.com/v1/opamp" `
+        -SecretKey "my-secret"
+
+.EXAMPLE
+    .\install_windows.ps1 -Distribution "mydistribution" `
+        -Url "https://github.com/org/repo" `
+        -Version "1.2.3"
+
+.EXAMPLE
+    .\install_windows.ps1 -Distribution "mydistribution" -Uninstall
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Distribution,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Url,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Endpoint,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SecretKey,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Labels,
+
+    [Parameter(Mandatory = $false)]
+    [string]$InstallDir,
+
+    [Parameter(Mandatory = $false)]
+    [string]$MsiUrl,
+
+    [Parameter(Mandatory = $false)]
+    [string]$MsiFile,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ProductName,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Interactive,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Uninstall,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipSignatureCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ---- Helpers -----------------------------------------------------------------
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO]  $Message"
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[WARN]  $Message" -ForegroundColor Yellow
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+    exit 1
+}
+
+# ---- Privilege check ---------------------------------------------------------
+
+function Assert-Administrator {
+    $principal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Fail "This script must be run as Administrator. Re-run from an elevated PowerShell prompt."
+    }
+}
+
+# ---- Architecture detection --------------------------------------------------
+
+function Get-Arch {
+    # PROCESSOR_ARCHITEW6432 is set when running a 32-bit process on a 64-bit OS (WOW64).
+    # Fall back to PROCESSOR_ARCHITECTURE when not in WOW64.
+    $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    switch ($arch) {
+        "AMD64" { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { Fail "Unsupported architecture: $arch. Only x64 (amd64) and ARM64 are supported." }
+    }
+}
+
+# ---- Version resolution ------------------------------------------------------
+
+function Get-LatestVersion {
+    param([string]$RepositoryUrl)
+    # GitHub redirects /releases/latest to /releases/tag/v{version}.
+    # We follow the redirect with AllowAutoRedirect = $false to extract the version.
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        $req = [System.Net.HttpWebRequest]::Create("$RepositoryUrl/releases/latest")
+        $req.AllowAutoRedirect = $false
+        $req.Method = "HEAD"
+        $resp = $req.GetResponse()
+        $location = $resp.Headers["Location"]
+        $resp.Close()
+        if (-not $location) {
+            Fail "No redirect received from $RepositoryUrl/releases/latest; cannot determine latest version."
+        }
+        return ($location -split '/')[-1].TrimStart('v')
+    }
+    catch {
+        Fail "Failed to retrieve latest version from ${RepositoryUrl}/releases/latest: $_"
+    }
+}
+
+# ---- Download ----------------------------------------------------------------
+
+function Get-Msi {
+    param(
+        [string]$Url,
+        [string]$Destination
+    )
+
+    Write-Info "Downloading MSI from $Url"
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        $wc = New-Object System.Net.WebClient
+        $wc.DownloadFile($Url, $Destination)
+    }
+    catch {
+        Fail "Failed to download MSI: $_"
+    }
+    Write-Info "Download complete: $Destination"
+}
+
+# ---- Build msiexec argument list ---------------------------------------------
+
+function Build-MsiexecArgs {
+    param(
+        [string]$MsiPath,
+        [string]$LogPath
+    )
+
+    $msiArgs = @("/i", "`"$MsiPath`"", "/l*v", "`"$LogPath`"")
+
+    if (-not $Interactive) {
+        $msiArgs += "/quiet"
+    }
+
+    # When an endpoint is provided, enable managed mode automatically.
+    if ($Endpoint) {
+        $msiArgs += "ENABLEMANAGEMENT=`"1`""
+        $msiArgs += "OPAMPENDPOINT=`"$Endpoint`""
+    }
+
+    if ($SecretKey) {
+        $msiArgs += "OPAMPSECRETKEY=`"$SecretKey`""
+    }
+
+    if ($Labels) {
+        $msiArgs += "OPAMPLABELS=`"$Labels`""
+    }
+
+    if ($InstallDir) {
+        $msiArgs += "INSTALLDIR=`"$InstallDir`""
+    }
+
+    return $msiArgs
+}
+
+# ---- Uninstall ---------------------------------------------------------------
+
+function Get-ProductCode {
+    param([string]$Name)
+    $product = Get-CimInstance -ClassName Win32_Product `
+        -Filter "Name LIKE '%$Name%'" `
+        -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($product) {
+        return $product.IdentifyingNumber
+    }
+    return $null
+}
+
+function Invoke-Uninstall {
+    $searchName = if ($ProductName) { $ProductName } else { $Distribution }
+    Write-Info "Searching for installed product matching '$searchName'..."
+
+    $productCode = Get-ProductCode -Name $searchName
+    if (-not $productCode) {
+        Fail "No installed product found matching '$searchName'."
+    }
+
+    Write-Info "Found product code: $productCode"
+
+    $msiArgs = @("/x", $productCode)
+    if (-not $Interactive) {
+        $msiArgs += "/quiet"
+    }
+
+    Write-Info "Running: msiexec $($msiArgs -join ' ')"
+
+    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
+    switch ($proc.ExitCode) {
+        0    { Write-Info "Uninstallation completed successfully." }
+        3010 { Write-Warn "Uninstallation succeeded. A reboot is required to complete removal." }
+        default { Fail "msiexec exited with code $($proc.ExitCode). See Windows Event Log for details." }
+    }
+}
+
+# ---- Main --------------------------------------------------------------------
+
+function Main {
+    Assert-Administrator
+
+    if ($Uninstall) {
+        Invoke-Uninstall
+        return
+    }
+
+    if (-not $MsiFile -and -not $MsiUrl -and -not $Url) {
+        Fail "Either -Url, -MsiUrl, or -MsiFile must be provided."
+    }
+
+    $tmpDir = [System.IO.Path]::GetTempPath()
+    $logPath = Join-Path $tmpDir "$Distribution-install.log"
+    $cleanupMsi = $false
+
+    if ($MsiFile) {
+        if (-not (Test-Path -Path $MsiFile -PathType Leaf)) {
+            Fail "MSI file not found: $MsiFile"
+        }
+        $msiPath = $MsiFile
+        Write-Info "Using local MSI: $msiPath"
+    }
+    else {
+        if ($MsiUrl) {
+            $resolvedUrl = $MsiUrl
+            $msiFileName = Split-Path $MsiUrl -Leaf
+        }
+        else {
+            $arch = Get-Arch
+            if (-not $Version -or $Version -eq "latest") {
+                $resolvedVersion = Get-LatestVersion -RepositoryUrl $Url
+                Write-Info "Latest version: $resolvedVersion"
+            }
+            else {
+                $resolvedVersion = $Version.TrimStart('v')
+            }
+            $msiFileName = "${Distribution}_v${resolvedVersion}_windows_${arch}.msi"
+            $resolvedUrl = "$($Url.TrimEnd('/'))/releases/download/v${resolvedVersion}/${msiFileName}"
+        }
+
+        $msiPath = Join-Path $tmpDir $msiFileName
+        $cleanupMsi = $true
+        Get-Msi -Url $resolvedUrl -Destination $msiPath
+    }
+
+    if (-not $SkipSignatureCheck) {
+        $sig = Get-AuthenticodeSignature -FilePath $msiPath
+        if ($sig.Status -ne 'Valid') {
+            Fail "MSI signature verification failed: $($sig.StatusMessage)"
+        }
+        Write-Info "MSI signature verification successful."
+    }
+
+    $msiArgs = Build-MsiexecArgs -MsiPath $msiPath -LogPath $logPath
+    Write-Info "Running: msiexec $($msiArgs -join ' ')"
+
+    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
+    $exitCode = $proc.ExitCode
+
+    if ($cleanupMsi) {
+        try {
+            Remove-Item -Path $msiPath -Force
+        }
+        catch {
+            Write-Warn "Failed to remove temporary MSI: $_"
+        }
+    }
+
+    switch ($exitCode) {
+        0    { Write-Info "Installation completed successfully." }
+        1603 { Fail "Installation failed. See the install log for details: $logPath" }
+        1638 { Write-Info "$Distribution is already installed at this version. No changes made." }
+        3010 { Write-Warn "Installation succeeded. A reboot is required to complete setup." }
+        default { Fail "msiexec exited with code $exitCode. See the install log for details: $logPath" }
+    }
+}
+
+Main

--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -55,8 +55,8 @@
 .PARAMETER MsiFile
     Path to a local MSI file. Skips all download and version resolution steps.
 
-.PARAMETER Interactive
-    Show the installer UI instead of running silently.
+.PARAMETER Quiet
+    Run the installer silently instead of showing the installer UI.
 
 .PARAMETER Uninstall
     Uninstall the distribution instead of installing it. Resolves the MSI the
@@ -113,7 +113,7 @@ param(
     [string]$MsiFile,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Interactive,
+    [switch]$Quiet,
 
     [Parameter(Mandatory = $false)]
     [switch]$Uninstall,
@@ -223,7 +223,7 @@ function Build-MsiexecArgs {
 
     $msiArgs = @("/i", "`"$MsiPath`"", "/l*v", "`"$LogPath`"")
 
-    if (-not $Interactive) {
+    if ($Quiet) {
         $msiArgs += "/quiet"
     }
 
@@ -297,17 +297,34 @@ function Main {
         Get-Msi -Url $resolvedUrl -Destination $msiPath
     }
 
-    if (-not $SkipSignatureCheck) {
+    if ($SkipSignatureCheck) {
+        Write-Warn "Authenticode signature verification is being bypassed with the '-SkipSignatureCheck' flag."
+        Write-Warn "This disables a critical security check and should only be used if your organization policies permit it."
+    }
+    else {
         $sig = Get-AuthenticodeSignature -FilePath $msiPath
         if ($sig.Status -ne 'Valid') {
-            Fail "MSI signature verification failed: $($sig.StatusMessage)"
+            $sigMessage = "MSI signature verification failed: $($sig.StatusMessage)"
+            if ($Quiet) {
+                Fail "Failed to verify MSI signature: $($sig.StatusMessage). Use '-SkipSignatureCheck' to skip verification."
+            }
+            Write-Warn $sigMessage
+            Write-Warn "This may indicate: the signing certificate is not trusted on this machine, the MSI has been tampered with, the signature or certificate has expired or been revoked, or the certificate chain could not be verified (e.g., network issues reaching CRL/OCSP)."
+            Write-Warn "Continuing is NOT RECOMMENDED."
+            $response = Read-Host "Continue with unverified MSI anyway? [y/N]"
+            if ($response -notmatch '^[yY]') {
+                Fail "Aborted by user."
+            }
+            Write-Warn "Continuing with unverified MSI at user's request."
         }
-        Write-Info "MSI signature verification successful."
+        else {
+            Write-Info "MSI signature verification successful."
+        }
     }
 
     if ($Uninstall) {
         $msiArgs = @("/x", "`"$msiPath`"", "/l*v", "`"$logPath`"")
-        if (-not $Interactive) {
+        if ($Quiet) {
             $msiArgs += "/quiet"
         }
     }


### PR DESCRIPTION
## Summary

- Adds `scripts/generic-install/install_windows.ps1` to complete Windows support alongside the existing `install_unix.sh` and `install_macos.sh`
- Assumes the OTel Distro Builder produces an MSI, following the filename convention `{distribution}.msi` or `{distribution}-arm64.msi`
- Resolves the latest version via the GitHub releases redirect (same logic as the shell scripts' `curl -Ls` approach)
- Passes OpAMP config (`ENABLEMANAGEMENT`, `OPAMPENDPOINT`, `OPAMPSECRETKEY`, `OPAMPLABELS`) as MSI properties; managed mode is enabled automatically when `-Endpoint` is provided
- Supports local file (`-MsiFile`), direct URL override (`-MsiUrl`), and standard GitHub release download
- Includes Authenticode signature verification by default, with `-SkipSignatureCheck` to opt out

## Test plan

See comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)