### PR TITLE
chore: gitignore Claude Code per-user local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ perf-test/
 
 # OCSF Schema files
 ocsf_schema.json
+
+# Claude Code per-user local settings
+.claude/settings.local.json


### PR DESCRIPTION
### Proposed Change
Add `.claude/settings.local.json` to `.gitignore`. This file holds per-user Claude Code settings (tool allow/deny lists, etc.) and should not be committed — it appeared as untracked in every status check.

##### Checklist
- [x] Changes are tested
- [x] CI has passed