### PR TITLE
feat(opamp): wire up opampconnectionextension (BPOP-4971)

### DIFF
--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -293,18 +293,18 @@ func (c *Client) Connect(ctx context.Context) error {
 	// Now that collector has successfully started kick off monitoring
 	c.startCollectorMonitoring(ctx)
 
-	// Wire the OpAMP client into any opamp_connection extensions that were
+	// Wire the OpAMP client into the opamp_connection extension if one was
 	// started by the collector. This must happen after the collector has
-	// started (so the extensions have registered themselves) and before the
-	// OpAMP client starts (so the extensions can advertise custom
-	// capabilities as soon as components register them).
+	// started (so the extension has registered itself) and before the OpAMP
+	// client starts (so the extension can advertise custom capabilities as
+	// soon as components register them).
 	//
 	// The Client itself is passed as the underlying CustomCapabilityClient
 	// so that SetCustomCapabilities can intercept and merge in the
 	// hardcoded capabilities.
-	opampconnectionextension.ForEachInstance(func(r opampconnectionextension.Registry) {
+	if r := opampconnectionextension.GetRegistry(); r != nil {
 		r.SetClient(c)
-	})
+	}
 
 	err = c.opampClient.Start(ctx, settings)
 	if err != nil {
@@ -450,9 +450,9 @@ func (c *Client) onMessageFuncHandler(ctx context.Context, msg *types.MessageDat
 		}
 	}
 	if msg.CustomMessage != nil {
-		opampconnectionextension.ForEachInstance(func(r opampconnectionextension.Registry) {
+		if r := opampconnectionextension.GetRegistry(); r != nil {
 			r.ProcessMessage(msg.CustomMessage)
-		})
+		}
 	}
 	if msg.CustomCapabilities != nil {
 		if slices.Contains(msg.CustomCapabilities.Capabilities, measurements.ReportMeasurementsV1Capability) {

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -56,8 +56,8 @@ const capabilities = protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus
 
 // Ensure interface is satisfied
 var (
-	_ opamp.Client                                    = (*Client)(nil)
-	_ opampconnectionextension.CustomCapabilityClient = (*Client)(nil)
+	_ opamp.Client                    = (*Client)(nil)
+	_ opampconnectionextension.Client = (*Client)(nil)
 )
 
 // hardcodedCustomCapabilities are the custom capabilities that this client
@@ -299,9 +299,9 @@ func (c *Client) Connect(ctx context.Context) error {
 	// client starts (so the extension can advertise custom capabilities as
 	// soon as components register them).
 	//
-	// The Client itself is passed as the underlying CustomCapabilityClient
-	// so that SetCustomCapabilities can intercept and merge in the
-	// hardcoded capabilities.
+	// The Client itself is passed as the underlying
+	// opampconnectionextension.Client so that SetCustomCapabilities can
+	// intercept and merge in the hardcoded capabilities.
 	if r := opampconnectionextension.GetRegistry(); r != nil {
 		r.SetClient(c)
 	}
@@ -334,7 +334,7 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	return c.opampClient.Stop(ctx)
 }
 
-// SetCustomCapabilities implements opampconnectionextension.CustomCapabilityClient.
+// SetCustomCapabilities implements opampconnectionextension.Client.
 //
 // It merges the supplied capabilities with the set that this client always
 // advertises (see hardcodedCustomCapabilities) and forwards the merged list
@@ -353,7 +353,7 @@ func (c *Client) SetCustomCapabilities(customCapabilities *protobufs.CustomCapab
 	})
 }
 
-// SendCustomMessage implements opampconnectionextension.CustomCapabilityClient.
+// SendCustomMessage implements opampconnectionextension.Client.
 func (c *Client) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
 	return c.opampClient.SendCustomMessage(message)
 }

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/observiq/bindplane-otel-collector/collector"
+	"github.com/observiq/bindplane-otel-collector/internal/extension/opampconnectionextension"
 	"github.com/observiq/bindplane-otel-collector/internal/report"
 	"github.com/observiq/bindplane-otel-collector/opamp"
 	"github.com/observiq/bindplane-otel-collector/packagestate"
@@ -54,7 +55,20 @@ const capabilities = protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus
 	protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat
 
 // Ensure interface is satisfied
-var _ opamp.Client = (*Client)(nil)
+var (
+	_ opamp.Client                                    = (*Client)(nil)
+	_ opampconnectionextension.CustomCapabilityClient = (*Client)(nil)
+)
+
+// hardcodedCustomCapabilities are the custom capabilities that this client
+// always advertises to the OpAMP server regardless of what components have
+// registered via an opamp_connection extension. The observiq client's
+// measurements and topology senders rely on the server knowing about these
+// capabilities even when no component has explicitly registered them.
+var hardcodedCustomCapabilities = []string{
+	measurements.ReportMeasurementsV1Capability,
+	topologyprocessor.ReportTopologyCapability,
+}
 
 // Client represents a client that is connected to Iris via OpAmp
 type Client struct {
@@ -154,12 +168,11 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		return nil, ErrUnsupportedURL
 	}
 
