### PR TITLE
feat: add the AWS Neuron receiver to the Bindplane manifest

### DIFF
--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -286,6 +286,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.151.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.151.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/receiver/awsneuronreceiver v1.8.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/awss3rehydrationreceiver v1.5.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/azureblobrehydrationreceiver v1.5.0


### PR DESCRIPTION
### Proposed Change
Adds `github.com/observiq/bindplane-otel-contrib/receiver/awsneuronreceiver` (`v1.8.0`) to the Bindplane collector manifest so the AWS Neuron receiver is built into the distribution. The receiver collects metrics from AWS Neuron accelerators (Inferentia and Trainium) via `neuron-monitor` and sysfs.

This manifest will not build until the distribution is updated to OpenTelemetry `v0.154.0` and the `bindplane-otel-contrib` modules to `v1.8.0`. That bump is expected as part of the release process.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
