### PR TITLE
chore(go): bump go mod tidy -compat to 1.25.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ fmt:
 
 .PHONY: tidy
 tidy:
-	$(MAKE) for-all CMD="go mod tidy -compat=1.25.7"
+	$(MAKE) for-all CMD="go mod tidy -compat=1.25.9"
 
 .PHONY: gosec
 gosec:

--- a/scripts/update-bindplane-contrib.sh
+++ b/scripts/update-bindplane-contrib.sh
@@ -56,7 +56,7 @@ for local_mod in $LOCAL_MODULES; do
         echo "Updating deps in $local_mod"
         cd "$local_mod"
         # go list will not work if module is not tidy, so we tidy first
-        go mod tidy -compat=1.25.7
+        go mod tidy -compat=1.25.9
 
         echo "  Tidied $local_mod"
 

--- a/scripts/update-otel.sh
+++ b/scripts/update-otel.sh
@@ -115,7 +115,7 @@ for local_mod in $LOCAL_MODULES; do
         echo "Updating deps in $local_mod"
         cd "$local_mod"
         # go list will not work if module is not tidy, so we tidy first
-        go mod tidy -compat=1.25.7
+        go mod tidy -compat=1.25.9
 
         echo "  Tidied $local_mod"
 


### PR DESCRIPTION
## Summary
- Follow-up to #3463 (Upgrade go 1.25.9): the Go bump updated `go.mod` files but left `-compat=1.25.7` in tidy invocations.
- Updates `Makefile` and the two `update-*.sh` scripts to use `-compat=1.25.9`.
- Intentionally does **not** touch `go.mod` files under directories listed in `migrated-modules.txt` (receiver/, processor/, exporter/, extension/, counter, expr, version, internal/aws, internal/azureblob, internal/blobconsume, internal/exporterutils, internal/measurements, internal/osinfo, internal/storageclient, internal/testutils).

## Test plan
- [ ] CI passes
- [ ] `make tidy` runs without compat-related complaints

🤖 Generated with [Claude Code](https://claude.com/claude-code)