### PR TITLE
fix: Save env name instead of secret key into new `manager.yaml`

### DIFF
--- a/internal/extension/opampconnectionextension/runtime/bootstrap.go
+++ b/internal/extension/opampconnectionextension/runtime/bootstrap.go
@@ -74,7 +74,8 @@ func bootstrapManagerConfig(configPath *string) error {
 			newConfig.AgentID = opamp.AgentIDFromUUID(u)
 		}
 
-		if sk, ok := os.LookupEnv(secretKeyENV); ok {
+		if _, ok := os.LookupEnv(secretKeyENV); ok {
+			sk := fmt.Sprintf("${env:%s}", secretKeyENV)
 			newConfig.SecretKey = &sk
 		}
 		if an, ok := os.LookupEnv(agentNameENV); ok {

--- a/internal/extension/opampconnectionextension/runtime/bootstrap_test.go
+++ b/internal/extension/opampconnectionextension/runtime/bootstrap_test.go
@@ -83,6 +83,25 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestCheckManagerConfigNoFileSecretKeyNotWrittenPlaintext(t *testing.T) {
+	t.Setenv(endpointENV, "0.0.0.0")
+	t.Setenv(secretKeyENV, "supersecret")
+
+	tmpdir := t.TempDir()
+	manager := filepath.Join(tmpdir, "manager.yaml")
+	err := bootstrapManagerConfig(&manager)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(manager)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "supersecret")
+	require.Contains(t, string(raw), "${env:OPAMP_SECRET_KEY}")
+
+	actual, err := opamp.ParseConfig(manager)
+	require.NoError(t, err)
+	require.Equal(t, "supersecret", *actual.SecretKey)
+}
+
 func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->
When creating the `manager.yaml` if the user had the secret key saved as an env variable it would get written to the file system. This broadens the attack surface. This change just writes the env variable name to the file which gets expanded when read.

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
