### PR TITLE
fix(makefile): stop doubling -SNAPSHOT-<sha> on release-test artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ PREVIOUS_TAG := $(shell git tag --sort=v:refname --no-contains HEAD | grep -E "[
 CURRENT_TAG := $(shell git tag --sort=v:refname --points-at HEAD | grep -E "v[0-9]+\.[0-9]+\.[0-9]+$$" | grep -v 'version' | tail -n1)
 # Version will be the tag pointing to the current commit, or the previous version tag if there is no such tag
 VERSION ?= $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG)-SNAPSHOT-$(SNAPSHOT))
+# Tag passed to goreleaser in --snapshot mode. Must be the bare tag; goreleaser's snapshot
+# template appends its own -SNAPSHOT-<sha> suffix, so passing VERSION here would double it.
+SNAPSHOT_TAG := $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG))
 
 .PHONY: version
 version:
@@ -353,7 +356,7 @@ release-test:
 # If there are no MSIs in the root dir, we'll create dummy ones so that goreleaser can complete successfully
 	if [ ! -e "./observiq-otel-collector.msi" ]; then touch ./observiq-otel-collector.msi; fi
 	if [ ! -e "./observiq-otel-collector-arm64.msi" ]; then touch ./observiq-otel-collector-arm64.msi; fi
-	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
+	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
 
 .PHONY: release-containers-test
 release-containers-test:
@@ -362,7 +365,7 @@ release-containers-test:
 	mv ./dist/collector_linux_amd64 ./tmp/collector_linux_amd64
 	mv ./dist/collector_linux_arm64 ./tmp/collector_linux_arm64
 	mv ./dist/collector_linux_ppc64le ./tmp/collector_linux_ppc64le
-	GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot --config .goreleaser-docker.yml
+	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot --config .goreleaser-docker.yml
 
 .PHONY: agent-linux-amd64 agent-linux-arm64 agent-linux-ppc64le
 agent-linux-amd64:
@@ -374,11 +377,11 @@ agent-linux-ppc64le:
 
 build-single:
 	$(MAKE)
-	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release --skip=publish --skip=sign --clean --skip=validate --snapshot --single-target
+	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --skip=publish --skip=sign --clean --skip=validate --snapshot --single-target
 
 .PHONY: release-test-single
 release-test-single:
-	GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release -f .goreleaser.arm64.yml --skip=publish --clean --skip=validate --snapshot
+	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release -f .goreleaser.arm64.yml --skip=publish --clean --skip=validate --snapshot
 
 .PHONY: for-all
 for-all:


### PR DESCRIPTION
### Proposed Change

`make release-test` (and the other `--snapshot`-mode goreleaser targets in the Makefile) were producing artifacts with a doubled snapshot suffix, e.g.:

```
observiq-otel-collector_v1.100.0-SNAPSHOT-0895c02bd-SNAPSHOT-0895c02bd_linux_amd64.rpm
```

instead of the correct single-suffix form (`v1.100.0-SNAPSHOT-0895c02bd`).

Two layers were each appending `-SNAPSHOT-<sha>`:

1. The Makefile `VERSION` formula already produces `<prev-tag>-SNAPSHOT-<sha>` when HEAD has no current tag.
2. That value was then handed to goreleaser as `GORELEASER_CURRENT_TAG`, and goreleaser`s `--snapshot` mode unconditionally applies its default `snapshot.name_template` (`{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}`), tacking on another `-SNAPSHOT-<sha>`.

Fix: introduce a separate `SNAPSHOT_TAG` variable that is the bare tag (no manual suffix) and use it as `GORELEASER_CURRENT_TAG` in all four `--snapshot`-mode invocations (`release-test`, `release-containers-test`, `build-single`, `release-test-single`). Goreleaser`s template then adds the suffix exactly once.

`VERSION` is preserved unchanged for its non-goreleaser consumers — the `version` target and the `agent` / `updater` ldflags used by `make agent` / `make updater` standalone builds, where there is no goreleaser template to add the suffix automatically.

Verified locally that `make -n release-test` now emits `GORELEASER_CURRENT_TAG=v1.100.0` (bare tag), and an out-of-band goreleaser snapshot run with a bare tag produces correctly-named single-suffix artifacts.

Note: this does NOT fix a separate RPM-version-ordering issue (SHA prefixes with leading digits sort above those with leading letters, causing spurious "newer version already installed" errors on snapshot-to-snapshot upgrades). That needs a monotonic suffix mechanism and is worth a separate ticket.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
