### PR TITLE
chore: Fix available components script for the azureblob exporter

### DIFF
--- a/scripts/retrieve-available-components.sh
+++ b/scripts/retrieve-available-components.sh
@@ -120,7 +120,6 @@ cat go.mod | grep -E '	(go.opentelemetry.io/collector|(github.com/(open-telemetr
 
 cat go.mod | grep -E '	(go.opentelemetry.io/collector|(github.com/(open-telemetry/opentelemetry-collector-contrib|observiq/bindplane-otel-collector|observiq/bindplane-otel-contrib|observiq/observiq-otel-collector|observiq/bindplane-agent)))/exporter/' | grep -v "// indirect" | grep -v "go.opentelemetry.io/collector/exporter/exportertest" | sed -E 's/^[[:space:]]*//;s/[[:space:]]*$//' | awk -F'/' 'BEGIN {
   printf "    exporters:\n      sub_component_details:\n"
-  myMap["azureblob"] = "azure_blob"
   myMap["splunkhec"] = "splunk_hec"
   myMap["tencentcloudlogservice"] = "tencentcloud_logservice"
   myMap["alibabacloudlogservice"] = "alibabacloud_logservice"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR fixes the available components generation script to remove the custom mapping from azureblob to azure_blob for the corresponding exporter. While the upstream exporter of the same name was renamed, we use this repo's azureblob exporter, which was not renamed.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
