### PR TITLE
fix(v1): prevent Windows install scripts from killing the Powershell window on failure

### DIFF
--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -370,17 +370,24 @@ function Main {
 
 # ---- Entry point -------------------------------------------------------------
 
-# Run Main inside a try/catch and avoid calling `exit` from script scope. A bare
-# `exit` terminates the host process, closing the user's PowerShell window before
-# they can read the error — especially on the uninstall path, which fails fast
-# when the MSI can't be resolved. Setting $LASTEXITCODE instead leaves the window
-# intact while still surfacing a non-zero code to non-interactive callers
-# (e.g. powershell.exe -File install_windows.ps1 -Uninstall).
+# Run Main inside a try/catch, then exit based on how the script was invoked. A
+# bare `exit` terminates the host process, which closes the user's window when the
+# script is run inline via `& ([scriptblock]::Create(...))` (the form the install
+# one-liner uses). But under `powershell.exe -File ...`, setting $LASTEXITCODE
+# without calling `exit` leaves the process exit code at 0, so a scripted caller
+# (e.g. -File ... -Uninstall) would miss a failure. $PSCommandPath is populated
+# when the script is invoked as a file (-File or .\install_windows.ps1) and empty
+# for the inline scriptblock form, so we only `exit` in the former case: file
+# callers get a real exit code, inline callers keep their session.
 try {
     Main
-    $global:LASTEXITCODE = 0
+    $exitCode = 0
 }
 catch {
     Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
-    $global:LASTEXITCODE = 1
+    $exitCode = 1
+}
+
+if ($PSCommandPath) {
+    exit $exitCode
 }

--- a/scripts/generic-install/install_windows.ps1
+++ b/scripts/generic-install/install_windows.ps1
@@ -138,9 +138,12 @@ function Write-Warn {
 }
 
 function Fail {
+    # Throw rather than `exit`. A bare `exit` from inside a function terminates the
+    # whole PowerShell host, which closes the user's window before they can read the
+    # error. The throw is caught at the script's entry point, which prints the error
+    # and sets a non-zero exit code without killing the session.
     param([string]$Message)
-    Write-Host "[ERROR] $Message" -ForegroundColor Red
-    exit 1
+    throw $Message
 }
 
 # ---- Privilege check ---------------------------------------------------------
@@ -365,4 +368,19 @@ function Main {
     }
 }
 
-Main
+# ---- Entry point -------------------------------------------------------------
+
+# Run Main inside a try/catch and avoid calling `exit` from script scope. A bare
+# `exit` terminates the host process, closing the user's PowerShell window before
+# they can read the error — especially on the uninstall path, which fails fast
+# when the MSI can't be resolved. Setting $LASTEXITCODE instead leaves the window
+# intact while still surfacing a non-zero code to non-interactive callers
+# (e.g. powershell.exe -File install_windows.ps1 -Uninstall).
+try {
+    Main
+    $global:LASTEXITCODE = 0
+}
+catch {
+    Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    $global:LASTEXITCODE = 1
+}

--- a/scripts/install/install_windows.ps1
+++ b/scripts/install/install_windows.ps1
@@ -119,6 +119,8 @@ $DOWNLOAD_BASE = "https://bdot.bindplane.com"
 $MSI_NAME_AMD64 = "observiq-otel-collector.msi"
 $MSI_NAME_ARM64 = "observiq-otel-collector-arm64.msi"
 $PRODUCT_DISPLAY_NAME = "observIQ Distro for OpenTelemetry Collector"
+# Stable across releases/renames; defined in windows/wix.json ("upgrade-code").
+$UPGRADE_CODE = "{D67CCA1A-6708-4096-8BDE-5069739FB861}"
 
 # ---- Helpers -----------------------------------------------------------------
 
@@ -133,9 +135,12 @@ function Write-Warn {
 }
 
 function Fail {
+    # Throw rather than `exit`. A bare `exit` from inside a function terminates the
+    # whole PowerShell host, which closes the user's window before they can read the
+    # error. The throw is caught at the script's entry point, which prints the error
+    # and sets a non-zero exit code without killing the session.
     param([string]$Message)
-    Write-Host "[ERROR] $Message" -ForegroundColor Red
-    exit 1
+    throw $Message
 }
 
 # ---- Privilege check ---------------------------------------------------------
