### PR TITLE
feat(extension): add opampconnectionextension (BPOP-4970)

### DIFF
--- a/factories/extensions.go
+++ b/factories/extensions.go
@@ -15,6 +15,7 @@
 package factories
 
 import (
+	"github.com/observiq/bindplane-otel-collector/internal/extension/opampconnectionextension"
 	"github.com/observiq/bindplane-otel-contrib/extension/awss3eventextension"
 	"github.com/observiq/bindplane-otel-contrib/extension/badgerextension"
 	"github.com/observiq/bindplane-otel-contrib/extension/opampgateway"
@@ -58,6 +59,7 @@ var defaultExtensions = []extension.Factory{
 	pebbleextension.NewFactory(),
 	oauth2clientauthextension.NewFactory(),
 	oidcauthextension.NewFactory(),
+	opampconnectionextension.NewFactory(),
 	opampgateway.NewFactory(),
 	pprofextension.NewFactory(),
 	redisstorageextension.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -570,7 +570,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.150.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile v0.150.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.150.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.150.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.150.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.150.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.150.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog v0.150.0 // indirect
@@ -1000,7 +1000,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
+	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/internal/extension/opampconnectionextension/config.go
+++ b/internal/extension/opampconnectionextension/config.go
@@ -1,0 +1,26 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opampconnectionextension
+
+// Config is the configuration for the opamp connection extension.
+//
+// The underlying OpAMP connection is owned by the opamp package rather than
+// the extension itself, so this extension does not accept any configuration.
+type Config struct{}
+
+// Validate implements component.ConfigValidator.
+func (Config) Validate() error {
+	return nil
+}

--- a/internal/extension/opampconnectionextension/doc.go
+++ b/internal/extension/opampconnectionextension/doc.go
@@ -1,0 +1,22 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package opampconnectionextension provides an extension that exposes the
+// OpAMP connection established by the opamp package to other collector
+// components. It implements the opampcustommessages.CustomCapabilityRegistry
+// interface so that processors and other extensions can register custom
+// capabilities, send custom messages, and receive custom messages from the
+// OpAMP server using the existing connection managed outside of the
+// collector.
+package opampconnectionextension

--- a/internal/extension/opampconnectionextension/extension.go
+++ b/internal/extension/opampconnectionextension/extension.go
@@ -34,57 +34,116 @@ import (
 // set are advertised automatically once SetClient is called.
 var ErrClientNotSet = errors.New("opamp client has not been set on opamp connection extension")
 
-// Registry is the public interface that processors and other collector
-// components may retrieve from the host in order to register custom
-// capabilities and send/receive custom messages over the shared OpAMP
-// connection.
+// Registry is the bridge that the owner of the OpAMP connection (the opamp
+// package) uses to wire its client into the opamp_connection extension and
+// to forward incoming custom messages.
 //
-// It is a superset of opampcustommessages.CustomCapabilityRegistry.
+// Registry is a package-level singleton and outlives individual extension
+// instances. The OpAMP client supplied via SetClient is cached and
+// forwarded to whichever opamp_connection extension instance is currently
+// attached, including instances that attach later (e.g. across a
+// collector restart). Per-extension state — registered capabilities and
+// message channels — lives with the extension instance and is abandoned
+// when that instance shuts down.
 //
-// The owner of the OpAMP connection (the opamp package) is expected to
-// supply the underlying client by calling SetClient and to forward incoming
-// custom messages by calling ProcessMessage.
+// The Register half of the upstream
+// opampcustommessages.CustomCapabilityRegistry interface is intentionally
+// not exposed here; components retrieve the extension itself via the
+// collector host and call Register on it directly.
 type Registry interface {
-	opampcustommessages.CustomCapabilityRegistry
-
-	// SetClient supplies the underlying OpAMP client that the registry will
-	// use to advertise custom capabilities and send custom messages. Any
-	// capabilities that were Registered before SetClient is called are
-	// advertised to the server at this point.
+	// SetClient supplies the underlying OpAMP client. The client is
+	// cached and forwarded to the currently-attached extension instance
+	// (if any) as well as to any instance that attaches in the future.
 	SetClient(c CustomCapabilityClient)
 
 	// ProcessMessage dispatches a custom message received from the OpAMP
-	// server to all handlers registered for its capability. Messages for
-	// capabilities with no registered handler are silently dropped.
+	// server to all handlers registered with the currently-attached
+	// extension instance. Messages received while no extension is
+	// attached are silently dropped.
 	ProcessMessage(cm *protobufs.CustomMessage)
 }
 
-// GetRegistry returns the Registry for the currently-started
-// opamp_connection extension, or nil if no extension is started. Only one
-// opamp_connection extension may be configured per collector, so this is
-// effectively a singleton lookup.
-//
-// It is intended to be called by the owner of the OpAMP connection (the
-// opamp package) so that it can wire its client into the extension once
-// both have been created.
+// GetRegistry returns the package-level Registry. It is always non-nil,
+// including when no opamp_connection extension is currently started:
+// SetClient calls are cached and ProcessMessage calls are dropped in that
+// case.
 func GetRegistry() Registry {
-	instanceMux.Lock()
-	defer instanceMux.Unlock()
-	if instance == nil {
-		return nil
-	}
-	return instance
+	return &manager
 }
 
-var (
-	instanceMux sync.Mutex
-	instance    *opampConnectionExtension
-)
+// manager is the package-level bridge between the opamp package and
+// whichever opamp_connection extension instance is currently started.
+// Because the collector rebuilds every component from its factory on each
+// restart, the extension instance itself is short-lived; the manager
+// remembers the client across those restarts so capabilities registered
+// by the next instance can be advertised immediately.
+var manager instanceManager
 
-// opampConnectionExtension is the concrete extension implementation. It is a
-// thin wrapper around customCapabilityRegistry that adds the extension
-// lifecycle and a package-level singleton so the OpAMP connection owner can
-// supply the underlying client.
+type instanceManager struct {
+	mux      sync.Mutex
+	instance *opampConnectionExtension
+	client   CustomCapabilityClient
+}
+
+// attach records e as the currently-started extension instance. If a
+// client has already been supplied via SetClient, it is forwarded to e's
+// registry so that capabilities registered against e are advertised
+// immediately.
+func (m *instanceManager) attach(e *opampConnectionExtension) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	if m.instance != nil {
+		return fmt.Errorf(
+			"only one opamp_connection extension may be configured per collector; %q is already configured",
+			m.instance.id,
+		)
+	}
+	m.instance = e
+	if m.client != nil {
+		e.registry.setClient(m.client)
+	}
+	return nil
+}
+
+// detach clears the currently-started instance if it is e. The cached
+// client is intentionally not cleared: it belongs to the opamp package,
+// not to any one extension instance, and must be forwarded to the next
+// instance that attaches.
+func (m *instanceManager) detach(e *opampConnectionExtension) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	if m.instance == e {
+		m.instance = nil
+	}
+}
+
+// SetClient implements Registry.
+func (m *instanceManager) SetClient(c CustomCapabilityClient) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.client = c
+	if m.instance != nil {
+		m.instance.registry.setClient(c)
+	}
+}
+
+// ProcessMessage implements Registry.
+func (m *instanceManager) ProcessMessage(cm *protobufs.CustomMessage) {
+	m.mux.Lock()
+	inst := m.instance
+	m.mux.Unlock()
+	if inst == nil {
+		return
+	}
+	inst.registry.ProcessMessage(cm)
+}
+
+// opampConnectionExtension is the concrete extension implementation. It
+// owns a per-instance customCapabilityRegistry whose lifetime matches the
+// extension's: on Shutdown the registry — and every capability and
+// message channel it holds — is abandoned. The package-level manager
+// bridges whichever instance is currently attached to the long-lived
+// OpAMP client.
 type opampConnectionExtension struct {
 	id       component.ID
 	logger   *zap.Logger
@@ -92,8 +151,8 @@ type opampConnectionExtension struct {
 }
 
 var (
-	_ extension.Extension = (*opampConnectionExtension)(nil)
-	_ Registry            = (*opampConnectionExtension)(nil)
+	_ extension.Extension                          = (*opampConnectionExtension)(nil)
+	_ opampcustommessages.CustomCapabilityRegistry = (*opampConnectionExtension)(nil)
 )
 
 func newExtension(id component.ID, logger *zap.Logger) *opampConnectionExtension {
@@ -104,46 +163,23 @@ func newExtension(id component.ID, logger *zap.Logger) *opampConnectionExtension
 	}
 }
 