-	err = observiqClient.opampClient.SetCustomCapabilities(&protobufs.CustomCapabilities{
-		Capabilities: []string{
-			measurements.ReportMeasurementsV1Capability,
-			topologyprocessor.ReportTopologyCapability,
-		},
-	})
+	// Advertise the hardcoded custom capabilities. Any additional
+	// capabilities that components register via an opamp_connection
+	// extension will be merged on top of these by the Client's own
+	// SetCustomCapabilities method.
+	err = observiqClient.SetCustomCapabilities(&protobufs.CustomCapabilities{})
 	if err != nil {
 		return nil, fmt.Errorf("error setting custom capabilities: %w", err)
 	}
@@ -280,6 +293,19 @@ func (c *Client) Connect(ctx context.Context) error {
 	// Now that collector has successfully started kick off monitoring
 	c.startCollectorMonitoring(ctx)
 
+	// Wire the OpAMP client into any opamp_connection extensions that were
+	// started by the collector. This must happen after the collector has
+	// started (so the extensions have registered themselves) and before the
+	// OpAMP client starts (so the extensions can advertise custom
+	// capabilities as soon as components register them).
+	//
+	// The Client itself is passed as the underlying CustomCapabilityClient
+	// so that SetCustomCapabilities can intercept and merge in the
+	// hardcoded capabilities.
+	opampconnectionextension.ForEachInstance(func(r opampconnectionextension.Registry) {
+		r.SetClient(c)
+	})
+
 	err = c.opampClient.Start(ctx, settings)
 	if err != nil {
 		// Set package status file for error (for Updater to pick up), but do not force send to Server
@@ -306,6 +332,30 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	}
 
 	return c.opampClient.Stop(ctx)
+}
+
+// SetCustomCapabilities implements opampconnectionextension.CustomCapabilityClient.
+//
+// It merges the supplied capabilities with the set that this client always
+// advertises (see hardcodedCustomCapabilities) and forwards the merged list
+// to the underlying OpAMP client. This lets the opamp_connection
+// extension's registry request its own capability set without clobbering
+// the measurements and topology capabilities the observiq client requires.
+func (c *Client) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
+	merged := append([]string(nil), customCapabilities.GetCapabilities()...)
+	for _, capability := range hardcodedCustomCapabilities {
+		if !slices.Contains(merged, capability) {
+			merged = append(merged, capability)
+		}
+	}
+	return c.opampClient.SetCustomCapabilities(&protobufs.CustomCapabilities{
+		Capabilities: merged,
+	})
+}
+
+// SendCustomMessage implements opampconnectionextension.CustomCapabilityClient.
+func (c *Client) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
+	return c.opampClient.SendCustomMessage(message)
 }
 
 // client callbacks
@@ -398,6 +448,11 @@ func (c *Client) onMessageFuncHandler(ctx context.Context, msg *types.MessageDat
 		if err := c.onAgentIdentificationHandler(ctx, msg.AgentIdentification); err != nil {
 			c.logger.Error("Error while processing Agent Identification Change", zap.Error(err))
 		}
+	}
+	if msg.CustomMessage != nil {
+		opampconnectionextension.ForEachInstance(func(r opampconnectionextension.Registry) {
+			r.ProcessMessage(msg.CustomMessage)
+		})
 	}
 	if msg.CustomCapabilities != nil {
 		if slices.Contains(msg.CustomCapabilities.Capabilities, measurements.ReportMeasurementsV1Capability) {


### PR DESCRIPTION
## Summary

Wires the `opamp_connection` extension (added in #3447) into the v1 OpAMP client so that components configured with it actually see the collector's OpAMP connection.

- `*observiq.Client` now implements `opampconnectionextension.CustomCapabilityClient`. Its `SetCustomCapabilities` merges the caller-supplied capability set with the hardcoded v1 capabilities (`measurements.ReportMeasurementsV1Capability`, `topologyprocessor.ReportTopologyCapability`) so there is a single path through to the underlying opamp client. The existing hardcoded advertisement in `NewClient` is routed through this method.
- After `collector.Run` (extensions have Started and registered themselves) but before `opampClient.Start` (first AgentToServer), `Connect` iterates `ForEachInstance` and calls `SetClient(c)` on each registered extension.
- `onMessageFuncHandler` forwards `msg.CustomMessage` to every registered extension via `ForEachInstance` → `ProcessMessage`.

Stacked on #3447 — merge that first.

Linear: https://linear.app/bindplane/issue/BPOP-4971

## Test plan

- [ ] Existing opamp/observiq tests still pass
- [ ] Manual: configure a collector with `opamp_connection` + a custom-message-using component, verify capability is advertised and messages flow both directions