### PR TITLE
ci: migrate from Namespace.so to GitHub Actions runners (PLAT-1019)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
   detect-changes:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' }}
     needs: optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       pull-requests: read
@@ -38,7 +38,7 @@ jobs:
       components: ${{ steps.filter.outputs.components }}
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Detect changed files
         uses: dorny/paths-filter@v3
         id: filter
@@ -96,51 +96,67 @@ jobs:
   setup-tools:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' }}
     needs: optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
 
   check-fmt:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check Formatting
@@ -148,23 +164,28 @@ jobs:
 
   verify-manifest:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.manifest == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Install ocb
         run: make install-ocb
       - name: Verify manifest
@@ -172,28 +193,36 @@ jobs:
 
   check-license:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.dockerfile == 'true' || needs.detect-changes.outputs.scripts == 'true') }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check License Headers
@@ -201,28 +230,36 @@ jobs:
 
   gosec:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Source
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Run Gosec Security Scanner
@@ -230,28 +267,36 @@ jobs:
 
   misspell:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.misspell == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check for Misspelled Words in Doc Files
@@ -259,28 +304,36 @@ jobs:
 
   lint:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Run Revive Linter
@@ -289,22 +342,27 @@ jobs:
   # Below checks don't need to run `make install-tools`
   check-plugin-docs:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.plugin-docs == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Plugin Doc Generation
         run: make create-plugin-docs
       - name: Check Changed Plugin Docs
@@ -320,31 +378,31 @@ jobs:
   # Below checks don't need to run `make install-tools`
   check-mod-paths:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.gomod == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Check Module Paths
         run: make check-mod-paths
 
   check-dependabot:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.dependabot == 'true' || needs.detect-changes.outputs.gomod == 'true') }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Check Dependabot
         run: make check-dependabot
 
   check-component-changes:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' && needs.detect-changes.outputs.components == 'true' }}
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,8 @@ jobs:
   analyze:
     name: Analyze
     if: github.actor != 'dependabot[bot]'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
-    timeout-minutes:  360 
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes:  360
     permissions:
       actions: read
       contents: read
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -31,9 +31,14 @@ jobs:
           go-version-file: internal/extension/opampconnectionextension/go.mod
           cache: false
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   vulncheck:
     name: Go Vulnerability Scan
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04-large
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 20
     steps:
       - name: Check out source code

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_linux:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-4x8
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
-    runs-on: nscloud-ubuntu-24.04-systemd-amd64-4x8
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/release-containers-test.yml
+++ b/.github/workflows/release-containers-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-containers-test:
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04-32x128
+    runs-on: ubuntu-latest-32-cores
     steps:
       - name: Redirect temp directories
         run: |
