### PR TITLE
feat: Add Dynatrace edge processing receiver to the manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ OUTDIR=./dist
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+# Private Dynatrace modules (e.g. dt-otelcol-edge-processing-components) are
+# not on the public module proxy or checksum database; fetch them directly
+# from git. Requires git credentials with read access to the Dynatrace org.
+export GOPRIVATE ?= github.com/Dynatrace/*
+
 INTEGRATION_TEST_ARGS?=-tags integration
 
 TOOLS_MOD_DIR := ./internal/tools

--- a/manifests/dbdot/manifest.yaml
+++ b/manifests/dbdot/manifest.yaml
@@ -223,6 +223,10 @@ receivers:
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/splunksearchapireceiver v1.9.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver v1.9.0
   - gomod: github.com/observiq/bindplane-otel-contrib/receiver/windowseventtracereceiver v1.9.0
+  # This project doesn't have a tagged release of this module yet. Will need to generate a ref until tags are ready.
+  # Need `GOPRIVATE=github.com/Dynatrace/*` set in order to access this component.
+  # The current ref points to the last commit that imported OTel v0.155.0/v1.61.0 in order to be compatible with the other components.
+  - gomod: github.com/Dynatrace/dt-otelcol-edge-processing-components/receiver/dtedgeprocessingreceiver v0.0.0-20260629111846-213089236f57
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.155.0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->

Add github.com/Dynatrace/dt-otelcol-edge-processing-components/receiver/dtedgeprocessingreceiver to the collector manifest. The module lives in a private repository, so export GOPRIVATE for the Dynatrace org in the Makefile to bypass the public module proxy and checksum database; builds require git credentials with read access to the org.

The component is deliberately pinned to a pseudo-version for now: the module lives in a subdirectory and the repository only carries a root v0.1.0 tag, which Go cannot resolve for a submodule. Replace the pin with a proper version once the repository tags receiver/dtedgeprocessingreceiver/vX.Y.Z.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
