### PR TITLE
deps: update AIX manifest replace directives for collector 2.0.0

### DIFF
--- a/manifests/observIQ/manifest-aix.yaml
+++ b/manifests/observIQ/manifest-aix.yaml
@@ -126,6 +126,6 @@ providers:
 replaces:
   # AIX patches for hostmetricsreceiver - dynamic OS check + nil guards for process scraper
   # Can be removed when upstream adds AIX support
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver => github.com/observIQ/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.0.0-20260330173229-3610f19ad33c
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver => github.com/observIQ/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.0.0-20260615140038-bbdad0fbda69
   # AIX patches for gopsutil - can be removed when upstream merges AIX support
-  - github.com/shirou/gopsutil/v4 => github.com/observIQ/gopsutil/v4 6764b38853b5406034f0badcaeee9d0e6b5c118f
+  - github.com/shirou/gopsutil/v4 => github.com/observIQ/gopsutil/v4 e8fe174c42e72c19208702014d5ccdde17ae9deb


### PR DESCRIPTION
### Proposed Change
Bumps the two fork `replace` directives in `manifests/observIQ/manifest-aix.yaml` to current commits.

- `hostmetricsreceiver`: `3610f19ad33c` → `bbdad0fbda69`. New commit carries the AIX process scraper rebased onto current upstream `contrib` main.
- `gopsutil/v4`: `6764b38853b5` → `e8fe174c42e7`. Latest on the `dylanmyers/aix_combined` fork branch.

Both refs resolve cleanly against their respective forks.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed