### PR TITLE
fix: Make MacOS unified logging receiver report the same available components for all platforms

### DIFF
--- a/internal/extension/opampconnectionextension/go.mod
+++ b/internal/extension/opampconnectionextension/go.mod
@@ -266,4 +266,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windo
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260701212116-67bea8600013
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver v0.0.0-20260708173836-48836fd1d949
+
 replace github.com/observiq/bindplane-otel-collector/internal/report => ../../../internal/report

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -258,3 +258,7 @@ replaces:
   # https://github.com/observIQ/opentelemetry-collector-contrib/tree/bdot-1.103.0
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.0.0-20260701212116-67bea8600013
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20260701212116-67bea8600013
+  # https://github.com/observIQ/opentelemetry-collector-contrib/tree/bdot-1.103.0
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49566
+  # this can be removed once the above PR is merged and released. Expected to be in OTel v0.157.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver => github.com/observiq/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver v0.0.0-20260708173836-48836fd1d949


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Most recent commit on https://github.com/observIQ/opentelemetry-collector-contrib/tree/bdot-1.103.0

This was causing inconsistent available components to be reported to Bindplane depending on what platform the collector was installed on.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