-// Start records the extension as the package-level singleton so that the
-// opamp package can look it up and supply the OpAMP client.
-//
-// Only a single opamp_connection extension may be configured per collector,
-// since they would otherwise overwrite each other's advertised custom
-// capabilities whenever a component registers or unregisters one.
+// Start attaches this extension instance to the package-level manager.
+// Only a single opamp_connection extension may be configured per
+// collector, since they would otherwise overwrite each other's advertised
+// custom capabilities whenever a component registers or unregisters one.
 func (e *opampConnectionExtension) Start(_ context.Context, _ component.Host) error {
-	instanceMux.Lock()
-	defer instanceMux.Unlock()
-	if instance != nil {
-		return fmt.Errorf(
-			"only one opamp_connection extension may be configured per collector; %q is already configured",
-			instance.id,
-		)
-	}
-	instance = e
-	return nil
+	return manager.attach(e)
 }
 
-// Shutdown clears the package-level singleton.
+// Shutdown detaches this extension instance from the package-level
+// manager. The per-instance registry is abandoned along with any
+// capabilities registered against it.
 func (e *opampConnectionExtension) Shutdown(_ context.Context) error {
-	instanceMux.Lock()
-	defer instanceMux.Unlock()
-	if instance == e {
-		instance = nil
-	}
+	manager.detach(e)
 	return nil
-}
-
-// SetClient implements Registry.
-func (e *opampConnectionExtension) SetClient(c CustomCapabilityClient) {
-	e.registry.setClient(c)
 }
 
 // Register implements opampcustommessages.CustomCapabilityRegistry.
 func (e *opampConnectionExtension) Register(capability string, opts ...opampcustommessages.CustomCapabilityRegisterOption) (opampcustommessages.CustomCapabilityHandler, error) {
 	return e.registry.Register(capability, opts...)
-}
-
-// ProcessMessage implements Registry.
-func (e *opampConnectionExtension) ProcessMessage(cm *protobufs.CustomMessage) {
-	e.registry.ProcessMessage(cm)
 }

--- a/internal/extension/opampconnectionextension/extension.go
+++ b/internal/extension/opampconnectionextension/extension.go
@@ -1,0 +1,159 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opampconnectionextension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+	"go.uber.org/zap"
+)
+
+// ErrClientNotSet is returned when an operation that requires the underlying
+// OpAMP client is attempted before the owner of the connection has called
+// SetClient.
+var ErrClientNotSet = errors.New("opamp client has not been set on opamp connection extension")
+
+// Registry is the public interface that processors and other collector
+// components may retrieve from the host in order to register custom
+// capabilities and send/receive custom messages over the shared OpAMP
+// connection.
+//
+// It is a superset of opampcustommessages.CustomCapabilityRegistry.
+//
+// The owner of the OpAMP connection (the opamp package) is expected to
+// supply the underlying client by calling SetClient and to forward incoming
+// custom messages by calling ProcessMessage.
+type Registry interface {
+	opampcustommessages.CustomCapabilityRegistry
+
+	// SetClient supplies the underlying OpAMP client that the registry will
+	// use to advertise custom capabilities and send custom messages. It must
+	// be called before any component attempts to Register a capability.
+	SetClient(c CustomCapabilityClient)
+
+	// ProcessMessage dispatches a custom message received from the OpAMP
+	// server to all handlers registered for its capability. Messages for
+	// capabilities with no registered handler are silently dropped.
+	ProcessMessage(cm *protobufs.CustomMessage)
+}
+
+// GetRegistry returns the Registry for the extension registered under the
+// given component ID, or nil if no such extension exists. It is intended to
+// be called by the owner of the OpAMP connection (the opamp package) so
+// that it can wire its client into the extension once both have been
+// created.
+func GetRegistry(id component.ID) Registry {
+	instancesMux.Lock()
+	defer instancesMux.Unlock()
+	if inst, ok := instances[id]; ok {
+		return inst
+	}
+	return nil
+}
+
+// ForEachInstance invokes f for every opamp_connection extension instance
+// that is currently started. It is intended for use by the owner of the
+// OpAMP connection (the opamp package) to propagate the underlying client
+// and forward incoming custom messages to every registered extension
+// without needing to know their component IDs ahead of time.
+func ForEachInstance(f func(Registry)) {
+	instancesMux.Lock()
+	snapshot := make([]*opampConnectionExtension, 0, len(instances))
+	for _, inst := range instances {
+		snapshot = append(snapshot, inst)
+	}
+	instancesMux.Unlock()
+
+	for _, inst := range snapshot {
+		f(inst)
+	}
+}
+
+var (
+	instancesMux sync.Mutex
+	instances    = map[component.ID]*opampConnectionExtension{}
+)
+
+// opampConnectionExtension is the concrete extension implementation. It is a
+// thin wrapper around customCapabilityRegistry that adds the extension
+// lifecycle and a package-level lookup so the OpAMP connection owner can
+// supply the underlying client.
+type opampConnectionExtension struct {
+	id       component.ID
+	logger   *zap.Logger
+	registry *customCapabilityRegistry
+}
+
+var (
+	_ extension.Extension = (*opampConnectionExtension)(nil)
+	_ Registry            = (*opampConnectionExtension)(nil)
+)
+
+func newExtension(id component.ID, logger *zap.Logger) *opampConnectionExtension {
+	return &opampConnectionExtension{
+		id:       id,
+		logger:   logger,
+		registry: newCustomCapabilityRegistry(logger),
+	}
+}
+
+// Start registers the extension in the package-level instance map so that
+// the opamp package can look it up and supply the OpAMP client.
+//
+// Only a single opamp_connection extension may be configured per collector,
+// since they would otherwise overwrite each other's advertised custom
+// capabilities whenever a component registers or unregisters one.
+func (e *opampConnectionExtension) Start(_ context.Context, _ component.Host) error {
+	instancesMux.Lock()
+	defer instancesMux.Unlock()
+	for id := range instances {
+		return fmt.Errorf(
+			"only one opamp_connection extension may be configured per collector; %q is already configured",
+			id,
+		)
+	}
+	instances[e.id] = e
+	return nil
+}
+
+// Shutdown removes the extension from the package-level instance map.
+func (e *opampConnectionExtension) Shutdown(_ context.Context) error {
+	instancesMux.Lock()
+	defer instancesMux.Unlock()
+	delete(instances, e.id)
+	return nil
+}
+
+// SetClient implements Registry.
+func (e *opampConnectionExtension) SetClient(c CustomCapabilityClient) {
+	e.registry.setClient(c)
+}
+
+// Register implements opampcustommessages.CustomCapabilityRegistry.
+func (e *opampConnectionExtension) Register(capability string, opts ...opampcustommessages.CustomCapabilityRegisterOption) (opampcustommessages.CustomCapabilityHandler, error) {
+	return e.registry.Register(capability, opts...)
+}
+
+// ProcessMessage implements Registry.
+func (e *opampConnectionExtension) ProcessMessage(cm *protobufs.CustomMessage) {
+	e.registry.ProcessMessage(cm)
+}

