### PR TITLE
chore: Add BINDPLANE_COLLECTOR_HOME env var to packages

### DIFF
--- a/docker/Dockerfile.jmx
+++ b/docker/Dockerfile.jmx
@@ -46,6 +46,7 @@ RUN mkdir \
     && chown -R otel:otel /etc/otel \
     && chmod 0750 /etc/otel/storage
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -40,6 +40,7 @@ COPY --from=stage --chown=otel:otel /etc/otel/storage /etc/otel/storage
 COPY observiq-otel-collector /collector/observiq-otel-collector
 
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -40,6 +40,7 @@ RUN mkdir \
     && chown -R otel:otel /etc/otel \
     && chmod 0750 /etc/otel/storage
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 RUN mkdir /licenses

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -102,6 +102,7 @@ User=root
 Group=${BDOT_GROUP}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
+Environment=BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
 WorkingDirectory=${BDOT_CONFIG_HOME}
 ExecStart=${BDOT_CONFIG_HOME}/observiq-otel-collector --config config.yaml
@@ -222,6 +223,7 @@ PIDFILE=/var/run/"\$BINARY".pid
 
 # Exported variables are used by the collector process.
 export OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
+export BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 export OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
 
 RETVAL=0

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -8,6 +8,8 @@
     <dict>
         <key>OIQ_OTEL_COLLECTOR_HOME</key>
         <string>[INSTALLDIR]</string>
+        <key>BINDPLANE_COLLECTOR_HOME</key>
+        <string>[INSTALLDIR]</string>
         <key>OIQ_OTEL_COLLECTOR_STORAGE</key>
         <string>[INSTALLDIR]storage</string>
     </dict>

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -70,6 +70,7 @@ PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
 export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
 export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -27,6 +27,7 @@ User=root
 Group={{.Group}}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME={{.InstallDir}}
+Environment=BINDPLANE_COLLECTOR_HOME={{.InstallDir}}
 Environment=OIQ_OTEL_COLLECTOR_STORAGE={{.InstallDir}}/storage
 WorkingDirectory={{.InstallDir}}
 ExecStart={{.InstallDir}}/observiq-otel-collector --config config.yaml
@@ -112,6 +113,7 @@ PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
 export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
 export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0

--- a/updater/internal/updater/testdata/observiq-otel-collector.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.golden
@@ -70,6 +70,7 @@ PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
 export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
 export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -9,6 +9,7 @@ User=root
 Group=bdot
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+Environment=BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
 ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -65,6 +65,14 @@
       "part": "all"
     },
     {
+      "name": "BINDPLANE_COLLECTOR_HOME",
+      "value": "[INSTALLDIR]",
+      "permanent": "no",
+      "system": "yes",
+      "action": "set",
+      "part": "all"
+    },
+    {
       "name": "OIQ_USER_GROUP_SID",
       "value": "System.Security.Principal.SecurityIdentifier('S-1-5-32-545')",
       "permanent": "no",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Set BINDPLANE_COLLECTOR_HOME alongside OIQ_OTEL_COLLECTOR_HOME with the same value in the Linux packages, updater service templates, macOS plist/init script, Windows MSI, and Docker images.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
