### PR TITLE
chore: Bump Windows Event Log receiver to v0.153.0 and modules to v1.101.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.9
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-otel-collector/internal/report v1.101.1
-	github.com/observiq/bindplane-otel-collector/packagestate v1.101.1
+	github.com/observiq/bindplane-otel-collector/internal/report v1.101.2
+	github.com/observiq/bindplane-otel-collector/packagestate v1.101.2
 	github.com/observiq/bindplane-otel-contrib/exporter/azureblobexporter v1.7.0
 	github.com/observiq/bindplane-otel-contrib/exporter/chronicleexporter v1.7.0
 	github.com/observiq/bindplane-otel-contrib/exporter/chronicleforwarderexporter v1.7.0
@@ -229,6 +229,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.153.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension v0.153.0
@@ -284,7 +285,6 @@ require (
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/observiq/bindplane-otel-contrib/internal/amqfilter v1.7.0 // indirect
 	github.com/okta/okta-sdk-golang/v6 v6.1.6 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension v0.153.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/basicauth v0.153.0 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/outscale/osc-sdk-go/v2 v2.32.0 // indirect
@@ -1039,9 +1039,9 @@ replace github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
 // github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension.test is forcing this dep to be updated, but it isn't compatible with the linux build process, so replacing to last stable version
 replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.11.0
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260422143330-2a6ebda5c14e
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260612155207-80547fbe912d
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260422143330-2a6ebda5c14e
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260612155207-80547fbe912d
 
 // The DataDog datadog-agent monorepo resolves these modules via intra-repo relative-path
 // replaces (e.g. logsagentexporter and delegatedauth reference delegatedauth, its cloudauth/aws

--- a/go.sum
+++ b/go.sum
@@ -1415,10 +1415,10 @@ github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver v
 github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver v1.7.0/go.mod h1:f2HTgVpPR8vwmPNiE58gWzrHANlScLH+h3tcQcnYOdg=
 github.com/observiq/bindplane-otel-contrib/receiver/windowseventtracereceiver v1.7.0 h1:wXL5LNs7Zx9XyPDhy9hTg/t9gb6oa/6zCZqAdHbqlbw=
 github.com/observiq/bindplane-otel-contrib/receiver/windowseventtracereceiver v1.7.0/go.mod h1:sSD72jjQCzHxuCKIixEpweVmNPKuLW7yjSTtYRnXY8w=
-github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260422143330-2a6ebda5c14e h1:dLJ1ED6FH9jnCDDaVxTQuSX9gu3cz1HVjNHbTXZtghE=
-github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260422143330-2a6ebda5c14e/go.mod h1:UnhYNTPJgpwIb+iOmcrExD2j4nj1EMaF6rmGf/mu+QI=
-github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260422143330-2a6ebda5c14e h1:nMxG7DdELqcTzJBWJOL75OrtMtn2eUobT6Nw8NyOnuU=
-github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260422143330-2a6ebda5c14e/go.mod h1:ZWrqXQPd7NEu47TCATJWvZvwi4d2S54QCP1rqf7CEvg=
+github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260612155207-80547fbe912d h1:y7MZQqE/fzKJmz5ABYQ3UTG2+GVVx39757B46Wg9EOI=
+github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260612155207-80547fbe912d/go.mod h1:siSHcXU/H/Ekk8Q7U52ehoWOtn02bFUZru3piYnFEVc=
+github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260612155207-80547fbe912d h1:/lMVKrXUaq4oSZspNKzPmlo9JLDy71Xqz5+HUzVmbvc=
+github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260612155207-80547fbe912d/go.mod h1:J2llkzEHXPRygkUYXlqR63b1Dv4pECYTZKEoJqNehmA=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/okta/okta-sdk-golang/v6 v6.1.6 h1:bObKXhkFh1c1tCfjcYoRoTjDJeIPMsEZHrjLasawEpk=

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-otel-collector/packagestate v1.101.1
+	github.com/observiq/bindplane-otel-collector/packagestate v1.101.2
 	github.com/open-telemetry/opamp-go v0.23.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This rebases https://github.com/observIQ/opentelemetry-collector-contrib/tree/bdot-1.98.0 to be against OTel v0.153.0. It has been pushed to https://github.com/observIQ/opentelemetry-collector-contrib/tree/bdot-1.101.2.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
