### PR TITLE
chore: `postinstall.sh` preserves config files on update

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -53,6 +53,14 @@ install() {
     # Ensure updater is owned by root.
     chown root:root "$stage_dir/updater"
 
+    # Seed default configs only when absent so upgrades/reinstalls preserve
+    # user edits. The stage dir is ephemeral, so pruning it here is safe.
+    for cfg in config.yaml logging.yaml; do
+        if [ -f "${BDOT_CONFIG_HOME}/${cfg}" ]; then
+            rm -f "${stage_dir}/${cfg}"
+        fi
+    done
+
     cp -r --preserve \
       "$stage_dir"/* \
       "${BDOT_CONFIG_HOME}"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Currently the postinstall script will copy all contents from the stage dir into the collectors home. This can cause config files to be overwritten on RPM during an upgrade.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
