### PR TITLE
deps(lookupprocessor): bump contrib pin for Redis/API/cache

### DIFF
--- a/docs/processors.md
+++ b/docs/processors.md
@@ -19,7 +19,7 @@ Below is a list of supported processors with links to their documentation pages.
 | Log Count Processor                     | [logcountprocessor](https://github.com/observiq/bindplane-otel-contrib/blob/v1.5.0/processor/logcountprocessor/README.md)                                          |
 | Log DeDuplication Processor             | [logdedupprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.151.0/processor/logdedupprocessor/README.md)                         |
 | Logs Transform Processor                | [logstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.151.0/processor/logstransformprocessor/README.md)                        |
-| Lookup Processor                        | [lookupprocessor](https://github.com/observiq/bindplane-otel-contrib/blob/v1.5.0/processor/lookupprocessor/README.md)                                              |
+| Lookup Processor                        | [lookupprocessor](https://github.com/observiq/bindplane-otel-contrib/blob/v1.6.0/processor/lookupprocessor/README.md)                                              |
 | Mask Processor                          | [maskprocessor](https://github.com/observiq/bindplane-otel-contrib/blob/v1.5.0/processor/maskprocessor/README.md)                                                  |
 | Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.151.0/processor/memorylimiterprocessor/README.md)                       |
 | Metric Extract Processor                | [metricextract](https://github.com/observiq/bindplane-otel-contrib/blob/v1.5.0/processor/metricextractprocessor/README.md)                                         |

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/observiq/bindplane-otel-contrib/exporter/webhookexporter v1.5.0
 	github.com/observiq/bindplane-otel-contrib/processor/datapointcountprocessor v1.5.0
 	github.com/observiq/bindplane-otel-contrib/processor/logcountprocessor v1.5.0
-	github.com/observiq/bindplane-otel-contrib/processor/lookupprocessor v1.5.0
+	github.com/observiq/bindplane-otel-contrib/processor/lookupprocessor v1.6.0
 	github.com/observiq/bindplane-otel-contrib/processor/maskprocessor v1.5.0
 	github.com/observiq/bindplane-otel-contrib/processor/metricextractprocessor v1.5.0
 	github.com/observiq/bindplane-otel-contrib/processor/metricstatsprocessor v1.5.0


### PR DESCRIPTION
## Summary
- Bumps `github.com/observiq/bindplane-otel-contrib/processor/lookupprocessor` from `v1.5.0` to `v1.6.0`.
- Picks up new lookup sources (Redis, HTTP API) and an optional TTL cache backed either by an OTel storage extension or a per-instance in-memory map.
- Updates the docs table link to point at the `v1.6.0` README in contrib.
- No factory change — `factories/processors.go` already imports and registers `lookupprocessor.NewFactory()`; the upgraded module exposes the same exported symbol.

## Depends on
- observIQ/bindplane-otel-contrib#308 — open at time of writing.
- **Blocked on** contrib tag `processor/lookupprocessor/v1.6.0`. Marking DRAFT until the tag lands and `go mod tidy` resolves clean. CI will be red until then.

## Test plan
- [ ] After contrib tag created: `make tidy` runs clean
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `make test` (factories pkg, lookupprocessor consumers)
- [ ] Smoke: build collector, run config with `lookup` processor using Redis source against a real Redis instance
- [ ] Smoke: same with HTTP API source against a real endpoint and `response_mapping`
- [ ] Smoke: cache_enabled true + `storage: file_storage` extension, verify entries persist across restarts