### PR TITLE
fix(docker): apt-get upgrade base image to patch Ubuntu CVEs

### DIFF
--- a/docker/Dockerfile.jmx
+++ b/docker/Dockerfile.jmx
@@ -25,6 +25,7 @@ FROM ubuntu:24.04
 WORKDIR /
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
         systemd tzdata ca-certificates && \
     apt-get clean && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -19,6 +19,7 @@ FROM ubuntu:24.04
 WORKDIR /
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
         systemd tzdata ca-certificates && \
     apt-get clean && \


### PR DESCRIPTION
## Summary
- Adds `apt-get upgrade -y` to `docker/Dockerfile.ubuntu` and `docker/Dockerfile.jmx` so the `ubuntu:24.04`-based final images pick up `noble-security` updates at build time.
- Resolves the 16 medium-severity Wiz findings against `bindplane-agent:1.100.0` covering `dpkg`, `libcap2`, `sed`, and `libgnutls30t64`.

## Why
The Wiz scan of `docker.io/observiq/bindplane-agent:1.100.0` failed `container-image-acquire-wizcli-policy` with 16 medium CVEs, all from packages baked into the upstream `ubuntu:24.04` base. A local `apt-get upgrade --dry-run` against that base confirms the upgrade installs the exact fixed versions reported by Wiz:

- `dpkg` 1.22.6ubuntu6.5 → 1.22.6ubuntu6.6 (CVE-2026-2219)
- `libcap2` 1:2.66-5ubuntu2.2 → 1:2.66-5ubuntu2.4 (CVE-2026-4878)
- `sed` 4.9-2build1 → 4.9-2ubuntu0.24.04.1 (CVE-2026-5958)
- `libgnutls30t64` 3.8.3-1.1ubuntu3.5 → 3.8.3-1.1ubuntu3.6 (13 CVEs)

The scratch image is unaffected — its final stage is `FROM scratch` and copies only ca-certs from Alpine, none of which appear in the Wiz findings.

## Test plan
- [ ] CI build of `bindplane-agent` succeeds with the upgraded packages baked in
- [ ] Re-run Wiz scan against a freshly built image and confirm 0 findings against `container-image-acquire-wizcli-policy`
- [ ] Sanity-check image size didn't balloon (apt upgrade should add only a few MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)