### PR TITLE
feat: Invert install script interactivity, allow skipping signature verification

### DIFF
--- a/scripts/install/install_windows.ps1
+++ b/scripts/install/install_windows.ps1
@@ -42,8 +42,8 @@
 .PARAMETER Clean
     Set to "1" to remove existing configuration on install. Default is "0".
 
-.PARAMETER Interactive
-    Show the installer UI instead of running silently.
+.PARAMETER Quiet
+    Run the installer silently instead of showing the installer UI.
 
 .PARAMETER Uninstall
     Uninstall the agent instead of installing it.
@@ -54,13 +54,16 @@
 .PARAMETER MsiFile
     Path to a local MSI file to install. Skips all download and version resolution steps.
 
+.PARAMETER SkipSignatureCheck
+    Skip MSI Authenticode signature verification.
+
 .EXAMPLE
     .\install_windows.ps1 -Version "1.94.0" -EnableManagement "1" `
         -OpAMPEndpoint "<your_endpoint>" `
         -OpAMPSecretKey "<secret-key>"
 
 .EXAMPLE
-    .\install_windows.ps1 -Version "1.94.0" -Interactive
+    .\install_windows.ps1 -Version "1.94.0" -Quiet
 
 .EXAMPLE
     .\install_windows.ps1 -Uninstall
@@ -98,10 +101,13 @@ param(
     [string]$MsiFile,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Interactive,
+    [switch]$Quiet,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Uninstall
+    [switch]$Uninstall,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipSignatureCheck
 )
 
 Set-StrictMode -Version Latest
@@ -201,7 +207,7 @@ function Build-MsiexecArgs {
 
     $msiArgs += "/l*v", "`"$LogPath`""
 
-    if (-not $Interactive) {
+    if ($Quiet) {
         $msiArgs += "/quiet"
     }
 
@@ -256,7 +262,7 @@ function Invoke-Uninstall {
     Write-Info "Found product code: $productCode"
 
     $msiArgs = @("/x", $productCode)
-    if (-not $Interactive) {
+    if ($Quiet) {
         $msiArgs += "/quiet"
     }
 
@@ -321,12 +327,30 @@ function Main {
         Get-Msi -Url $resolvedUrl -Destination $msiPath
     }
 
-    $sig = Get-AuthenticodeSignature -FilePath $msiPath
-    if ($sig.Status -ne 'Valid') {
-        Fail "MSI signature verification failed: $($sig.StatusMessage)"
+    if ($SkipSignatureCheck) {
+        Write-Warn "Authenticode signature verification is being bypassed with the '-SkipSignatureCheck' flag."
+        Write-Warn "This disables a critical security check and should only be used if your organization policies permit it."
     }
-
-    Write-Info "MSI signature verification successful"
+    else {
+        $sig = Get-AuthenticodeSignature -FilePath $msiPath
+        if ($sig.Status -ne 'Valid') {
+            $sigMessage = "MSI signature verification failed: $($sig.StatusMessage)"
+            if ($Quiet) {
+                Fail "Failed to verify MSI signature: $($sig.StatusMessage). Use '-SkipSignatureCheck' to skip verification."
+            }
+            Write-Warn $sigMessage
+            Write-Warn "This may indicate: the signing certificate is not trusted on this machine, the MSI has been tampered with, the signature or certificate has expired or been revoked, or the certificate chain could not be verified (e.g., network issues reaching CRL/OCSP)."
+            Write-Warn "Continuing is NOT RECOMMENDED."
+            $response = Read-Host "Continue with unverified MSI anyway? [y/N]"
+            if ($response -notmatch '^[yY]') {
+                Fail "Aborted by user."
+            }
+            Write-Warn "Continuing with unverified MSI at user's request."
+        }
+        else {
+            Write-Info "MSI signature verification successful"
+        }
+    }
 
     $msiArgs = Build-MsiexecArgs -MsiPath $msiPath -LogPath $logPath
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This changes our BDOT Windows install script to default to interactive instead of requiring a flag to do so, adds a new -Quiet flag to make it non-interactive, and allows for the skipping of signature verification to bring this script up to parity with our Unix install scripts.

Test suite:
```
# Test commands for scripts/install/install_windows.ps1
# Target release: https://github.com/observIQ/bindplane-otel-collector/releases/tag/v1.98.0
#
# Run from an elevated PowerShell prompt in the scripts/install/ directory.
#
# This suite exercises only the recent changes:
#   - -Interactive replaced with -Quiet (interactive installer UI is now the default)
#   - -SkipSignatureCheck added, with loud WARN lines when active
#   - Authenticode failure now prompts in interactive mode, hard-fails in -Quiet mode

# =============================================================================
# Flag inversion: -Quiet vs. default interactive
# =============================================================================

# 1. -Quiet: installs silently (no UI).
.\install_windows.ps1 `
  -Version "1.98.0" `
  -EnableManagement "1" `
  -OpAMPEndpoint "wss://app.bindplane.com/v1/opamp" `
  -OpAMPSecretKey "<REDACTED>" `
  -OpAMPLabels "configuration=windows" `
  -Quiet

# 2. Default (no -Quiet): launches the MSI installer UI.
.\install_windows.ps1 `
  -Version "1.98.0" `
  -EnableManagement "1" `
  -OpAMPEndpoint "wss://app.bindplane.com/v1/opamp" `
  -OpAMPSecretKey "<REDACTED>" `
  -OpAMPLabels "configuration=windows"


# =============================================================================
# -SkipSignatureCheck: two WARN lines, then install proceeds
# =============================================================================

# 3. Expect these [WARN] lines before install starts:
#      [WARN]  Authenticode signature verification is being bypassed with the '-SkipSignatureCheck' flag.
#      [WARN]  This disables a critical security check and should only be used if your organization policies permit it.
.\install_windows.ps1 `
  -Version "1.98.0" `
  -SkipSignatureCheck `
  -Quiet


# =============================================================================
# Authenticode failure handling
# =============================================================================

# Preparation: create a tampered MSI so Authenticode verification fails.
#   # Download the v1.98.0 amd64 MSI first, then:
#   Copy-Item .\observiq-otel-collector.msi .\tampered.msi
#   $b = [System.IO.File]::ReadAllBytes(".\tampered.msi")
#   $b[100] = ($b[100] -bxor 0xFF)
#   [System.IO.File]::WriteAllBytes(".\tampered.msi", $b)

# 4. Tampered MSI with -Quiet -> hard fails with:
#    "Failed to verify MSI signature: <reason>. Use '-SkipSignatureCheck' to skip verification."
.\install_windows.ps1 `
  -MsiFile ".\tampered.msi" `
  -Quiet

# 5. Tampered MSI in interactive mode -> prints the failure message, the possible-cause blurb,
#    "Continuing is NOT RECOMMENDED.", then prompts "Continue with unverified MSI anyway? [y/N]".
#    Answer "n" -> "Aborted by user." Answer "y" -> continues install.
.\install_windows.ps1 `
  -MsiFile ".\tampered.msi"

# 6. Tampered MSI with both -SkipSignatureCheck and -Quiet -> two bypass-warning lines,
#    then install proceeds without checking the signature (msiexec may still fail at 1603
#    since the MSI file itself is damaged - that is expected).
.\install_windows.ps1 `
  -MsiFile ".\tampered.msi" `
  -SkipSignatureCheck `
  -Quiet

```

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
