### PR TITLE
fix(ci): remove undeclared pr_labels input from notifications caller

### DIFF
--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -21,7 +21,6 @@ jobs:
     with:
       comment_body: ${{ github.event.comment.body }}
       pr_api_url: ${{ github.event.issue.pull_request.url }}
-      pr_labels: ${{ toJSON(github.event.issue.labels) }}
       comment_id: ${{ github.event.comment.id }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.ORG_IRIS_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- The `pr-notify` job in `.github/workflows/pr-notifications.yml` was passing a `pr_labels` input to `observIQ/gha-workflows/.github/workflows/reusable-slack-pr-notify.yml@main`, but that reusable workflow's `workflow_call` only declares `comment_body`, `pr_api_url`, `comment_id`, and `bot_name`.
- GitHub Actions rejects the whole workflow at evaluation time when a caller passes an undeclared input, which is why every recent run shows 0s duration and "This run likely failed because of a workflow file issue" — for all events, not just `issue_comment`.
- Example failing run: https://github.com/observIQ/bindplane-otel-collector/actions/runs/24724646096
