### PR TITLE
release: wire goreleaser to use ocb-built binaries

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -164,7 +164,7 @@ jobs:
         with:
           cache: go
       - name: Install ocb
-        run: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0
+        run: make install-ocb
       - name: Verify manifest
         run: make verify-manifest
 

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -45,6 +45,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
+      - name: Install ocb
+        run: make install-ocb
+        shell: bash
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -19,6 +19,8 @@ jobs:
           cache-dependency-path: |
             go.sum
             **/go.sum
+      - name: Install ocb
+        run: make install-ocb
       - name: Build
         run: make build-linux
       - name: Scan Third Party Dependency Licenses
@@ -38,6 +40,8 @@ jobs:
           cache-dependency-path: |
             go.sum
             **/go.sum
+      - name: Install ocb
+        run: make install-ocb
       - name: Build
         run: make build-darwin
       - name: Scan Third Party Dependency Licenses
@@ -57,6 +61,8 @@ jobs:
           cache-dependency-path: |
             go.sum
             **/go.sum
+      - name: Install ocb
+        run: make install-ocb
       - name: Build
         run: make build-windows
       - name: Scan Third Party Dependency Licenses

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
+      - name: Install ocb
+        run: make install-ocb
+        shell: bash
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash
@@ -104,6 +107,8 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: go
+      - name: Install ocb
+        run: make install-ocb
 
       - name: Retrieve Windows AMD64 MSI Installer
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
           cache-dependency-path: "**/go.sum"
+      - name: Install ocb
+        run: make install-ocb
+        shell: bash
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash
@@ -116,6 +119,8 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: go
+      - name: Install ocb
+        run: make install-ocb
       - name: Retrieve Windows AMD64 MSI Installer
         uses: actions/download-artifact@v4
         with:

--- a/.goreleaser.arm64.yml
+++ b/.goreleaser.arm64.yml
@@ -5,25 +5,25 @@ project_name: observiq-otel-collector
 before:
   hooks:
     - make release-prep CURR_VERSION={{ .Version }}
+    # Pre-build the linux/arm64 binary via ocb-driven `make`.
+    - GOOS=linux GOARCH=arm64 make build-binaries OUTDIR="tmp"
 
+after:
+  hooks:
+    - cmd: rm -rf tmp
+
+# `builder: prebuilt` — Make owns the build (`AGENT_LDFLAGS`, `-tags bindplane,ocb`).
 builds:
   - id: collector
+    builder: prebuilt
     binary: observiq-otel-collector
-    main: ./cmd/collector
-    env:
-      - CGO_ENABLED=0
     mod_timestamp: "{{ .CommitTimestamp }}"
-    tags:
-      - bindplane
     goos:
       - linux
     goarch:
       - arm64
-    ldflags:
-      - -s -w
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.version=v{{ .Version }}
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.gitHash={{ .FullCommit }}
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.date={{ .Date }}
+    prebuilt:
+      path: tmp/collector_{{ .Os }}_{{ .Arch }}{{ .Ext }}
 
 dockers:
   - id: ubuntu-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,17 +5,24 @@ project_name: observiq-otel-collector
 before:
   hooks:
     - make release-prep-gpg CURR_VERSION={{ .Version }}
+    # Build collector + updater binaries via ocb-driven `make`. Goreleaser
+    # picks them up below via `builder: prebuilt`. Mirrors v2.0.1-beta.3.
+    - make build-all-non-aix OUTDIR="tmp"
+
+after:
+  hooks:
+    - cmd: rm -rf tmp
 
 # https://goreleaser.com/customization/build/
+#
+# `ldflags`, `tags`, and `main` are no longer set here — the Make targets own
+# them (`AGENT_LDFLAGS` / `UPDATER_LDFLAGS` + `-tags bindplane,ocb`). Goreleaser
+# only packages the pre-built binaries.
 builds:
   - id: collector
+    builder: prebuilt
     binary: observiq-otel-collector
-    main: ./cmd/collector
-    env:
-      - CGO_ENABLED=0
     mod_timestamp: "{{ .CommitTimestamp }}"
-    tags:
-      - bindplane
     goos:
       - linux
       - darwin
@@ -37,18 +44,11 @@ builds:
         goarch: ppc64
       - goos: windows
         goarch: ppc64le
-    ldflags:
-      - -s -w
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.version=v{{ .Version }}
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.gitHash={{ .FullCommit }}
-      - -X github.com/observiq/bindplane-otel-contrib/pkg/version.date={{ .Date }}
-    no_unique_dist_dir: false
+    prebuilt:
+      path: tmp/collector_{{ .Os }}_{{ .Arch }}{{ .Ext }}
   - id: updater
+    builder: prebuilt
     binary: updater
-    dir: ./updater/
-    main: ./cmd/updater
-    env:
-      - CGO_ENABLED=0
     mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux
@@ -71,12 +71,8 @@ builds:
         goarch: ppc64
       - goos: windows
         goarch: ppc64le
-    ldflags:
-      - -s -w
-      - -X github.com/observiq/bindplane-otel-collector/updater/internal/version.version=v{{ .Version }}
-      - -X github.com/observiq/bindplane-otel-collector/updater/internal/version.gitHash={{ .FullCommit }}
-      - -X github.com/observiq/bindplane-otel-collector/updater/internal/version.date={{ .Date }}
-    no_unique_dist_dir: false
+    prebuilt:
+      path: tmp/updater_{{ .Os }}_{{ .Arch }}{{ .Ext }}
 
 # https://goreleaser.com/customization/archive/
 archives:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ The Bindplane Distro for OpenTelemetry Collector (BDOT Collector) is Bindplane's
 ## Development Commands
 
 ### Build Commands
