### PR TITLE
chore: Go 1.26.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ fmt:
 
 .PHONY: tidy
 tidy:
-	$(MAKE) for-all CMD="go mod tidy -compat=1.25.9"
+	$(MAKE) for-all CMD="go mod tidy -compat=1.26.4"
 
 .PHONY: gosec
 gosec:

--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/plugindocgen
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/observiq/bindplane-otel-contrib/receiver/pluginreceiver v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
@@ -229,6 +229,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.153.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension v0.153.0
@@ -284,7 +285,6 @@ require (
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/observiq/bindplane-otel-contrib/internal/amqfilter v1.7.0 // indirect
 	github.com/okta/okta-sdk-golang/v6 v6.1.6 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.153.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/basicauth v0.153.0 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/outscale/osc-sdk-go/v2 v2.32.0 // indirect

--- a/internal/report/go.mod
+++ b/internal/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/report
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/observiq/bindplane-otel-contrib/pkg/snapshot v1.7.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/internal/tools
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/packagestate/go.mod
+++ b/packagestate/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/packagestate
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/open-telemetry/opamp-go v0.23.0

--- a/scripts/update-bindplane-contrib.sh
+++ b/scripts/update-bindplane-contrib.sh
@@ -56,7 +56,7 @@ for local_mod in $LOCAL_MODULES; do
         echo "Updating deps in $local_mod"
         cd "$local_mod"
         # go list will not work if module is not tidy, so we tidy first
-        go mod tidy -compat=1.25.9
+        go mod tidy -compat=1.26.4
 
         echo "  Tidied $local_mod"
 

--- a/scripts/update-otel.sh
+++ b/scripts/update-otel.sh
@@ -115,7 +115,7 @@ for local_mod in $LOCAL_MODULES; do
         echo "Updating deps in $local_mod"
         cd "$local_mod"
         # go list will not work if module is not tidy, so we tidy first
-        go mod tidy -compat=1.25.9
+        go mod tidy -compat=1.26.4
 
         echo "  Tidied $local_mod"
 

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-otel-collector/updater
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR bumps the Go dependency to 1.26.4.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
