### PR TITLE
feat: Update manifests before release v2.0.1-beta.3

### DIFF
--- a/manifests/observIQ/manifest-aix.yaml
+++ b/manifests/observIQ/manifest-aix.yaml
@@ -4,7 +4,7 @@ dist:
   module: github.com/observiq/bindplane-otel-collector
   name: bindplane-otel-collector
   description: ObservIQ's custom distro for OpenTelemetry Collector
-  version: "v2.0.1-beta.2"
+  version: "v2.0.1-beta.3"
   output_path: ./builder
 conf_resolver:
   default_uri_scheme: "env"

--- a/manifests/observIQ/manifest-aix.yaml
+++ b/manifests/observIQ/manifest-aix.yaml
@@ -126,6 +126,6 @@ providers:
 replaces:
   # AIX patches for hostmetricsreceiver - dynamic OS check + nil guards for process scraper
   # Can be removed when upstream adds AIX support
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver => github.com/Dylan-M/opentelemetry-collector-contrib/receiver/hostmetricsreceiver 3610f19ad33cf4f53dd3577bad12bf0116be8c63
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver => github.com/observIQ/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.0.0-20260330173229-3610f19ad33c
   # AIX patches for gopsutil - can be removed when upstream merges AIX support
   - github.com/shirou/gopsutil/v4 => github.com/observIQ/gopsutil/v4 6764b38853b5406034f0badcaeee9d0e6b5c118f

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -4,7 +4,7 @@ dist:
   module: github.com/observiq/bindplane-otel-collector
   name: bindplane-otel-collector
   description: Bindplane's custom distro for the OpenTelemetry Collector
-  version: "v2.0.1-beta.2"
+  version: "v2.0.1-beta.3"
   output_path: ./builder
 conf_resolver:
   default_uri_scheme: "env"
@@ -54,9 +54,11 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension v0.151.0
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/awss3eventextension v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/badgerextension v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/bindplaneextension v1.5.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/extension/opampgateway v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/pebbleextension v1.5.0
 exporters:
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.13
@@ -84,6 +86,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.151.0
@@ -107,6 +110,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.151.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/exporter/awssecuritylakeexporter v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/exporter/azureblobexporter v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/exporter/azureloganalyticsexporter v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/exporter/chronicleexporter v1.5.0
@@ -126,6 +130,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.151.0
@@ -145,6 +150,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.151.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.151.0
@@ -155,12 +161,14 @@ processors:
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/maskprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/metricextractprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/metricstatsprocessor v1.5.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/processor/ocsfstandardizationprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/randomfailureprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/removeemptyvaluesprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/resourceattributetransposerprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/samplingprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/snapshotprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/spancountprocessor v1.5.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/processor/threatenrichmentprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/throughputmeasurementprocessor v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/processor/topologyprocessor v1.5.0
 receivers:
@@ -284,6 +292,7 @@ receivers:
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/azureblobrehydrationreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/azureblobpollingreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/bindplaneauditlogs v1.5.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/googlecloudstoragerehydrationreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/httpreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/m365receiver v1.5.0

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -86,7 +86,6 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.151.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.151.0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This update adds missing otel-collector-contrib and bindplane-otel-contrib components to the observiq manifest and bumps the version to v2.0.1-beta.3.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