@@ -18,7 +18,7 @@ jobs:
           echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "GOTMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Checkout Repo
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -48,9 +48,12 @@ jobs:
       #   env:
       #     COSIGN_PRIVATE_KEY: ${{secrets.ORG_COSIGN_PRIVATE_KEY}}
       - name: Cache Goreleaser Build
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: ~/.cache/goreleaser
+          key: ${{ runner.os }}-goreleaser-${{ hashFiles('.goreleaser-docker.yml', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-goreleaser-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-containers.yml
+++ b/.github/workflows/release-containers.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   release-containers:
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04-32x128
+    runs-on: ubuntu-latest-32-cores
     # Uncomment the following when switching to workflow_run trigger,
     # to ensure the job only runs if the release workflow succeeded.
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -30,7 +30,7 @@ jobs:
           echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "GOTMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Checkout Repo
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -77,9 +77,12 @@ jobs:
       #   env:
       #     COSIGN_PRIVATE_KEY: ${{secrets.ORG_COSIGN_PRIVATE_KEY}}
       - name: Cache Goreleaser Build
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: ~/.cache/goreleaser
+          key: ${{ runner.os }}-goreleaser-${{ hashFiles('.goreleaser-docker.yml', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-goreleaser-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -83,18 +83,18 @@ jobs:
           smctl sign --keypair-alias ${{ secrets.BDOT_DIGICERT_KEYPAIR_ALIAS }} --input C:/build/${{ matrix.msi_name }} --config-file C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg
         shell: cmd
       - name: Upload MSI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.msi_name }}
           path: C:/build/${{ matrix.msi_name }}
           retention-days: 1
 
   release-test:
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04-32x128
+    runs-on: ubuntu-latest-32-cores
     needs: [build-msi]
     steps:
       - name: Checkout Repo
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -102,21 +102,26 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Install ocb
         run: make install-ocb
 
       - name: Retrieve Windows AMD64 MSI Installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: observiq-otel-collector.msi
 
       - name: Retrieve Windows ARM64 MSI Installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: observiq-otel-collector-arm64.msi
 
@@ -144,9 +149,12 @@ jobs:
         run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
 
       - name: Cache Goreleaser Build
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: ~/.cache/goreleaser
+          key: ${{ runner.os }}-goreleaser-${{ hashFiles('.goreleaser.yml', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-goreleaser-
 
       - name: Write signing key for nFPM
         shell: bash
@@ -198,7 +206,7 @@ jobs:
           du -sh artifacts
 
       - name: Upload build artifacts
-        uses: namespace-actions/upload-artifact@v1
+        uses: actions/upload-artifact@v7
         with:
           name: observiq-otel-collector-${{ github.event.inputs.version }}-artifacts.tar.gz
           path: observiq-otel-collector-${{ github.event.inputs.version }}-artifacts.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
 
   release:
     needs: [build-msi]
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04-32x128
+    runs-on: ubuntu-latest-32-cores
     steps:
       - name: Redirect temp directories
         run: |
@@ -99,7 +99,7 @@ jobs:
           echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "GOTMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Checkout Repo
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
         with:
           # For goreleaser
           fetch-depth: 0
@@ -114,11 +114,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache: false # Use Namespace caching instead
+          cache: false # Caching handled by the actions/cache step below
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Install ocb
         run: make install-ocb
       - name: Retrieve Windows AMD64 MSI Installer
@@ -137,9 +142,12 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{secrets.ORG_COSIGN_PRIVATE_KEY}}
       - name: Cache Goreleaser Build
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: ~/.cache/goreleaser
+          key: ${{ runner.os }}-goreleaser-${{ hashFiles('.goreleaser.yml', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-goreleaser-
       - name: Sign AMD64 MSI
         run: cosign sign-blob --key=cosign.key --output-signature ./observiq-otel-collector.msi.sig ./observiq-otel-collector.msi
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
   detect-changes:
     if: ${{ needs.optimize_ci.outputs.skip != 'true' }}
     needs: optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       pull-requests: read
@@ -31,7 +31,7 @@ jobs:
       updater: ${{ steps.filter.outputs.updater == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.makefile == 'true' }}
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
       - name: Detect changed files
         uses: dorny/paths-filter@v3
         id: filter
@@ -61,25 +61,28 @@ jobs:
         include:
           # Ubuntu - All tests
           - os: ubuntu
-            runner: namespace-profile-bindplane-default-ubuntu-24-04-32x64
-            test_cmd: sudo make test-updater-integration
+            runner: ubuntu-latest-32-cores
+            # GitHub-hosted runners execute as the unprivileged `runner` user, so
+            # `sudo` sanitizes PATH (secure_path) and drops /home/runner/go/bin where
+            # gotestsum lives. Preserve PATH so the tools installed above resolve.
+            test_cmd: sudo env "PATH=$PATH" make test-updater-integration
           # macOS - All tests
           - os: macos
-            runner: namespace-profile-bindplane-default-macos-15
+            runner: macos-15-xlarge
             test_cmd: make test-updater-integration
           # Windows - All tests
           - os: windows
-            runner: namespace-profile-bindplane-default-windows-2022-16x32
+            runner: windows-2022-16-cores
             test_cmd: make test-updater-integration
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout Sources (Namespace)
+      - name: Checkout Sources (non-Windows)
         if: matrix.os != 'windows'
-        uses: namespacelabs/nscloud-checkout-action@v7
+        uses: actions/checkout@v7
 
       - name: Checkout Sources (Windows)
         if: matrix.os == 'windows'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -87,104 +90,84 @@ jobs:
           go-version-file: internal/extension/opampconnectionextension/go.mod
           cache: false
 
-      # link.exe (external linking is forced by -race) writes its go-link temp via
-      # Go's os.TempDir(), which on Windows Server 2022 routes through GetTempPath2.
-      # These Namespace runners execute as SYSTEM, and for SYSTEM processes
-      # GetTempPath2 ignores TMP/TEMP and returns C:\Windows\SystemTemp; that volume
-      # is under disk pressure, which is the "not enough space" linker failure.
-      #
-      # Per the GetTempPath2 docs, the one env var a SYSTEM process honors is
-      # SystemTemp, so we set it to redirect the linker's go.o onto the roomy D:
-      # volume (where the workspace already lives). We also relocate the Go build and
-      # module caches to D: as hygiene (GOCACHE/GOMODCACHE are read directly by the go
-      # tool, never via GetTempPath2). GOPATH stays on C: so setup-go's PATH entry for
-      # installed tools (gotestsum, etc.) remains valid.
-      # Ref: https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-gettemppath2w
-      - name: "Configure temp and Go cache dirs on D: (Windows)"
-        if: matrix.os == 'windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path D:\Temp, D:\gocache, D:\gomodcache | Out-Null
-          "SystemTemp=D:\Temp"       | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "GOTMPDIR=D:\Temp"         | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "GOCACHE=D:\gocache"       | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "GOMODCACHE=D:\gomodcache" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Free disk space and report (Windows)
-        if: matrix.os == 'windows'
-        shell: pwsh
-        run: |
-          Write-Host "== Effective temp/cache redirection (confirm SYSTEM honored SystemTemp) =="
-          Write-Host "SystemTemp=$env:SystemTemp"
-          go env GOCACHE GOMODCACHE GOTMPDIR
-          Write-Host "== Disk usage before cleanup =="
-          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
-          Write-Host "== Largest known C: consumers =="
-          foreach ($p in @('C:\hostedtoolcache','C:\Users\runneradmin\AppData\Local\go-build','C:\Users\runneradmin\go','C:\Windows\SystemTemp')) {
-            if (Test-Path $p) {
-              $gb = [math]::Round(((Get-ChildItem $p -Recurse -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum)/1GB, 2)
-              Write-Host ("{0,8} GB  {1}" -f $gb, $p)
-            }
-          }
-          # Clear stale temp on the C: volume that link.exe is pinned to.
-          Remove-Item -Recurse -Force C:\Windows\SystemTemp\* -ErrorAction SilentlyContinue
-          Write-Host "== Disk usage after cleanup =="
-          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
-
-      - name: Cache Go (Namespace)
-        if: matrix.os != 'windows'
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: go
-
       - name: Cache Go modules (Ubuntu)
         if: matrix.os == 'ubuntu'
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+
+      - name: Cache Go build cache (Ubuntu)
+        if: matrix.os == 'ubuntu'
+        uses: actions/cache@v6
+        with:
+          path: /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Cache Go modules (macOS)
         if: matrix.os == 'macos'
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /Users/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+
+      - name: Cache Go build cache (macOS)
+        if: matrix.os == 'macos'
+        uses: actions/cache@v6
+        with:
+          path: /Users/runner/Library/Caches/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Cache Go modules (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
-          path: D:\gomodcache
+          path: C:\Users\runneradmin\go\pkg\mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-mod-
 
       - name: Cache Go build cache (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
-          path: D:\gocache
+          path: C:\Users\runneradmin\AppData\Local\go-build
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
           restore-keys: |
             ${{ runner.os }}-go-build-
 
       - name: Cache Tools (Ubuntu)
         if: matrix.os == 'ubuntu'
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
 
       - name: Cache Tools (macOS)
         if: matrix.os == 'macos'
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: actions/cache@v6
         with:
           path: /Users/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
 
       - name: Cache Tools (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: C:\Users\runneradmin\go\bin
-          key: ${{ runner.os }}-go-tools-${{ hashFiles('internal/tools/go.sum') }}
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum', '**/Makefile') }}
           restore-keys: |
             ${{ runner.os }}-go-tools-
 


### PR DESCRIPTION
**Overview**

We are migrating from Namespace.so back to Github Actions Runners.