### PR TITLE
fix: `sanitizeArchivePath` could save to a different directory with the same prefix

### DIFF
--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager.go
@@ -312,7 +312,8 @@ func extractZip(archivePath, extractPath string) error {
 
 func sanitizeArchivePath(dir, file string) (string, error) {
 	s := filepath.Join(dir, file)
-	if strings.HasPrefix(s, filepath.Clean(dir)) {
+	cleanDir := filepath.Clean(dir)
+	if s == cleanDir || strings.HasPrefix(s, cleanDir+string(filepath.Separator)) {
 		return s, nil
 	}
 	return "", fmt.Errorf("content filepath is tainted: %q", file)

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager_test.go
@@ -329,10 +329,10 @@ func TestSanitizeArchivePath(t *testing.T) {
 		file      string
 		wantTaint bool
 	}{
-		// The vulnerability: a sibling dir sharing the prefix escapes the
+		// A sibling dir sharing the prefix escapes the
 		// extraction dir but passes the HasPrefix check. "/tmp/dest" + this
-		// resolves to "/tmp/dest-evil/payload", which starts with "/tmp/dest".
-		{name: "sibling prefix escape", file: filepath.Join("..", "dest-evil", "payload"), wantTaint: true},
+		// resolves to "/tmp/dest-other/payload", which starts with "/tmp/dest".
+		{name: "sibling prefix escape", file: filepath.Join("..", "dest-other", "payload"), wantTaint: true},
 		{name: "parent traversal", file: filepath.Join("..", "..", "etc", "passwd"), wantTaint: true},
 		{name: "normal file", file: filepath.Join("sub", "config.yaml"), wantTaint: false},
 		{name: "root entry", file: ".", wantTaint: false},

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_downloadable_file_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -318,6 +319,37 @@ func TestDownloadAndVerifyInvalidURL(t *testing.T) {
 	downloadableFileManager := newDownloadableFileManager(zap.NewNop(), tmpDir)
 	err := downloadableFileManager.FetchAndExtractArchive(file)
 	require.ErrorContains(t, err, "failed to determine archive download path:")
+}
+
+func TestSanitizeArchivePath(t *testing.T) {
+	dir := filepath.Join(string(filepath.Separator), "tmp", "dest")
+
+	tests := []struct {
+		name      string
+		file      string
+		wantTaint bool
+	}{
+		// The vulnerability: a sibling dir sharing the prefix escapes the
+		// extraction dir but passes the HasPrefix check. "/tmp/dest" + this
+		// resolves to "/tmp/dest-evil/payload", which starts with "/tmp/dest".
+		{name: "sibling prefix escape", file: filepath.Join("..", "dest-evil", "payload"), wantTaint: true},
+		{name: "parent traversal", file: filepath.Join("..", "..", "etc", "passwd"), wantTaint: true},
+		{name: "normal file", file: filepath.Join("sub", "config.yaml"), wantTaint: false},
+		{name: "root entry", file: ".", wantTaint: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeArchivePath(dir, tt.file)
+			if tt.wantTaint {
+				require.Error(t, err, "expected %q to be rejected as tainted", tt.file)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, got == dir || strings.HasPrefix(got, dir+string(filepath.Separator)),
+				"resolved path %q escaped extraction dir %q", got, dir)
+		})
+	}
 }
 
 func TestCleanupArtifacts(t *testing.T) {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->



### Proposed Change
<!-- Please provide a description of the change here. -->
The `sanitizeArchivePath` function could return an archive path that had the same file prefix. This change ensures it is actually in the correct folder.

Ex.
`/tmp/extract` -> `/tmp/extract-other`

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