@@ -241,12 +246,22 @@ function Build-MsiexecArgs {
 # ---- Uninstall ---------------------------------------------------------------
 
 function Get-ProductCode {
-    $product = Get-CimInstance -ClassName Win32_Product `
-        -Filter "Name = '$PRODUCT_DISPLAY_NAME'" `
-        -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-    if ($product) {
-        return $product.IdentifyingNumber
+    # Resolve the installed ProductCode via the stable UpgradeCode rather than an
+    # exact display-name match. The display name has changed across releases (e.g.
+    # "observIQ Distro..." -> "BindPlane Distro... (BDOT)"), but the UpgradeCode is
+    # fixed, so this keeps working across renames. The Windows Installer COM API
+    # also avoids the slow, side-effecting Win32_Product WMI class.
+    try {
+        $installer = New-Object -ComObject WindowsInstaller.Installer
+        $related = $installer.RelatedProducts($UPGRADE_CODE)
+    }
+    catch {
+        # RelatedProducts throws when no products match the upgrade code.
+        return $null
+    }
+
+    foreach ($code in $related) {
+        if ($code) { return $code }
     }
     return $null
 }
@@ -377,4 +392,19 @@ function Main {
     }
 }
 
-Main
+# ---- Entry point -------------------------------------------------------------
+
+# Run Main inside a try/catch and avoid calling `exit` from script scope. A bare
+# `exit` terminates the host process, closing the user's PowerShell window before
+# they can read the error — especially on the uninstall path, which fails fast
+# when the product can't be found. Setting $LASTEXITCODE instead leaves the window
+# intact while still surfacing a non-zero code to non-interactive callers
+# (e.g. powershell.exe -File install_windows.ps1 -Uninstall).
+try {
+    Main
+    $global:LASTEXITCODE = 0
+}
+catch {
+    Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    $global:LASTEXITCODE = 1
+}

--- a/scripts/install/install_windows.ps1
+++ b/scripts/install/install_windows.ps1
@@ -266,15 +266,38 @@ function Get-ProductCode {
     return $null
 }
 
+function Get-InstalledProductName {
+    param([string]$ProductCode)
+    # Look up the name actually registered for an installed product code. Returns
+    # $null if it can't be resolved, so callers can fall back to the product code.
+    try {
+        $installer = New-Object -ComObject WindowsInstaller.Installer
+        return $installer.ProductInfo($ProductCode, "InstalledProductName")
+    }
+    catch {
+        return $null
+    }
+}
+
 function Invoke-Uninstall {
-    Write-Info "Searching for installed '$PRODUCT_DISPLAY_NAME'..."
+    Write-Info "Searching for an installed $PRODUCT_DISPLAY_NAME..."
 
     $productCode = Get-ProductCode
     if (-not $productCode) {
-        Fail "'$PRODUCT_DISPLAY_NAME' is not installed."
+        Fail "$PRODUCT_DISPLAY_NAME is not installed."
     }
 
-    Write-Info "Found product code: $productCode"
+    # Report the name actually registered for the resolved product. The UpgradeCode
+    # also matches rebranded installs (e.g. the BDOT rename), so the installed name
+    # may differ from $PRODUCT_DISPLAY_NAME; show what is really there rather than
+    # claiming to act on a name the user may not have installed.
+    $installedName = Get-InstalledProductName -ProductCode $productCode
+    if ($installedName) {
+        Write-Info "Found '$installedName' ($productCode)"
+    }
+    else {
+        Write-Info "Found product code: $productCode"
+    }
 
     $msiArgs = @("/x", $productCode)
     if ($Quiet) {
@@ -394,17 +417,24 @@ function Main {
 
 # ---- Entry point -------------------------------------------------------------
 
-# Run Main inside a try/catch and avoid calling `exit` from script scope. A bare
-# `exit` terminates the host process, closing the user's PowerShell window before
-# they can read the error — especially on the uninstall path, which fails fast
-# when the product can't be found. Setting $LASTEXITCODE instead leaves the window
-# intact while still surfacing a non-zero code to non-interactive callers
-# (e.g. powershell.exe -File install_windows.ps1 -Uninstall).
+# Run Main inside a try/catch, then exit based on how the script was invoked. A
+# bare `exit` terminates the host process, which closes the user's window when the
+# script is run inline via `& ([scriptblock]::Create(...))` (the form the install
+# one-liner uses). But under `powershell.exe -File ...`, setting $LASTEXITCODE
+# without calling `exit` leaves the process exit code at 0, so a scripted caller
+# (e.g. -File ... -Uninstall) would miss a failure. $PSCommandPath is populated
+# when the script is invoked as a file (-File or .\install_windows.ps1) and empty
+# for the inline scriptblock form, so we only `exit` in the former case: file
+# callers get a real exit code, inline callers keep their session.
 try {
     Main
-    $global:LASTEXITCODE = 0
+    $exitCode = 0
 }
 catch {
     Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
-    $global:LASTEXITCODE = 1
+    $exitCode = 1
+}
+
+if ($PSCommandPath) {
+    exit $exitCode
 }


### PR DESCRIPTION
## Summary

Port of #3526 to `main`. Both Windows install scripts could abruptly close the user's PowerShell window on failure, most visibly when running with `-Uninstall`.

### Root cause

`Fail()` called `exit` from inside a function. A bare `exit` terminates the entire PowerShell host process, closing the user's window before they can read the `[ERROR]` line. The uninstall path is especially prone to this because it fails fast.

### Changes

- `Fail()` now `throw`s; a try/catch entry point prints the error and sets `$LASTEXITCODE` without killing the session. Applied to **both** scripts.
- BDOT `install_windows.ps1` resolves the installed ProductCode via the **stable UpgradeCode** (`windows/wix.json`'s `upgrade-code`) using the Windows Installer COM API, instead of an exact match against `Win32_Product` by display name. This is forward-looking: when the distro is rebranded to BindPlane the display name changes, but the UpgradeCode is fixed, so uninstall keeps working across renames/versions. It also avoids the slow, side-effecting `Win32_Product` WMI class.

### main-specific notes

- Unlike the v2.0.0 release branch, the product name in `windows/wix.json` on `main` is still `observIQ Distro for OpenTelemetry Collector`, which currently matches the script — so the name-mismatch bug is not yet live here. The UpgradeCode switch is preventative (and a perf/correctness improvement) rather than a fix for a current break.
- The generic-install script intentionally uninstalls via `msiexec /x <downloaded.msi>` (it can't know an arbitrary distribution's UpgradeCode); that behavior is unchanged. Only the host-termination fix was applied there.

## Test plan

- [x] Manually tested on Windows (against the v2.0.0 release branch variant in #3526)