### PR TITLE
ci: run make verify-manifest on every PR

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,6 +67,12 @@ jobs:
               - 'go.mod'
             dependabot:
               - '.github/dependabot.yml'
+            manifest:
+              - 'manifests/**'
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'Makefile'
+              - 'internal/extension/opampconnectionextension/cmd/main/**'
             components:
               - 'receiver/**'
               - 'processor/**'
@@ -137,6 +143,30 @@ jobs:
         run: make install-tools
       - name: Check Formatting
         run: make check-fmt
+
+  verify-manifest:
+    if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.manifest == 'true' }}
+    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    needs:
+      - optimize_ci
+      - setup-tools
+      - detect-changes
+    steps:
+      - name: Checkout Sources
+        uses: namespacelabs/nscloud-checkout-action@v7
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: internal/extension/opampconnectionextension/go.mod
+          cache: false # Use Namespace caching instead
+      - name: Set up Go cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+      - name: Install ocb
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.151.0
+      - name: Verify manifest
+        run: make verify-manifest
 
   check-license:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.dockerfile == 'true' || needs.detect-changes.outputs.scripts == 'true') }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -164,7 +164,7 @@ jobs:
         with:
           cache: go
       - name: Install ocb
-        run: go install go.opentelemetry.io/collector/cmd/builder@v0.151.0
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0
       - name: Verify manifest
         run: make verify-manifest
 


### PR DESCRIPTION
Closes [FLEET-500](https://linear.app/bindplane/issue/FLEET-500/run-verify-manifest-on-every-pr-as-a-ci-gate).

5/7. Adds a `verify-manifest` CI job that installs ocb v0.152.0 and runs `make verify-manifest` when manifest or build files change, catching manifest drift before merge instead of at release time.
