### PR TITLE
feat(release): add embed_library build tag for telemetrygeneratorreceiver blitz embed integration (PIPE-1017)

### DIFF
--- a/.goreleaser.arm64.yml
+++ b/.goreleaser.arm64.yml
@@ -15,6 +15,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - bindplane
+      - embed_library
     goos:
       - linux
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - bindplane
+      - embed_library
     goos:
       - linux
       - darwin


### PR DESCRIPTION
### Proposed Change

Adds `-tags embed_library` to the `collector` build in `.goreleaser.yml` and `.goreleaser.arm64.yml` so released BDOT binaries link the blitz filegen data library required by the `telemetrygeneratorreceiver` blitz integration ([PIPE-1017](https://linear.app/bindplane/issue/PIPE-1017), contrib). The `updater` build is intentionally left untouched — it doesn't link the receiver.

Without this tag, the receiver fails fast at Start when a `Type: "blitz"` entry is configured (its embedded-library assertion), and `package:` references in `blitz_yaml` configs can't resolve.

Verified locally: built the collector with `-tags "bindplane embed_library"` against the blitz-containing receiver (`df8d0cef`) and ran a `Type: "blitz"` recipe config end-to-end — clean startup, embedded recipe resolved, logs flowed.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
