### PR TITLE
deps: Bump enhanceindexings3exporter to v0.0.17

### DIFF
--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -61,7 +61,7 @@ extensions:
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/opampgateway v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/extension/pebbleextension v1.5.0
 exporters:
-  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.13
+  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.17
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.151.0
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.151.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.151.0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This bumps the enhanceindexings3exporter dependency to v0.0.17, aligned with OTel v0.151.0.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