--- a/internal/extension/opampconnectionextension/extension.go
+++ b/internal/extension/opampconnectionextension/extension.go
@@ -54,7 +54,7 @@ type Registry interface {
 	// SetClient supplies the underlying OpAMP client. The client is
 	// cached and forwarded to the currently-attached extension instance
 	// (if any) as well as to any instance that attaches in the future.
-	SetClient(c CustomCapabilityClient)
+	SetClient(c Client)
 
 	// ProcessMessage dispatches a custom message received from the OpAMP
 	// server to all handlers registered with the currently-attached
@@ -82,7 +82,7 @@ var manager instanceManager
 type instanceManager struct {
 	mux      sync.Mutex
 	instance *opampConnectionExtension
-	client   CustomCapabilityClient
+	client   Client
 }
 
 // attach records e as the currently-started extension instance. If a
@@ -118,7 +118,7 @@ func (m *instanceManager) detach(e *opampConnectionExtension) {
 }
 
 // SetClient implements Registry.
-func (m *instanceManager) SetClient(c CustomCapabilityClient) {
+func (m *instanceManager) SetClient(c Client) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	m.client = c

--- a/internal/extension/opampconnectionextension/extension.go
+++ b/internal/extension/opampconnectionextension/extension.go
@@ -27,9 +27,11 @@ import (
 	"go.uber.org/zap"
 )
 
-// ErrClientNotSet is returned when an operation that requires the underlying
-// OpAMP client is attempted before the owner of the connection has called
-// SetClient.
+// ErrClientNotSet is returned by operations that require the underlying
+// OpAMP client (currently only sending messages) when they are attempted
+// before the owner of the connection has called SetClient. Register itself
+// does not return this error — capabilities Registered before the client is
+// set are advertised automatically once SetClient is called.
 var ErrClientNotSet = errors.New("opamp client has not been set on opamp connection extension")
 
 // Registry is the public interface that processors and other collector
@@ -46,8 +48,9 @@ type Registry interface {
 	opampcustommessages.CustomCapabilityRegistry
 
 	// SetClient supplies the underlying OpAMP client that the registry will
-	// use to advertise custom capabilities and send custom messages. It must
-	// be called before any component attempts to Register a capability.
+	// use to advertise custom capabilities and send custom messages. Any
+	// capabilities that were Registered before SetClient is called are
+	// advertised to the server at this point.
 	SetClient(c CustomCapabilityClient)
 
 	// ProcessMessage dispatches a custom message received from the OpAMP

--- a/internal/extension/opampconnectionextension/extension.go
+++ b/internal/extension/opampconnectionextension/extension.go
@@ -59,46 +59,31 @@ type Registry interface {
 	ProcessMessage(cm *protobufs.CustomMessage)
 }
 
-// GetRegistry returns the Registry for the extension registered under the
-// given component ID, or nil if no such extension exists. It is intended to
-// be called by the owner of the OpAMP connection (the opamp package) so
-// that it can wire its client into the extension once both have been
-// created.
-func GetRegistry(id component.ID) Registry {
-	instancesMux.Lock()
-	defer instancesMux.Unlock()
-	if inst, ok := instances[id]; ok {
-		return inst
+// GetRegistry returns the Registry for the currently-started
+// opamp_connection extension, or nil if no extension is started. Only one
+// opamp_connection extension may be configured per collector, so this is
+// effectively a singleton lookup.
+//
+// It is intended to be called by the owner of the OpAMP connection (the
+// opamp package) so that it can wire its client into the extension once
+// both have been created.
+func GetRegistry() Registry {
+	instanceMux.Lock()
+	defer instanceMux.Unlock()
+	if instance == nil {
+		return nil
 	}
-	return nil
-}
-
-// ForEachInstance invokes f for every opamp_connection extension instance
-// that is currently started. It is intended for use by the owner of the
-// OpAMP connection (the opamp package) to propagate the underlying client
-// and forward incoming custom messages to every registered extension
-// without needing to know their component IDs ahead of time.
-func ForEachInstance(f func(Registry)) {
-	instancesMux.Lock()
-	snapshot := make([]*opampConnectionExtension, 0, len(instances))
-	for _, inst := range instances {
-		snapshot = append(snapshot, inst)
-	}
-	instancesMux.Unlock()
-
-	for _, inst := range snapshot {
-		f(inst)
-	}
+	return instance
 }
 
 var (
-	instancesMux sync.Mutex
-	instances    = map[component.ID]*opampConnectionExtension{}
+	instanceMux sync.Mutex
+	instance    *opampConnectionExtension
 )
 
 // opampConnectionExtension is the concrete extension implementation. It is a
 // thin wrapper around customCapabilityRegistry that adds the extension
-// lifecycle and a package-level lookup so the OpAMP connection owner can
+// lifecycle and a package-level singleton so the OpAMP connection owner can
 // supply the underlying client.
 type opampConnectionExtension struct {
 	id       component.ID
@@ -119,30 +104,32 @@ func newExtension(id component.ID, logger *zap.Logger) *opampConnectionExtension
 	}
 }
 
-// Start registers the extension in the package-level instance map so that
-// the opamp package can look it up and supply the OpAMP client.
+// Start records the extension as the package-level singleton so that the
+// opamp package can look it up and supply the OpAMP client.
 //
 // Only a single opamp_connection extension may be configured per collector,
 // since they would otherwise overwrite each other's advertised custom
 // capabilities whenever a component registers or unregisters one.
 func (e *opampConnectionExtension) Start(_ context.Context, _ component.Host) error {
-	instancesMux.Lock()
-	defer instancesMux.Unlock()
-	for id := range instances {
+	instanceMux.Lock()
+	defer instanceMux.Unlock()
+	if instance != nil {
 		return fmt.Errorf(
 			"only one opamp_connection extension may be configured per collector; %q is already configured",
-			id,
+			instance.id,
 		)
 	}
-	instances[e.id] = e
+	instance = e
 	return nil
 }
 
-// Shutdown removes the extension from the package-level instance map.
+// Shutdown clears the package-level singleton.
 func (e *opampConnectionExtension) Shutdown(_ context.Context) error {
-	instancesMux.Lock()
-	defer instancesMux.Unlock()
-	delete(instances, e.id)
+	instanceMux.Lock()
+	defer instanceMux.Unlock()
+	if instance == e {
+		instance = nil
+	}
 	return nil
 }
 

--- a/internal/extension/opampconnectionextension/extension_test.go
+++ b/internal/extension/opampconnectionextension/extension_test.go
@@ -49,33 +49,11 @@ func TestExtension_Shutdown_AllowsSubsequentStart(t *testing.T) {
 }
 
 func TestGetRegistry(t *testing.T) {
-	id := component.MustNewIDWithName("opamp_connection", "lookup")
-	ext := newExtension(id, zap.NewNop())
+	require.Nil(t, GetRegistry(), "should return nil before Start")
 
-	require.Nil(t, GetRegistry(id), "should return nil before Start")
-
+	ext := newExtension(component.MustNewIDWithName("opamp_connection", "lookup"), zap.NewNop())
 	require.NoError(t, ext.Start(context.Background(), nil))
 	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
 
-	got := GetRegistry(id)
-	require.NotNil(t, got)
-	require.Equal(t, Registry(ext), got)
-
-	require.Nil(t, GetRegistry(component.MustNewIDWithName("opamp_connection", "other")))
-}
-
-func TestForEachInstance(t *testing.T) {
-	id := component.MustNewIDWithName("opamp_connection", "foreach")
-	ext := newExtension(id, zap.NewNop())
-
-	require.NoError(t, ext.Start(context.Background(), nil))
-	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
-
-	var seen []Registry
-	ForEachInstance(func(r Registry) {
-		seen = append(seen, r)
-	})
-
-	require.Len(t, seen, 1)
-	require.Equal(t, Registry(ext), seen[0])
+	require.Equal(t, Registry(ext), GetRegistry())
 }

--- a/internal/extension/opampconnectionextension/extension_test.go
+++ b/internal/extension/opampconnectionextension/extension_test.go
@@ -18,12 +18,28 @@ import (
 	"context"
 	"testing"
 
+	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
 
+// resetManager clears the package-level manager state between tests so a
+// leaked instance or client reference from one test does not affect
+// another.
+func resetManager(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		manager.mux.Lock()
+		manager.instance = nil
+		manager.client = nil
+		manager.mux.Unlock()
+	})
+}
+
 func TestExtension_Start_RejectsSecondInstance(t *testing.T) {
+	resetManager(t)
+
 	ext1 := newExtension(component.MustNewIDWithName("opamp_connection", "one"), zap.NewNop())
 	ext2 := newExtension(component.MustNewIDWithName("opamp_connection", "two"), zap.NewNop())
 
@@ -36,6 +52,8 @@ func TestExtension_Start_RejectsSecondInstance(t *testing.T) {
 }
 
 func TestExtension_Shutdown_AllowsSubsequentStart(t *testing.T) {
+	resetManager(t)
+
 	ext1 := newExtension(component.MustNewIDWithName("opamp_connection", "first"), zap.NewNop())
 	ext2 := newExtension(component.MustNewIDWithName("opamp_connection", "second"), zap.NewNop())
 
@@ -48,12 +66,119 @@ func TestExtension_Shutdown_AllowsSubsequentStart(t *testing.T) {
 	t.Cleanup(func() { _ = ext2.Shutdown(context.Background()) })
 }
 
-func TestGetRegistry(t *testing.T) {
-	require.Nil(t, GetRegistry(), "should return nil before Start")
+func TestRegistry_ForwardsClientToCurrentInstance(t *testing.T) {
+	resetManager(t)
 
-	ext := newExtension(component.MustNewIDWithName("opamp_connection", "lookup"), zap.NewNop())
+	var advertised []*protobufs.CustomCapabilities
+	client := mockCustomCapabilityClient{
+		setCustomCapabilities: func(cc *protobufs.CustomCapabilities) error {
+			advertised = append(advertised, cc)
+			return nil
+		},
+	}
+
+	ext := newExtension(component.MustNewIDWithName("opamp_connection", "x"), zap.NewNop())
 	require.NoError(t, ext.Start(context.Background(), nil))
 	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
 
-	require.Equal(t, Registry(ext), GetRegistry())
+	// SetClient after Start forwards to the attached instance immediately.
+	GetRegistry().SetClient(client)
+
+	_, err := ext.Register("io.opentelemetry.teapot")
+	require.NoError(t, err)
+	require.Len(t, advertised, 1)
+	require.Equal(t, []string{"io.opentelemetry.teapot"}, advertised[0].Capabilities)
+}
+
+func TestRegistry_ForwardsCachedClientToLateInstance(t *testing.T) {
+	resetManager(t)
+
+	var advertised []*protobufs.CustomCapabilities
+	client := mockCustomCapabilityClient{
+		setCustomCapabilities: func(cc *protobufs.CustomCapabilities) error {
+			advertised = append(advertised, cc)
+			return nil
+		},
+	}
+
+	// Client supplied before any extension instance has started.
+	GetRegistry().SetClient(client)
+
+	ext := newExtension(component.MustNewIDWithName("opamp_connection", "late"), zap.NewNop())
+
+	// Register before Start — the per-instance registry has no client
+	// yet, so no advertisement goes out.
+	_, err := ext.Register("io.opentelemetry.teapot")
+	require.NoError(t, err)
+	require.Empty(t, advertised)
+
+	// Start forwards the cached client to the instance's registry, which
+	// flushes accumulated capabilities.
+	require.NoError(t, ext.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+
+	require.Len(t, advertised, 1)
+	require.Equal(t, []string{"io.opentelemetry.teapot"}, advertised[0].Capabilities)
+}
+
+func TestRegistry_CachesClientAcrossInstances(t *testing.T) {
+	resetManager(t)
+
+	var advertised []*protobufs.CustomCapabilities
+	client := mockCustomCapabilityClient{
+		setCustomCapabilities: func(cc *protobufs.CustomCapabilities) error {
+			advertised = append(advertised, cc)
+			return nil
+		},
+	}
+
+	// First instance starts, client is wired, then it shuts down. This
+	// mirrors the collector lifecycle before a config reload.
+	ext1 := newExtension(component.MustNewIDWithName("opamp_connection", "first"), zap.NewNop())
+	require.NoError(t, ext1.Start(context.Background(), nil))
+	GetRegistry().SetClient(client)
+	require.NoError(t, ext1.Shutdown(context.Background()))
+
+	// A second instance starts after the restart. No second SetClient
+	// call is made — the manager's cached client must reach the new
+	// registry automatically.
+	ext2 := newExtension(component.MustNewIDWithName("opamp_connection", "second"), zap.NewNop())
+	require.NoError(t, ext2.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext2.Shutdown(context.Background()) })
+
+	advertised = nil
+	_, err := ext2.Register("io.opentelemetry.teapot")
+	require.NoError(t, err)
+	require.Len(t, advertised, 1, "capability registered after restart should be advertised")
+	require.Equal(t, []string{"io.opentelemetry.teapot"}, advertised[0].Capabilities)
+}
+
+func TestRegistry_ProcessMessageRoutesToCurrentInstance(t *testing.T) {
+	resetManager(t)
+
+	ext := newExtension(component.MustNewIDWithName("opamp_connection", "x"), zap.NewNop())
+	require.NoError(t, ext.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+	GetRegistry().SetClient(mockCustomCapabilityClient{})
+
+	handler, err := ext.Register("io.opentelemetry.teapot")
+	require.NoError(t, err)
+
+	msg := &protobufs.CustomMessage{
+		Capability: "io.opentelemetry.teapot",
+		Type:       "steep",
+		Data:       []byte("blackTea"),
+	}
+	GetRegistry().ProcessMessage(msg)
+	require.Equal(t, msg, <-handler.Message())
+}
+
+func TestRegistry_ProcessMessageWithoutInstanceIsNoop(t *testing.T) {
+	resetManager(t)
+
+	// No extension attached — should be a harmless no-op.
+	GetRegistry().ProcessMessage(&protobufs.CustomMessage{
+		Capability: "io.opentelemetry.teapot",
+		Type:       "steep",
+	})
 }

--- a/internal/extension/opampconnectionextension/extension_test.go
+++ b/internal/extension/opampconnectionextension/extension_test.go
@@ -1,0 +1,81 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opampconnectionextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+)
+
+func TestExtension_Start_RejectsSecondInstance(t *testing.T) {
+	ext1 := newExtension(component.MustNewIDWithName("opamp_connection", "one"), zap.NewNop())
+	ext2 := newExtension(component.MustNewIDWithName("opamp_connection", "two"), zap.NewNop())
+
+	require.NoError(t, ext1.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext1.Shutdown(context.Background()) })
+
+	err := ext2.Start(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only one opamp_connection extension")
+}
+
+func TestExtension_Shutdown_AllowsSubsequentStart(t *testing.T) {
+	ext1 := newExtension(component.MustNewIDWithName("opamp_connection", "first"), zap.NewNop())
+	ext2 := newExtension(component.MustNewIDWithName("opamp_connection", "second"), zap.NewNop())
+
+	require.NoError(t, ext1.Start(context.Background(), nil))
+	require.NoError(t, ext1.Shutdown(context.Background()))
+
+	// After the first extension shuts down, a second one can start in its
+	// place (e.g. across a collector restart).
+	require.NoError(t, ext2.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext2.Shutdown(context.Background()) })
+}
+
+func TestGetRegistry(t *testing.T) {
+	id := component.MustNewIDWithName("opamp_connection", "lookup")
+	ext := newExtension(id, zap.NewNop())
+
+	require.Nil(t, GetRegistry(id), "should return nil before Start")
+
+	require.NoError(t, ext.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+
+	got := GetRegistry(id)
+	require.NotNil(t, got)
+	require.Equal(t, Registry(ext), got)
+
+	require.Nil(t, GetRegistry(component.MustNewIDWithName("opamp_connection", "other")))
+}
+
+func TestForEachInstance(t *testing.T) {
+	id := component.MustNewIDWithName("opamp_connection", "foreach")
+	ext := newExtension(id, zap.NewNop())
+
+	require.NoError(t, ext.Start(context.Background(), nil))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+
+	var seen []Registry
+	ForEachInstance(func(r Registry) {
+		seen = append(seen, r)
+	})
+
+	require.Len(t, seen, 1)
+	require.Equal(t, Registry(ext), seen[0])
+}

--- a/internal/extension/opampconnectionextension/factory.go
+++ b/internal/extension/opampconnectionextension/factory.go
@@ -1,0 +1,45 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opampconnectionextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+)
+
+// componentType is the unique type of this extension.
+var componentType = component.MustNewType("opamp_connection")
+
+const stability = component.StabilityLevelAlpha
+
+// NewFactory creates a factory for the opamp connection extension.
+func NewFactory() extension.Factory {
+	return extension.NewFactory(
+		componentType,
+		createDefaultConfig,
+		createExtension,
+		stability,
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+func createExtension(_ context.Context, set extension.Settings, _ component.Config) (extension.Extension, error) {
+	return newExtension(set.ID, set.Logger), nil
+}

--- a/internal/extension/opampconnectionextension/registry.go
+++ b/internal/extension/opampconnectionextension/registry.go
@@ -63,15 +63,32 @@ func newCustomCapabilityRegistry(logger *zap.Logger) *customCapabilityRegistry {
 	}
 }
 
-// setClient supplies the underlying OpAMP client to the registry. It must be
-// called before any component attempts to Register a capability.
+// setClient supplies the underlying OpAMP client to the registry. Any
+// capabilities that were Registered before the client was supplied are
+// advertised to the server now.
 func (cr *customCapabilityRegistry) setClient(c CustomCapabilityClient) {
 	cr.mux.Lock()
 	defer cr.mux.Unlock()
 	cr.client = c
+	if caps := cr.capabilities(); len(caps) > 0 {
+		if err := c.SetCustomCapabilities(&protobufs.CustomCapabilities{
+			Capabilities: caps,
+		}); err != nil {
+			// Not fatal: the server just won't know we support these
+			// capabilities until something else triggers an update.
+			cr.logger.Error("Failed to advertise capabilities after client was set", zap.Error(err))
+		}
+	}
 }
 
-// Register implements CustomCapabilityRegistry.Register
+// Register implements CustomCapabilityRegistry.Register.
+//
+// Register tolerates being called before setClient: in that case the
+// capability is recorded and will be advertised to the OpAMP server once the
+// client is supplied. This matters in the v1 agent, where components (e.g.
+// the snapshot processor) register their capabilities during pipeline
+// startup, but the owner of the OpAMP connection only calls setClient after
+// the collector has finished starting.
 func (cr *customCapabilityRegistry) Register(capability string, opts ...opampcustommessages.CustomCapabilityRegisterOption) (opampcustommessages.CustomCapabilityHandler, error) {
 	optsStruct := opampcustommessages.DefaultCustomCapabilityRegisterOptions()
 	for _, opt := range opts {
@@ -80,22 +97,6 @@ func (cr *customCapabilityRegistry) Register(capability string, opts ...opampcus
 
 	cr.mux.Lock()
 	defer cr.mux.Unlock()
-
-	if cr.client == nil {
-		return nil, ErrClientNotSet
-	}
-
-	capabilities := cr.capabilities()
-	if !slices.Contains(capabilities, capability) {
-		capabilities = append(capabilities, capability)
-	}
-
-	err := cr.client.SetCustomCapabilities(&protobufs.CustomCapabilities{
-		Capabilities: capabilities,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("set custom capabilities: %w", err)
-	}
 
 	capabilityList := cr.capabilityToMsgChannels[capability]
 	if capabilityList == nil {
@@ -106,8 +107,28 @@ func (cr *customCapabilityRegistry) Register(capability string, opts ...opampcus
 	msgChan := make(chan *protobufs.CustomMessage, optsStruct.MaxQueuedMessages)
 	callbackElem := capabilityList.PushBack(msgChan)
 
+	// If the client is already set, advertise the new capability immediately.
+	// Otherwise setClient will flush the accumulated set when it's called.
+	if cr.client != nil {
+		capabilities := cr.capabilities()
+		if !slices.Contains(capabilities, capability) {
+			capabilities = append(capabilities, capability)
+		}
+		if err := cr.client.SetCustomCapabilities(&protobufs.CustomCapabilities{
+			Capabilities: capabilities,
+		}); err != nil {
+			// Roll back so a failed advertisement does not leave a
+			// dangling registration.
+			capabilityList.Remove(callbackElem)
+			if capabilityList.Front() == nil {
+				delete(cr.capabilityToMsgChannels, capability)
+			}
+			return nil, fmt.Errorf("set custom capabilities: %w", err)
+		}
+	}
+
 	unregisterFunc := cr.removeCapabilityFunc(capability, callbackElem)
-	sender := newCustomMessageHandler(cr, cr.client, capability, msgChan, unregisterFunc)
+	sender := newCustomMessageHandler(cr, capability, msgChan, unregisterFunc)
 
 	return sender, nil
 }
@@ -183,7 +204,6 @@ type customMessageHandler struct {
 	unregisteredMux *sync.Mutex
 
 	capability               string
-	opampClient              CustomCapabilityClient
 	registry                 *customCapabilityRegistry
 	sendChan                 <-chan *protobufs.CustomMessage
 	unregisterCapabilityFunc func()
@@ -195,7 +215,6 @@ var _ opampcustommessages.CustomCapabilityHandler = (*customMessageHandler)(nil)
 
 func newCustomMessageHandler(
 	registry *customCapabilityRegistry,
-	opampClient CustomCapabilityClient,
 	capability string,
 	sendChan <-chan *protobufs.CustomMessage,
 	unregisterCapabilityFunc func(),
@@ -204,7 +223,6 @@ func newCustomMessageHandler(
 		unregisteredMux: &sync.Mutex{},
 
 		capability:               capability,
-		opampClient:              opampClient,
 		registry:                 registry,
 		sendChan:                 sendChan,
 		unregisterCapabilityFunc: unregisterCapabilityFunc,
@@ -216,7 +234,9 @@ func (c *customMessageHandler) Message() <-chan *protobufs.CustomMessage {
 	return c.sendChan
 }
 
-// SendMessage implements CustomCapabilityHandler.SendMessage
+// SendMessage implements CustomCapabilityHandler.SendMessage. The client is
+// looked up through the registry at send time so that a handler obtained
+// before the client was supplied still works once setClient has been called.
 func (c *customMessageHandler) SendMessage(messageType string, message []byte) (messageSendingChannel chan struct{}, err error) {
 	c.unregisteredMux.Lock()
 	defer c.unregisteredMux.Unlock()
@@ -225,13 +245,21 @@ func (c *customMessageHandler) SendMessage(messageType string, message []byte) (
 		return nil, errors.New("capability has already been unregistered")
 	}
 
+	c.registry.mux.Lock()
+	client := c.registry.client
+	c.registry.mux.Unlock()
+
+	if client == nil {
+		return nil, ErrClientNotSet
+	}
+
 	cm := &protobufs.CustomMessage{
 		Capability: c.capability,
 		Type:       messageType,
 		Data:       message,
 	}
 
-	return c.opampClient.SendCustomMessage(cm)
+	return client.SendCustomMessage(cm)
 }
 
 // Unregister implements CustomCapabilityHandler.Unregister

--- a/internal/extension/opampconnectionextension/registry.go
+++ b/internal/extension/opampconnectionextension/registry.go
@@ -37,11 +37,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages"
 )
 
-// CustomCapabilityClient is the subset of the OpAMP client used by
-// customCapabilityRegistry. It is exported so that the owner of the OpAMP
-// connection can implement it to intercept calls (for example to merge in
-// additional capabilities) before delegating to the real client.
-type CustomCapabilityClient interface {
+// Client is the subset of the OpAMP client used by customCapabilityRegistry.
+// It is exported so that the owner of the OpAMP connection can implement it
+// to intercept calls (for example to merge in additional capabilities)
+// before delegating to the real client.
+type Client interface {
 	SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error
 	SendCustomMessage(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error)
 }
@@ -49,7 +49,7 @@ type CustomCapabilityClient interface {
 type customCapabilityRegistry struct {
 	mux                     *sync.Mutex
 	capabilityToMsgChannels map[string]*list.List
-	client                  CustomCapabilityClient
+	client                  Client
 	logger                  *zap.Logger
 }
 
@@ -66,7 +66,7 @@ func newCustomCapabilityRegistry(logger *zap.Logger) *customCapabilityRegistry {
 // setClient supplies the underlying OpAMP client to the registry. Any
 // capabilities that were Registered before the client was supplied are
 // advertised to the server now.
-func (cr *customCapabilityRegistry) setClient(c CustomCapabilityClient) {
+func (cr *customCapabilityRegistry) setClient(c Client) {
 	cr.mux.Lock()
 	defer cr.mux.Unlock()
 	cr.client = c

--- a/internal/extension/opampconnectionextension/registry.go
+++ b/internal/extension/opampconnectionextension/registry.go
@@ -1,0 +1,245 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is roughly equivalent to registry.go in the opampextension
+// package of opentelemetry-collector-contrib
+// (github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension).
+// It is kept deliberately close to that file so that the two
+// implementations can be compared and kept in sync. The main difference is
+// that the underlying OpAMP client is supplied after construction via
+// setClient, because in this distribution the OpAMP connection is owned by
+// the opamp package rather than the extension itself.
+
+package opampconnectionextension
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages"
+)
+
+// CustomCapabilityClient is the subset of the OpAMP client used by
+// customCapabilityRegistry. It is exported so that the owner of the OpAMP
+// connection can implement it to intercept calls (for example to merge in
+// additional capabilities) before delegating to the real client.
+type CustomCapabilityClient interface {
+	SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error
+	SendCustomMessage(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error)
+}
+
+type customCapabilityRegistry struct {
+	mux                     *sync.Mutex
+	capabilityToMsgChannels map[string]*list.List
+	client                  CustomCapabilityClient
+	logger                  *zap.Logger
+}
+
+var _ opampcustommessages.CustomCapabilityRegistry = (*customCapabilityRegistry)(nil)
+
+func newCustomCapabilityRegistry(logger *zap.Logger) *customCapabilityRegistry {
+	return &customCapabilityRegistry{
+		mux:                     &sync.Mutex{},
+		capabilityToMsgChannels: make(map[string]*list.List),
+		logger:                  logger,
+	}
+}
+
+// setClient supplies the underlying OpAMP client to the registry. It must be
+// called before any component attempts to Register a capability.
+func (cr *customCapabilityRegistry) setClient(c CustomCapabilityClient) {
+	cr.mux.Lock()
+	defer cr.mux.Unlock()
+	cr.client = c
+}
+
+// Register implements CustomCapabilityRegistry.Register
+func (cr *customCapabilityRegistry) Register(capability string, opts ...opampcustommessages.CustomCapabilityRegisterOption) (opampcustommessages.CustomCapabilityHandler, error) {
+	optsStruct := opampcustommessages.DefaultCustomCapabilityRegisterOptions()
+	for _, opt := range opts {
+		opt(optsStruct)
+	}
+
+	cr.mux.Lock()
+	defer cr.mux.Unlock()
+
+	if cr.client == nil {
+		return nil, ErrClientNotSet
+	}
+
+	capabilities := cr.capabilities()
+	if !slices.Contains(capabilities, capability) {
+		capabilities = append(capabilities, capability)
+	}
+
+	err := cr.client.SetCustomCapabilities(&protobufs.CustomCapabilities{
+		Capabilities: capabilities,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("set custom capabilities: %w", err)
+	}
+
+	capabilityList := cr.capabilityToMsgChannels[capability]
+	if capabilityList == nil {
+		capabilityList = list.New()
+		cr.capabilityToMsgChannels[capability] = capabilityList
+	}
+
+	msgChan := make(chan *protobufs.CustomMessage, optsStruct.MaxQueuedMessages)
+	callbackElem := capabilityList.PushBack(msgChan)
+
+	unregisterFunc := cr.removeCapabilityFunc(capability, callbackElem)
+	sender := newCustomMessageHandler(cr, cr.client, capability, msgChan, unregisterFunc)
+
+	return sender, nil
+}
+
+// ProcessMessage processes a custom message, asynchronously broadcasting it to all registered capability handlers for
+// the messages capability.
+func (cr customCapabilityRegistry) ProcessMessage(cm *protobufs.CustomMessage) {
+	cr.mux.Lock()
+	defer cr.mux.Unlock()
+
+	msgChannels, ok := cr.capabilityToMsgChannels[cm.Capability]
+	if !ok {
+		return
+	}
+
+	for node := msgChannels.Front(); node != nil; node = node.Next() {
+		msgChan, ok := node.Value.(chan *protobufs.CustomMessage)
+		if !ok {
+			continue
+		}
+
+		// If the channel is full, we will skip sending the message to the receiver.
+		// We do this because we don't want a misbehaving component to be able to
+		// block the opamp extension, or block other components from receiving messages.
+		select {
+		case msgChan <- cm:
+		default:
+		}
+	}
+}
+
+// removeCapabilityFunc returns a func that removes the custom capability with the given msg channel list element and sender,
+// then recalculates and sets the list of custom capabilities on the OpAMP client.
+func (cr *customCapabilityRegistry) removeCapabilityFunc(capability string, callbackElement *list.Element) func() {
+	return func() {
+		cr.mux.Lock()
+		defer cr.mux.Unlock()
+
+		msgChanList := cr.capabilityToMsgChannels[capability]
+		msgChanList.Remove(callbackElement)
+
+		if msgChanList.Front() == nil {
+			// Since there are no more callbacks for this capability,
+			// this capability is no longer supported
+			delete(cr.capabilityToMsgChannels, capability)
+		}
+
+		if cr.client == nil {
+			return
+		}
+
+		capabilities := cr.capabilities()
+		err := cr.client.SetCustomCapabilities(&protobufs.CustomCapabilities{
+			Capabilities: capabilities,
+		})
+		if err != nil {
+			// It's OK if we couldn't actually remove the capability, it just means we won't
+			// notify the server properly, and the server may send us messages that we have no associated callbacks for.
+			cr.logger.Error("Failed to set new capabilities", zap.Error(err))
+		}
+	}
+}
+
+// capabilities gives the current set of custom capabilities with at least one
+// callback registered.
+func (cr *customCapabilityRegistry) capabilities() []string {
+	return maps.Keys(cr.capabilityToMsgChannels)
+}
+
+type customMessageHandler struct {
+	// unregisteredMux protects unregistered, and makes sure that a message cannot be sent
+	// on an unregistered capability.
+	unregisteredMux *sync.Mutex
+
+	capability               string
+	opampClient              CustomCapabilityClient
+	registry                 *customCapabilityRegistry
+	sendChan                 <-chan *protobufs.CustomMessage
+	unregisterCapabilityFunc func()
+
+	unregistered bool
+}
+
+var _ opampcustommessages.CustomCapabilityHandler = (*customMessageHandler)(nil)
+
+func newCustomMessageHandler(
+	registry *customCapabilityRegistry,
+	opampClient CustomCapabilityClient,
+	capability string,
+	sendChan <-chan *protobufs.CustomMessage,
+	unregisterCapabilityFunc func(),
+) *customMessageHandler {
+	return &customMessageHandler{
+		unregisteredMux: &sync.Mutex{},
+
+		capability:               capability,
+		opampClient:              opampClient,
+		registry:                 registry,
+		sendChan:                 sendChan,
+		unregisterCapabilityFunc: unregisterCapabilityFunc,
+	}
+}
+
+// Message implements CustomCapabilityHandler.Message
+func (c *customMessageHandler) Message() <-chan *protobufs.CustomMessage {
+	return c.sendChan
+}
+
+// SendMessage implements CustomCapabilityHandler.SendMessage
+func (c *customMessageHandler) SendMessage(messageType string, message []byte) (messageSendingChannel chan struct{}, err error) {
+	c.unregisteredMux.Lock()
+	defer c.unregisteredMux.Unlock()
+
+	if c.unregistered {
+		return nil, errors.New("capability has already been unregistered")
+	}
+
+	cm := &protobufs.CustomMessage{
+		Capability: c.capability,
+		Type:       messageType,
+		Data:       message,
+	}
+
+	return c.opampClient.SendCustomMessage(cm)
+}
+
+// Unregister implements CustomCapabilityHandler.Unregister
+func (c *customMessageHandler) Unregister() {
+	c.unregisteredMux.Lock()
+	defer c.unregisteredMux.Unlock()
+
+	c.unregistered = true
+
+	c.unregisterCapabilityFunc()
+}

--- a/internal/extension/opampconnectionextension/registry_test.go
+++ b/internal/extension/opampconnectionextension/registry_test.go
@@ -1,0 +1,322 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is roughly equivalent to registry_test.go in the opampextension
+// package of opentelemetry-collector-contrib. It is kept deliberately close
+// to that file so the two implementations can be compared and kept in sync.
+// The main deltas are: the registry is constructed without a client and the
+// client is supplied later via setClient, and there is an additional test
+// verifying that Register returns ErrClientNotSet before setClient is
+// called.
+
+package opampconnectionextension
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestRegistry_Register(t *testing.T) {
+	t.Run("Registers successfully", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+
+		client := mockCustomCapabilityClient{
+			setCustomCapabilities: func(customCapabilities *protobufs.CustomCapabilities) error {
+				require.Equal(t,
+					&protobufs.CustomCapabilities{
+						Capabilities: []string{capabilityString},
+					},
+					customCapabilities)
+				return nil
+			},
+		}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		sender, err := registry.Register(capabilityString)
+		require.NoError(t, err)
+		require.NotNil(t, sender)
+	})
+
+	t.Run("Setting capabilities fails", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		capabilityErr := errors.New("network error")
+
+		client := mockCustomCapabilityClient{
+			setCustomCapabilities: func(_ *protobufs.CustomCapabilities) error {
+				return capabilityErr
+			},
+		}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		sender, err := registry.Register(capabilityString)
+		require.Nil(t, sender)
+		require.ErrorIs(t, err, capabilityErr)
+		require.Empty(t, registry.capabilityToMsgChannels, "Setting capability failed, but callback ended up in the map anyways")
+	})
+
+	t.Run("Register before client is set returns ErrClientNotSet", func(t *testing.T) {
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+
+		sender, err := registry.Register("io.opentelemetry.teapot")
+		require.Nil(t, sender)
+		require.ErrorIs(t, err, ErrClientNotSet)
+		require.Empty(t, registry.capabilityToMsgChannels)
+	})
+}
+
+func TestRegistry_ProcessMessage(t *testing.T) {
+	t.Run("Calls registered callback", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "steep"
+		messageBytes := []byte("blackTea")
+		customMessage := &protobufs.CustomMessage{
+			Capability: capabilityString,
+			Type:       messageType,
+			Data:       messageBytes,
+		}
+
+		client := mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		sender, err := registry.Register(capabilityString)
+		require.NotNil(t, sender)
+		require.NoError(t, err)
+
+		registry.ProcessMessage(customMessage)
+
+		require.Equal(t, customMessage, <-sender.Message())
+	})
+
+	t.Run("Skips blocked message channels", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "steep"
+		messageBytes := []byte("blackTea")
+		customMessage := &protobufs.CustomMessage{
+			Capability: capabilityString,
+			Type:       messageType,
+			Data:       messageBytes,
+		}
+
+		client := mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		sender, err := registry.Register(capabilityString, opampcustommessages.WithMaxQueuedMessages(0))
+		require.NotNil(t, sender)
+		require.NoError(t, err)
+
+		// If we did not skip sending on blocked channels, we'd expect this to never return.
+		registry.ProcessMessage(customMessage)
+
+		require.Empty(t, sender.Message())
+	})
+
+	t.Run("Callback is called only for its own capability", func(t *testing.T) {
+		teapotCapabilityString1 := "io.opentelemetry.teapot"
+		coffeeMakerCapabilityString2 := "io.opentelemetry.coffeeMaker"
+
+		messageType1 := "steep"
+		messageBytes1 := []byte("blackTea")
+
+		messageType2 := "brew"
+		messageBytes2 := []byte("blackCoffee")
+
+		customMessageSteep := &protobufs.CustomMessage{
+			Capability: teapotCapabilityString1,
+			Type:       messageType1,
+			Data:       messageBytes1,
+		}
+
+		customMessageBrew := &protobufs.CustomMessage{
+			Capability: coffeeMakerCapabilityString2,
+			Type:       messageType2,
+			Data:       messageBytes2,
+		}
+
+		client := mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		teapotSender, err := registry.Register(teapotCapabilityString1)
+		require.NotNil(t, teapotSender)
+		require.NoError(t, err)
+
+		coffeeMakerSender, err := registry.Register(coffeeMakerCapabilityString2)
+		require.NotNil(t, coffeeMakerSender)
+		require.NoError(t, err)
+
+		registry.ProcessMessage(customMessageSteep)
+		registry.ProcessMessage(customMessageBrew)
+
+		require.Equal(t, customMessageSteep, <-teapotSender.Message())
+		require.Empty(t, teapotSender.Message())
+		require.Equal(t, customMessageBrew, <-coffeeMakerSender.Message())
+		require.Empty(t, coffeeMakerSender.Message())
+	})
+}
+
+func TestCustomCapability_SendMessage(t *testing.T) {
+	t.Run("Sends message", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "brew"
+		messageBytes := []byte("black")
+
+		client := mockCustomCapabilityClient{
+			sendCustomMessage: func(message *protobufs.CustomMessage) (chan struct{}, error) {
+				require.Equal(t, &protobufs.CustomMessage{
+					Capability: capabilityString,
+					Type:       messageType,
+					Data:       messageBytes,
+				}, message)
+				return nil, nil
+			},
+		}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		sender, err := registry.Register(capabilityString)
+		require.NoError(t, err)
+		require.NotNil(t, sender)
+
+		channel, err := sender.SendMessage(messageType, messageBytes)
+		require.NoError(t, err)
+		require.Nil(t, channel)
+	})
+}
+
+func TestCustomCapability_Unregister(t *testing.T) {
+	t.Run("Unregistered capability callback is no longer called", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "steep"
+		messageBytes := []byte("blackTea")
+		customMessage := &protobufs.CustomMessage{
+			Capability: capabilityString,
+			Type:       messageType,
+			Data:       messageBytes,
+		}
+
+		client := mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		unregisteredSender, err := registry.Register(capabilityString)
+		require.NotNil(t, unregisteredSender)
+		require.NoError(t, err)
+
+		unregisteredSender.Unregister()
+
+		registry.ProcessMessage(customMessage)
+
+		select {
+		case <-unregisteredSender.Message():
+			t.Fatalf("Unregistered capability should not be called")
+		default: // OK
+		}
+	})
+
+	t.Run("Unregister is successful even if set capabilities fails", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "steep"
+		messageBytes := []byte("blackTea")
+		customMessage := &protobufs.CustomMessage{
+			Capability: capabilityString,
+			Type:       messageType,
+			Data:       messageBytes,
+		}
+
+		client := &mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		unregisteredSender, err := registry.Register(capabilityString)
+		require.NotNil(t, unregisteredSender)
+		require.NoError(t, err)
+
+		client.setCustomCapabilities = func(_ *protobufs.CustomCapabilities) error {
+			return errors.New("failed to set capabilities")
+		}
+
+		unregisteredSender.Unregister()
+
+		registry.ProcessMessage(customMessage)
+
+		select {
+		case <-unregisteredSender.Message():
+			t.Fatalf("Unregistered capability should not be called")
+		default: // OK
+		}
+	})
+
+	t.Run("Does not send if unregistered", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+		messageType := "steep"
+		messageBytes := []byte("blackTea")
+
+		client := mockCustomCapabilityClient{}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+		registry.setClient(client)
+
+		unregisteredSender, err := registry.Register(capabilityString)
+		require.NotNil(t, unregisteredSender)
+		require.NoError(t, err)
+
+		unregisteredSender.Unregister()
+
+		_, err = unregisteredSender.SendMessage(messageType, messageBytes)
+		require.ErrorContains(t, err, "capability has already been unregistered")
+
+		select {
+		case <-unregisteredSender.Message():
+			t.Fatalf("Unregistered capability should not be called")
+		default: // OK
+		}
+	})
+}
+
+type mockCustomCapabilityClient struct {
+	sendCustomMessage     func(message *protobufs.CustomMessage) (chan struct{}, error)
+	setCustomCapabilities func(customCapabilities *protobufs.CustomCapabilities) error
+}
+
+func (m mockCustomCapabilityClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
+	if m.setCustomCapabilities != nil {
+		return m.setCustomCapabilities(customCapabilities)
+	}
+	return nil
+}
+
+func (m mockCustomCapabilityClient) SendCustomMessage(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error) {
+	if m.sendCustomMessage != nil {
+		return m.sendCustomMessage(message)
+	}
+
+	return make(chan struct{}), nil
+}

--- a/internal/extension/opampconnectionextension/registry_test.go
+++ b/internal/extension/opampconnectionextension/registry_test.go
@@ -16,9 +16,9 @@
 // package of opentelemetry-collector-contrib. It is kept deliberately close
 // to that file so the two implementations can be compared and kept in sync.
 // The main deltas are: the registry is constructed without a client and the
-// client is supplied later via setClient, and there is an additional test
-// verifying that Register returns ErrClientNotSet before setClient is
-// called.
+// client is supplied later via setClient; there are additional tests
+// covering the deferred-advertise behavior when Register is called before
+// setClient, and that SendMessage returns ErrClientNotSet in that window.
 
 package opampconnectionextension
 
@@ -74,13 +74,43 @@ func TestRegistry_Register(t *testing.T) {
 		require.Empty(t, registry.capabilityToMsgChannels, "Setting capability failed, but callback ended up in the map anyways")
 	})
 
-	t.Run("Register before client is set returns ErrClientNotSet", func(t *testing.T) {
+	t.Run("Register before client is set defers advertisement", func(t *testing.T) {
+		capabilityString := "io.opentelemetry.teapot"
+
+		var advertised []*protobufs.CustomCapabilities
+		client := mockCustomCapabilityClient{
+			setCustomCapabilities: func(customCapabilities *protobufs.CustomCapabilities) error {
+				advertised = append(advertised, customCapabilities)
+				return nil
+			},
+		}
+
+		registry := newCustomCapabilityRegistry(zap.NewNop())
+
+		// Register before the client is supplied — Register should succeed
+		// and the capability should NOT be advertised yet.
+		sender, err := registry.Register(capabilityString)
+		require.NoError(t, err)
+		require.NotNil(t, sender)
+		require.Empty(t, advertised, "no advertisement should happen before setClient")
+
+		// Supplying the client flushes the accumulated capabilities.
+		registry.setClient(client)
+		require.Equal(t,
+			[]*protobufs.CustomCapabilities{{Capabilities: []string{capabilityString}}},
+			advertised,
+		)
+	})
+
+	t.Run("SendMessage before client is set returns ErrClientNotSet", func(t *testing.T) {
 		registry := newCustomCapabilityRegistry(zap.NewNop())
 
 		sender, err := registry.Register("io.opentelemetry.teapot")
-		require.Nil(t, sender)
+		require.NoError(t, err)
+		require.NotNil(t, sender)
+
+		_, err = sender.SendMessage("brew", []byte("black"))
 		require.ErrorIs(t, err, ErrClientNotSet)
-		require.Empty(t, registry.capabilityToMsgChannels)
 	})
 }
 


### PR DESCRIPTION
## Summary

Introduces `internal/extension/opampconnectionextension`, an extension that implements `opampcustommessages.CustomCapabilityRegistry` so components in this distribution can register custom capabilities and exchange custom OpAMP messages over the connection owned by the `opamp` package. Registers its factory in `factories/extensions.go`.

The implementation mirrors upstream [opampextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension) as closely as possible — see the comment at the top of `registry.go` — with two deliberate differences:

- The underlying OpAMP client is supplied after `Start` via `SetClient`, since in this distribution the OpAMP connection is owned by `opamp/observiq`. A small `CustomCapabilityClient` subset interface lets the owner intercept `SetCustomCapabilities` (used in BPOP-4971 to merge in hardcoded capabilities).
- Only a single `opamp_connection` extension may be configured per collector (enforced in `Start`). Package-level `GetRegistry` / `ForEachInstance` let the owner wire its client in without needing the component ID up front.

This PR only adds the extension and registers its factory. The opamp-package wiring (making `*observiq.Client` implement `CustomCapabilityClient`, calling `SetClient` / `ProcessMessage`) is a separate stacked PR for BPOP-4971.

Linear: https://linear.app/bindplane/issue/BPOP-4970

## Test plan

- [x] `TestExtension_Start_RejectsSecondInstance`
- [x] `TestExtension_Shutdown_AllowsSubsequentStart`
- [x] `TestGetRegistry`, `TestForEachInstance`
- [x] Registry tests mirror upstream `opampextension`: `TestRegistry_Register`, `TestRegistry_ProcessMessage`, `TestCustomCapability_SendMessage`, `TestCustomCapability_Unregister`
- [x] Additional `Register` pre-SetClient returns `ErrClientNotSet`