### PR TITLE
feat: open AIX for public beta (PIPE-997)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,8 +307,7 @@ jobs:
             --source dist/bindplane-otel-collector_${{ github.ref_name }}_linux_ppc64.rpm
 
   # AIX release job — runs in parallel with the main release job.
-  # AIX is currently in alpha; artifacts are uploaded to GCS only.
-  # GitHub release upload is commented out until AIX exits alpha.
+  # Artifacts are uploaded to GCS and appended to the main GitHub release.
   release-aix:
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04-32x128
     steps:
@@ -357,8 +356,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           COSIGN_PWD: ${{ secrets.ORG_COSIGN_PWD }}
           GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}
-      # TODO(AIX alpha): Uncomment when AIX exits alpha to upload artifacts to the GitHub release.
-      # - name: Upload AIX artifacts to GitHub release
-      #   run: gh release upload ${{ github.ref_name }} ./dist/*tar.gz ./dist/*SHA256SUMS --clobber
-      #   env:
-      #     GH_TOKEN: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
+      - name: Upload AIX artifacts to GitHub release
+        run: gh release upload ${{ github.ref_name }} ./dist/*tar.gz ./dist/*SHA256SUMS --clobber
+        env:
+          GH_TOKEN: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}

--- a/.goreleaser-aix.yml
+++ b/.goreleaser-aix.yml
@@ -2,9 +2,7 @@
 # This is separate from the main .goreleaser.yml because AIX uses a different
 # OCB manifest (manifest-aix.yaml) with a reduced component set.
 #
-# AIX is currently in alpha status. Artifacts are uploaded to GCS for
-# direct-URL distribution to alpha testers, but are NOT published to
-# GitHub releases or included in the combined artifact archive.
+# Artifacts are uploaded to GCS and appended to the main GitHub release.
 
 version: 2
 
@@ -47,7 +45,7 @@ builds:
 # https://goreleaser.com/customization/archive/
 archives:
   - format: tar.gz
-    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - src: release_deps/plugins/*
@@ -87,13 +85,12 @@ signs:
     artifacts: all
 
 # https://goreleaser.com/customization/release/
-# AIX alpha: GitHub release is disabled. Uncomment and switch to mode: append
-# when AIX exits alpha and should be included in the main GitHub release.
+# AIX artifacts are appended to the main GitHub release created by the
+# primary goreleaser run.
 release:
-  disable: true
-  # draft: false
-  # prerelease: "true"
-  # mode: append
+  draft: false
+  prerelease: "true"
+  mode: append
 
 # https://console.cloud.google.com/storage/browser/bdot-release
 blobs:

--- a/manifests/observIQ/manifest-aix.yaml
+++ b/manifests/observIQ/manifest-aix.yaml
@@ -4,7 +4,7 @@ dist:
   module: github.com/observiq/bindplane-otel-collector
   name: bindplane-otel-collector
   description: ObservIQ's custom distro for OpenTelemetry Collector
-  version: "v2.0.0-aix-alpha.10"
+  version: "v2.0.1-beta.2"
   output_path: ./builder
 conf_resolver:
   default_uri_scheme: "env"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -435,10 +435,16 @@ setup_installation() {
 
 set_file_names() {
   _os_lower=$(echo "$OS_TYPE" | tr '[:upper:]' '[:lower:]')
-  if [ -z "$version" ]; then
-    package_file_name="${PACKAGE_NAME}_${_os_lower}_${os_arch}.${package_type}"
+  # AIX is distributed as a tar.gz; for deb/rpm the package_type doubles as the file extension.
+  if [ "$OS_TYPE" = "AIX" ]; then
+    _package_extension="tar.gz"
   else
-    package_file_name="${PACKAGE_NAME}_v${version}_${_os_lower}_${os_arch}.${package_type}"
+    _package_extension="$package_type"
+  fi
+  if [ -z "$version" ]; then
+    package_file_name="${PACKAGE_NAME}_${_os_lower}_${os_arch}.${_package_extension}"
+  else
+    package_file_name="${PACKAGE_NAME}_v${version}_${_os_lower}_${os_arch}.${_package_extension}"
   fi
   package_out_file_path="$TMP_DIR/$package_file_name"
 
@@ -550,7 +556,13 @@ set_download_urls()
     fi
 
     _os_lower=$(echo "$OS_TYPE" | tr '[:upper:]' '[:lower:]')
-    collector_download_url="$base_url/v$version/${PACKAGE_NAME}_v${version}_${_os_lower}_${os_arch}.${package_type}"
+    # AIX is distributed as a tar.gz; for deb/rpm the package_type doubles as the file extension.
+    if [ "$OS_TYPE" = "AIX" ]; then
+      _package_extension="tar.gz"
+    else
+      _package_extension="$package_type"
+    fi
+    collector_download_url="$base_url/v$version/${PACKAGE_NAME}_v${version}_${_os_lower}_${os_arch}.${_package_extension}"
   else
     collector_download_url="$url"
   fi


### PR DESCRIPTION
## Summary
- Bumps AIX OCB manifest version to match the primary manifest (`v2.0.1-beta.2`) so AIX rides the same release train.
- Enables GitHub release publishing for AIX artifacts (`mode: append`, `prerelease: "true"`) and uncomments the `gh release upload` step in `release.yml`.
- Switches the AIX archive `name_template` to underscores so the URL constructed by `install_unix.sh` resolves.
- Special-cases AIX in `install_unix.sh` (`set_file_names` + `set_download_urls`) to use `.tar.gz` for the file extension while keeping `package_type=mkssys` for control-flow branches (verify/install/service).

Tracker: PIPE-997

## Test plan
- [ ] Run `release-test` workflow against this branch; confirm AIX `.tar.gz` + SHA256SUMS land in the dist artifact bundle.
- [ ] Manually resolve a generated install URL of the form `bdot.bindplane.com/v2.0.1-beta.2/bindplane-otel-collector_v2.0.1-beta.2_aix_ppc64.tar.gz`.
- [ ] After tagging the next v2.0.1 release, confirm AIX artifacts appear on the GitHub release alongside the other platforms.
- [ ] Run the install one-liner on an AIX 7.2/7.3 host and confirm it downloads + extracts + registers the SRC subsystem cleanly.