### PR TITLE
fix(timezone): embed tz database in v2 distros via timetzdata build tag

### DIFF
--- a/manifests/minimal/manifest.yaml
+++ b/manifests/minimal/manifest.yaml
@@ -3,6 +3,9 @@ dist:
   name: bindplane-distro
   description: Bindplane's minimal distro for the OpenTelemetry Collector
   output_path: ./dist
+  # Embed the IANA tz database so time.LoadLocation (OTTL Time(), etc.) resolves
+  # named zones on any platform, incl. scratch/Windows/AIX with no system tzdata.
+  build_tags: timetzdata
 conf_resolver:
   default_uri_scheme: "env"
 extensions:

--- a/manifests/observIQ/manifest-aix.yaml
+++ b/manifests/observIQ/manifest-aix.yaml
@@ -7,7 +7,9 @@ dist:
   version: "v2.0.1-beta.5"
   output_path: ./builder
   # embed_library enables the telemetrygeneratorreceiver blitz embed integration (PIPE-1017)
-  build_tags: embed_library
+  # timetzdata embeds the IANA tz database so time.LoadLocation resolves named
+  # zones on any platform, incl. scratch/Windows/AIX with no system tzdata.
+  build_tags: embed_library,timetzdata
 conf_resolver:
   default_uri_scheme: "env"
 extensions:

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -7,7 +7,9 @@ dist:
   version: "v2.0.1-beta.5"
   output_path: ./builder
   # embed_library enables the telemetrygeneratorreceiver blitz embed integration (PIPE-1017)
-  build_tags: embed_library
+  # timetzdata embeds the IANA tz database so time.LoadLocation resolves named
+  # zones on any platform, incl. scratch/Windows/AIX with no system tzdata.
+  build_tags: embed_library,timetzdata
 conf_resolver:
   default_uri_scheme: "env"
 extensions:


### PR DESCRIPTION
### Proposed Change
v2 distros embed no tz database, so `time.LoadLocation` (used by OTTL `Time()`, etc.) fails to resolve named IANA zones on any platform without system tzdata: scratch/distroless images, Windows, and AIX. v2 is a pure-ocb build with no hand-written main to hold a `time/tzdata` import the way v1 does. This adds Go's documented build-tag equivalent, `timetzdata`, to `build_tags` in all three ocb manifests (`minimal`, `observIQ`, `observIQ-aix`). The goreleaser configs are `builder: prebuilt` (packaging only), so they need no changes.

### How a reviewer can test
- Build the `observIQ` distro from this branch: `builder --config manifests/observIQ/manifest.yaml`. `go version -m builder/bindplane-otel-collector` shows `-tags=embed_library,timetzdata`.
- Run it with a transform statement that calls `Time(..., "US/Hawaii")`, in an environment with no system tzdata (empty `/usr/share/zoneinfo`, no `$GOROOT/lib/time/zoneinfo.zip`; `unshare -rm` works). It reaches "Everything is ready" and processes. Built without the tag, the same setup fails at startup with `unknown time zone US/Hawaii`, which is the reported bug (OTTL `Time()` resolves the zone via `time.LoadLocation` when the statement is parsed).
- The `minimal` distro is broken for an unrelated reason right now (an `xexporterhelper` module version skew); use `observIQ`.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
