### PR TITLE
chore: Derive OIQ env vars at startup

### DIFF
--- a/docker/Dockerfile.jmx
+++ b/docker/Dockerfile.jmx
@@ -45,9 +45,8 @@ RUN mkdir \
     /etc/otel/storage \
     && chown -R otel:otel /etc/otel \
     && chmod 0750 /etc/otel/storage
-ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
-ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
+ENV BINDPLANE_COLLECTOR_STORAGE=/etc/otel/storage
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=jdk $JAVA_HOME $JAVA_HOME

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -39,9 +39,8 @@ COPY --from=stage --chown=otel:otel /etc/otel/storage /etc/otel/storage
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
 
-ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
-ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
+ENV BINDPLANE_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -39,9 +39,8 @@ RUN mkdir \
     /etc/otel/storage \
     && chown -R otel:otel /etc/otel \
     && chmod 0750 /etc/otel/storage
-ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV BINDPLANE_COLLECTOR_HOME=/etc/otel
-ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
+ENV BINDPLANE_COLLECTOR_STORAGE=/etc/otel/storage
 
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license

--- a/internal/extension/opampconnectionextension/runtime/run.go
+++ b/internal/extension/opampconnectionextension/runtime/run.go
@@ -74,6 +74,8 @@ type Options struct {
 //  4. Bootstraps manager.yaml from env vars if absent (managed mode entry).
 //  5. Launches the appropriate RunnableService (managed or standalone).
 func Run(opts Options) {
+	setLegacyEnvVars()
+
 	logOpts, err := loadLoggingOptions(opts.LoggingConfigPath)
 	if err != nil {
 		log.Fatalf("Failed to get log options: %v", err)
@@ -114,6 +116,25 @@ func Run(opts Options) {
 
 	if err := service.RunService(logger, runnableService); err != nil {
 		logger.Fatal("RunService returned error", zap.Error(err))
+	}
+}
+
+// setLegacyEnvVars derives the legacy OIQ_* environment variables from the
+// BINDPLANE_* ones. Packages only set the BINDPLANE_* variables; configs and
+// code referencing ${env:OIQ_OTEL_COLLECTOR_HOME} et al. keep working. Must
+// run before logging setup, which expands OIQ_OTEL_COLLECTOR_HOME. An
+// explicitly set OIQ_* variable wins.
+func setLegacyEnvVars() {
+	for legacy, generic := range map[string]string{
+		"OIQ_OTEL_COLLECTOR_HOME":    "BINDPLANE_COLLECTOR_HOME",
+		"OIQ_OTEL_COLLECTOR_STORAGE": "BINDPLANE_COLLECTOR_STORAGE",
+	} {
+		if _, ok := os.LookupEnv(legacy); ok {
+			continue
+		}
+		if v, ok := os.LookupEnv(generic); ok {
+			_ = os.Setenv(legacy, v)
+		}
 	}
 }
 

--- a/internal/extension/opampconnectionextension/runtime/run_test.go
+++ b/internal/extension/opampconnectionextension/runtime/run_test.go
@@ -1,0 +1,73 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetLegacyEnvVars(t *testing.T) {
+	testCases := []struct {
+		name        string
+		env         map[string]string
+		wantHome    string
+		wantStorage string
+	}{
+		{
+			name: "derives legacy vars from generic vars",
+			env: map[string]string{
+				"BINDPLANE_COLLECTOR_HOME":    "/opt/observiq-otel-collector",
+				"BINDPLANE_COLLECTOR_STORAGE": "/opt/observiq-otel-collector/storage",
+			},
+			wantHome:    "/opt/observiq-otel-collector",
+			wantStorage: "/opt/observiq-otel-collector/storage",
+		},
+		{
+			name: "explicitly set legacy var wins",
+			env: map[string]string{
+				"BINDPLANE_COLLECTOR_HOME": "/opt/observiq-otel-collector",
+				"OIQ_OTEL_COLLECTOR_HOME":  "/custom/home",
+			},
+			wantHome: "/custom/home",
+		},
+		{
+			name: "nothing set leaves legacy vars unset",
+			env:  map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, key := range []string{
+				"OIQ_OTEL_COLLECTOR_HOME", "OIQ_OTEL_COLLECTOR_STORAGE",
+				"BINDPLANE_COLLECTOR_HOME", "BINDPLANE_COLLECTOR_STORAGE",
+			} {
+				t.Setenv(key, "")
+				os.Unsetenv(key)
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			setLegacyEnvVars()
+
+			require.Equal(t, tc.wantHome, os.Getenv("OIQ_OTEL_COLLECTOR_HOME"))
+			require.Equal(t, tc.wantStorage, os.Getenv("OIQ_OTEL_COLLECTOR_STORAGE"))
+		})
+	}
+}

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -101,9 +101,8 @@ Type=simple
 User=root
 Group=${BDOT_GROUP}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 Environment=BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
+Environment=BINDPLANE_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
 WorkingDirectory=${BDOT_CONFIG_HOME}
 ExecStart=${BDOT_CONFIG_HOME}/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000
@@ -222,9 +221,8 @@ LOCKFILE=/var/lock/"\$BINARY"
 PIDFILE=/var/run/"\$BINARY".pid
 
 # Exported variables are used by the collector process.
-export OIQ_OTEL_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
 export BINDPLANE_COLLECTOR_HOME=${BDOT_CONFIG_HOME}
-export OIQ_OTEL_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
+export BINDPLANE_COLLECTOR_STORAGE=${BDOT_CONFIG_HOME}/storage
 
 RETVAL=0
 start() {
@@ -359,7 +357,7 @@ otel_status() {
   echo
 }
 
-cd "\$OIQ_OTEL_COLLECTOR_HOME" || exit 1
+cd "\$BINDPLANE_COLLECTOR_HOME" || exit 1
 case "\$1" in
   # Start the service
   start)

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -6,11 +6,9 @@
     <string>com.observiq.collector</string>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>OIQ_OTEL_COLLECTOR_HOME</key>
-        <string>[INSTALLDIR]</string>
         <key>BINDPLANE_COLLECTOR_HOME</key>
         <string>[INSTALLDIR]</string>
-        <key>OIQ_OTEL_COLLECTOR_STORAGE</key>
+        <key>BINDPLANE_COLLECTOR_STORAGE</key>
         <string>[INSTALLDIR]storage</string>
     </dict>
     <key>ProgramArguments</key>

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -69,9 +69,8 @@ LOCKFILE=/var/lock/"$BINARY"
 PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
-export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
-export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+export BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0
 start() {
@@ -206,7 +205,7 @@ otel_status() {
   echo
 }
 
-cd "$OIQ_OTEL_COLLECTOR_HOME" || exit 1
+cd "$BINDPLANE_COLLECTOR_HOME" || exit 1
 case "$1" in
   # Start the service
   start)

--- a/updater/internal/updater/templates.go
+++ b/updater/internal/updater/templates.go
@@ -26,9 +26,8 @@ Type=simple
 User=root
 Group={{.Group}}
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME={{.InstallDir}}
 Environment=BINDPLANE_COLLECTOR_HOME={{.InstallDir}}
-Environment=OIQ_OTEL_COLLECTOR_STORAGE={{.InstallDir}}/storage
+Environment=BINDPLANE_COLLECTOR_STORAGE={{.InstallDir}}/storage
 WorkingDirectory={{.InstallDir}}
 ExecStart={{.InstallDir}}/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000
@@ -112,9 +111,8 @@ LOCKFILE=/var/lock/"$BINARY"
 PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
-export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
-export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+export BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0
 start() {
@@ -249,7 +247,7 @@ otel_status() {
   echo
 }
 
-cd "$OIQ_OTEL_COLLECTOR_HOME" || exit 1
+cd "$BINDPLANE_COLLECTOR_HOME" || exit 1
 case "$1" in
   # Start the service
   start)

--- a/updater/internal/updater/testdata/observiq-otel-collector.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.golden
@@ -69,9 +69,8 @@ LOCKFILE=/var/lock/"$BINARY"
 PIDFILE=/var/run/"$BINARY".pid
 
 # Exported variables are used by the collector process.
-export OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 export BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
-export OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+export BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 
 RETVAL=0
 start() {
@@ -206,7 +205,7 @@ otel_status() {
   echo
 }
 
-cd "$OIQ_OTEL_COLLECTOR_HOME" || exit 1
+cd "$BINDPLANE_COLLECTOR_HOME" || exit 1
 case "$1" in
   # Start the service
   start)

--- a/updater/internal/updater/testdata/observiq-otel-collector.service.golden
+++ b/updater/internal/updater/testdata/observiq-otel-collector.service.golden
@@ -8,9 +8,8 @@ Type=simple
 User=root
 Group=bdot
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=BINDPLANE_COLLECTOR_HOME=/opt/observiq-otel-collector
-Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+Environment=BINDPLANE_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
 ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
 LimitNOFILE=65000

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -49,16 +49,8 @@
   ],
   "environments": [
     {
-      "name": "OIQ_OTEL_COLLECTOR_STORAGE",
+      "name": "BINDPLANE_COLLECTOR_STORAGE",
       "value": "[INSTALLDIR]storage",
-      "permanent": "no",
-      "system": "yes",
-      "action": "set",
-      "part": "all"
-    },
-    {
-      "name": "OIQ_OTEL_COLLECTOR_HOME",
-      "value": "[INSTALLDIR]",
       "permanent": "no",
       "system": "yes",
       "action": "set",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Packages no longer preset OIQ_OTEL_COLLECTOR_HOME/OIQ_OTEL_COLLECTOR_STORAGE; they set BINDPLANE_COLLECTOR_HOME and the new BINDPLANE_COLLECTOR_STORAGE. The collector derives the legacy OIQ_* vars at startup so existing configs referencing them keep working. An explicitly set OIQ_* var wins.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
