### PR TITLE
deps: Azure Blob receiver patch for deleting blobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1045,3 +1045,5 @@ replace github.com/DataDog/datadog-agent/comp/core/delegatedauth => github.com/D
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260422143330-2a6ebda5c14e
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260422143330-2a6ebda5c14e
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver => github.com/observIQ/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.0.0-20260507185839-98c20ac26318

--- a/go.sum
+++ b/go.sum
@@ -1290,6 +1290,8 @@ github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7oOxrWo=
 github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
+github.com/observIQ/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.0.0-20260507185839-98c20ac26318 h1:8lubRlxb8D0Jg7nU06vS66ngkaTG9uQJGesSdwufx9E=
+github.com/observIQ/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.0.0-20260507185839-98c20ac26318/go.mod h1:GGuG+rJszayAUhLCS8swT+kgPAXLRGSYKC7YY3M9nUM=
 github.com/observiq/bindplane-otel-contrib/exporter/awssecuritylakeexporter v1.5.0 h1:WyWBzeN25qXt2NL5d+ECMuAv76tC8kHP2EPFBRyxFwY=
 github.com/observiq/bindplane-otel-contrib/exporter/awssecuritylakeexporter v1.5.0/go.mod h1:qWkjhP1Qj5TGDn9uvl1OWZUdbry7KXu5Tm0OFbjSnw8=
 github.com/observiq/bindplane-otel-contrib/exporter/azureblobexporter v1.5.0 h1:5J10uDBU4uhSu/DAYHA0H8HNMbWu1Pl4ipYFHNx2eGQ=
@@ -1725,8 +1727,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver v0.151.0/go.mod h1:4saUJXLlOxLTvKZj2BqUhfsgKHAZ8MHOGxbCgF5LJi4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.151.0 h1:OhXCJjSgjhqVUtrchramXg7jUkDYhqfQid50lhf++mc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.151.0/go.mod h1:+jOXUUdVXRFq+tVQsCNh9prj+8C2BkfMwm5ZzKG7sMw=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.151.0 h1:fW6j0U5Us1rJavFYG+zLCVkXPFxxL27BWQncb00eNPk=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.151.0/go.mod h1:GGuG+rJszayAUhLCS8swT+kgPAXLRGSYKC7YY3M9nUM=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.151.0 h1:n3qrmY5+8yZlJiHLH4GIr0LUGCDMxBhmQ+i4PRYTR/I=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.151.0/go.mod h1:KK/j34B6OePrUliUBf+OCAxKgdUXSUjLzYXyTSJoVYA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver v0.151.0 h1:XGEO9aZts5DzW8MX25m5OaJ3QZgWjkNtfIpQoDzW59M=


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR pulls in the patch of OTel v0.151.0 to include [this change](https://github.com/observIQ/opentelemetry-collector-contrib/pull/4728). The change adjusts the Azure Event receiver to not delete blobs when they aren't read or processed successfully.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