-- `make agent` - Build the collector via the OTel Collector Builder, using `manifests/observIQ/manifest.yaml` as the source of truth for components. Overwrites the ocb-generated `main.go` with `internal/extension/opampconnectionextension/cmd/main/main.go` so the managed/standalone runtime is wired in. Requires `builder` (`go install go.opentelemetry.io/collector/cmd/builder@v0.153.0`).
+- `make agent` - Build the collector via the OTel Collector Builder, using `manifests/observIQ/manifest.yaml` as the source of truth for components. Overwrites the ocb-generated `main.go` with `internal/extension/opampconnectionextension/cmd/main/main.go` so the managed/standalone runtime is wired in. Requires `builder` (`make install-ocb`; version pinned via `OCB_VERSION` in the Makefile).
 - `make verify-manifest` - CI gate: regenerates sources from the manifest and compiles them. Fails if the manifest references unresolvable modules or has version drift. Cheap to run on every PR.
 - `make agent-clean` - Wipe the ocb-generated `./build/` tree.
 - `make updater` - Build just the updater binary for current OS/architecture

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,12 @@ build-binaries: agent updater
 .PHONY: build-all
 build-all: build-linux build-darwin build-windows
 
+# Alias matching v2.0.1-beta.3's naming. v1 doesn't ship AIX binaries today,
+# so build-all and build-all-non-aix are equivalent. Goreleaser's before-hook
+# uses this target name to mirror the v2 release flow.
+.PHONY: build-all-non-aix
+build-all-non-aix: build-all
+
 .PHONY: build-linux
 build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-ppc64 build-linux-ppc64le
 

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,15 @@ version:
 #   - `builder` on PATH
 #   - $(GOBIN)/builder (else $$HOME/go/bin/builder)
 #
-# Install with: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0
+# Install with: make install-ocb
+OCB_VERSION ?= v0.153.0
 OCB ?= $(shell command -v $${OCB:-builder} 2>/dev/null || echo $${GOBIN:-$$HOME/go/bin}/builder)
+
+# Installs the ocb builder at the pinned version. The single source of truth
+# for the ocb version — CI workflows call this instead of pinning their own.
+.PHONY: install-ocb
+install-ocb:
+	go install go.opentelemetry.io/collector/cmd/builder@$(OCB_VERSION)
 MANIFEST ?= manifests/observIQ/manifest.yaml
 BUILD_DIR ?= ./build
 AGENT_MAIN ?= internal/extension/opampconnectionextension/cmd/main/main.go
@@ -89,7 +96,7 @@ AGENT_MAIN ?= internal/extension/opampconnectionextension/cmd/main/main.go
 .PHONY: verify-manifest
 verify-manifest:
 	@if [ ! -x "$(OCB)" ]; then \
-		echo "ocb not found at $(OCB). Install with: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0"; \
+		echo "ocb not found at $(OCB). Install with: make install-ocb"; \
 		exit 1; \
 	fi
 	rm -rf $(BUILD_DIR)
@@ -103,7 +110,7 @@ verify-manifest:
 .PHONY: agent
 agent:
 	@if [ ! -x "$(OCB)" ]; then \
-		echo "ocb not found at $(OCB). Install with: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0"; \
+		echo "ocb not found at $(OCB). Install with: make install-ocb"; \
 		exit 1; \
 	fi
 	$(OCB) --config $(MANIFEST) --skip-compilation
@@ -466,7 +473,7 @@ V2_MANIFEST ?= manifests/observIQ/manifest-v2.yaml
 .PHONY: agent-v2
 agent-v2:
 	@if [ ! -x "$(OCB)" ]; then \
-		echo "ocb not found at $(OCB). Install with: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0"; \
+		echo "ocb not found at $(OCB). Install with: make install-ocb"; \
 		exit 1; \
 	fi
 	CGO_ENABLED=0 $(OCB) --config="$(V2_MANIFEST)" --ldflags "$(AGENT_LDFLAGS)"
@@ -480,7 +487,7 @@ V2_AIX_MANIFEST ?= manifests/observIQ/manifest-v2-aix.yaml
 .PHONY: agent-v2-aix
 agent-v2-aix:
 	@if [ ! -x "$(OCB)" ]; then \
-		echo "ocb not found at $(OCB). Install with: go install go.opentelemetry.io/collector/cmd/builder@v0.153.0"; \
+		echo "ocb not found at $(OCB). Install with: make install-ocb"; \
 		exit 1; \
 	fi
 	CGO_ENABLED=0 $(OCB) --config="$(V2_AIX_MANIFEST)" --ldflags "$(AGENT_LDFLAGS)"

--- a/manifests/observIQ/README.md
+++ b/manifests/observIQ/README.md
@@ -11,10 +11,10 @@ Three manifests live here, all driving ocb builds:
 ## Installing ocb
 
 ```
-go install go.opentelemetry.io/collector/cmd/builder@v0.153.0
+make install-ocb
 ```
 
-ocb v0.153.0 matches the OTel core version pinned in all three manifests.
+The ocb version is pinned via `OCB_VERSION` in the root Makefile and matches the OTel core version pinned in all three manifests.
 
 ## Building
 


### PR DESCRIPTION
Closes [FLEET-501](https://linear.app/bindplane/issue/FLEET-501/wire-goreleaser-to-use-ocb-built-binaries-prebuilt-pattern).

6/7. Switches goreleaser to the `prebuilt` pattern, sourcing binaries from `make build-all-non-aix` instead of compiling inline. Needed because #3502 removes `cmd/collector/` and the top-level `go.mod` that goreleaser used to build.
