### PR TITLE
chore: Use BINDPLANE_COLLECTOR_STORAGE in plugin templates

### DIFF
--- a/docs/plugins/bindplane_logs.md
+++ b/docs/plugins/bindplane_logs.md
@@ -9,7 +9,7 @@ Log parser for Bindplane Observability Pipeline.
 | log_paths | A list of file glob patterns that match the file paths to be read | []string | `[/var/log/bindplane/bindplane.log]` | false |  |
 | exclude_file_log_path | A list of file glob patterns to exclude from reading | []string | `[/var/log/bindplane/bindplane-*.log.gz]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
 ## Example Config:
@@ -24,6 +24,6 @@ receivers:
       log_paths: [/var/log/bindplane/bindplane.log]
       exclude_file_log_path: [/var/log/bindplane/bindplane-*.log.gz]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       parse: true
 ```

--- a/docs/plugins/cockroachdb_logs.md
+++ b/docs/plugins/cockroachdb_logs.md
@@ -25,7 +25,7 @@ Log parser for CockroachDB
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
 ## Example Config:
@@ -56,6 +56,6 @@ receivers:
       save_log_record_original: false
       retain_raw_logs: false
       parse_to: body
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       parse: true
 ```

--- a/docs/plugins/container_logs.md
+++ b/docs/plugins/container_logs.md
@@ -13,7 +13,7 @@ Log parser for Kubernetes Container logs. This plugin is meant to be used with t
 | body_json_parsing | If the application log is detected as json, parse the values into the log entry's body. | bool | `true` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | log_driver | The container runtime's log driver used to write container logs to disk. Valid options include `auto`, `docker-json-file` and `containerd-cri`. When set to `auto`, the format will be detected using regex. Format detection is convenient but comes with the cost of performing a regex match against every log entry read by the file_log receiver. | string | `auto` | false | `auto`, `docker-json-file`, `containerd-cri` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
 ## Example Config:
@@ -32,6 +32,6 @@ receivers:
       body_json_parsing: true
       start_at: end
       log_driver: auto
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       parse: true
 ```

--- a/docs/plugins/file_logs.md
+++ b/docs/plugins/file_logs.md
@@ -18,7 +18,7 @@ Log parser for generic files
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
 ## Example Config:
@@ -40,6 +40,6 @@ receivers:
       start_at: end
       retain_raw_logs: false
       parse_to: body
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       parse: true
 ```

--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -19,7 +19,7 @@ Log parser for IIS
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`). | string | `beginning` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -44,7 +44,7 @@ receivers:
       start_at: beginning
       retain_raw_logs: false
       parse_to: body
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/jboss_logs.md
+++ b/docs/plugins/jboss_logs.md
@@ -9,7 +9,7 @@ Log parser for JBoss
 | file_path | The absolute path to the JBoss logs | []string | `[/usr/local/JBoss/EAP-*/*/log/server.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -25,7 +25,7 @@ receivers:
       file_path: [/usr/local/JBoss/EAP-*/*/log/server.log]
       start_at: end
       timezone: UTC
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/kafka_logs.md
+++ b/docs/plugins/kafka_logs.md
@@ -16,7 +16,7 @@ Log parser for Apache Kafka
 | log_cleaner_log_path | Apache Kafka log-cleaner log path | []string | `[/home/kafka/kafka/logs/log-cleaner.log*]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -39,7 +39,7 @@ receivers:
       log_cleaner_log_path: [/home/kafka/kafka/logs/log-cleaner.log*]
       start_at: end
       timezone: UTC
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/macos_logs.md
+++ b/docs/plugins/macos_logs.md
@@ -11,7 +11,7 @@ Log parser for macOS
 | enable_install_log | Enable to collect MacOS install logs | bool | `true` | false |  |
 | install_log_path | The absolute path to the Install log | []string | `[/var/log/install.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -29,7 +29,7 @@ receivers:
       enable_install_log: true
       install_log_path: [/var/log/install.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/mongodb_logs.md
+++ b/docs/plugins/mongodb_logs.md
@@ -10,7 +10,7 @@ Log parser for MongoDB
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -27,7 +27,7 @@ receivers:
       start_at: end
       retain_raw_logs: false
       parse_to: body
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/mysql_logs.md
+++ b/docs/plugins/mysql_logs.md
@@ -25,7 +25,7 @@ To enable slow query logging run the following with an admin user:
 | enable_mariadb_audit_log | Enable to collect MySQL audit logs provided by MariaDB Audit plugin | bool | `false` | false |  |
 | mariadb_audit_log_paths | Path to audit log file created by MariaDB plugin | []string | `[/var/log/mysql/audit.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -47,7 +47,7 @@ receivers:
       enable_mariadb_audit_log: false
       mariadb_audit_log_paths: [/var/log/mysql/audit.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/nginx_logs.md
+++ b/docs/plugins/nginx_logs.md
@@ -14,7 +14,7 @@ Log parser for NGINX
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | encoding | Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected | string | `utf-8` | false | `nop`, `utf-8`, `utf-16le`, `utf-16be`, `ascii`, `big5` |
 | data_flow | High mode keeps all entries, low mode filters out based on http request status | string | `high` | false | `high`, `low` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -35,7 +35,7 @@ receivers:
       start_at: end
       encoding: utf-8
       data_flow: high
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/oracle_database_logs.md
+++ b/docs/plugins/oracle_database_logs.md
@@ -13,7 +13,7 @@ Oracle Database
 | enable_listener_log | Enable to collect OracleDB listener logs | bool | `true` | false |  |
 | listener_log_path | Path to the listener log file | []string | `[/u01/app/oracle/product/*/dbhome_1/diag/tnslsnr/*/listener/alert/log.xml]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -33,7 +33,7 @@ receivers:
       enable_listener_log: true
       listener_log_path: [/u01/app/oracle/product/*/dbhome_1/diag/tnslsnr/*/listener/alert/log.xml]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/pgbouncer_logs.md
+++ b/docs/plugins/pgbouncer_logs.md
@@ -8,7 +8,7 @@ Log parser for PgBouncer
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_path | The absolute path to the PgBouncer logs | []string | `[/var/log/pgbouncer/pgbouncer.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -23,7 +23,7 @@ receivers:
     parameters:
       file_path: [/var/log/pgbouncer/pgbouncer.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/postgresql_logs.md
+++ b/docs/plugins/postgresql_logs.md
@@ -16,7 +16,7 @@ Slow query logging can be enabled via the following steps:
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | postgresql_log_path | Path to the PostgreSQL log file | []string | `[/var/log/postgresql/postgresql*.log /var/lib/pgsql/data/log/postgresql*.log /var/lib/pgsql/*/data/log/postgresql*.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -31,7 +31,7 @@ receivers:
     parameters:
       postgresql_log_path: [/var/log/postgresql/postgresql*.log /var/lib/pgsql/data/log/postgresql*.log /var/lib/pgsql/*/data/log/postgresql*.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/rabbitmq_logs.md
+++ b/docs/plugins/rabbitmq_logs.md
@@ -8,7 +8,7 @@ Log parser for RabbitMQ
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | daemon_log_paths | The absolute path to the RabbitMQ Daemon logs | []string | `[/var/log/rabbitmq/rabbit@*.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -23,7 +23,7 @@ receivers:
     parameters:
       daemon_log_paths: [/var/log/rabbitmq/rabbit@*.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/redis_logs.md
+++ b/docs/plugins/redis_logs.md
@@ -8,7 +8,7 @@ Log parser for Redis
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_path | The absolute path to the Redis logs | []string | `[/var/log/redis/redis-server.log /var/log/redis_6379.log /var/log/redis/redis.log /var/log/redis/default.log /var/log/redis/redis_6379.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -23,7 +23,7 @@ receivers:
     parameters:
       file_path: [/var/log/redis/redis-server.log /var/log/redis_6379.log /var/log/redis/redis.log /var/log/redis/default.log /var/log/redis/redis_6379.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/sap_hana_logs.md
+++ b/docs/plugins/sap_hana_logs.md
@@ -10,7 +10,7 @@ Log parser for SAP HANA
 | exclude | The directories to exclude for the SAP HANA trace logs. | []string | `[/usr/sap/*/HDB*/*/trace/nameserver_history*.trc /usr/sap/*/HDB*/*/trace/nameserver*loads*.trc /usr/sap/*/HDB*/*/trace/nameserver*unlaods*.trc /usr/sap/*/HDB*/*/trace/nameserver*executed_statements*.trc]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -27,7 +27,7 @@ receivers:
       exclude: [/usr/sap/*/HDB*/*/trace/nameserver_history*.trc /usr/sap/*/HDB*/*/trace/nameserver*loads*.trc /usr/sap/*/HDB*/*/trace/nameserver*unlaods*.trc /usr/sap/*/HDB*/*/trace/nameserver*executed_statements*.trc]
       start_at: end
       timezone: UTC
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/solr_logs.md
+++ b/docs/plugins/solr_logs.md
@@ -8,7 +8,7 @@ Log parser for Solr
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_log_path | The absolute path to the Solr logs | []string | `[/var/solr/logs/solr.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -23,7 +23,7 @@ receivers:
     parameters:
       file_log_path: [/var/solr/logs/solr.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/tomcat_logs.md
+++ b/docs/plugins/tomcat_logs.md
@@ -15,7 +15,7 @@ Log parser for Apache Tomcat
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp. | timezone | `UTC` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -37,7 +37,7 @@ receivers:
       start_at: end
       timezone: UTC
       parse_to: body
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/w3c_logs.md
+++ b/docs/plugins/w3c_logs.md
@@ -25,7 +25,7 @@ Log Parser for W3C
 | header | The W3C header which specifies the field names. Field names will be auto detected if unspecified. | string |  | false |  |
 | delimiter | Delimiter character used between fields (Defaults to a tab character) | string | `	` | false |  |
 | header_delimiter | Delimiter character used between header fields (Defaults to the value of 'delimiter') | string |  | false |  |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -53,7 +53,7 @@ receivers:
       include_file_path: false
       include_file_name_resolved: false
       include_file_path_resolved: false
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/wildfly_logs.md
+++ b/docs/plugins/wildfly_logs.md
@@ -13,7 +13,7 @@ Log parser for Wildfly
 | domain_controller_path | Path to domain controller logs | []string | `[/opt/wildfly/domain/log/*.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -33,7 +33,7 @@ receivers:
       domain_controller_path: [/opt/wildfly/domain/log/*.log]
       start_at: end
       timezone: UTC
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/windows_dhcp.md
+++ b/docs/plugins/windows_dhcp.md
@@ -8,7 +8,7 @@ Log parser for Windows DHCP
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_path | <nil> | []string | `[C:/Windows/System32/dhcp/DhcpSrvLog-*.log]` | false |  |
 | start_at | <nil> | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -23,7 +23,7 @@ receivers:
     parameters:
       file_path: [C:/Windows/System32/dhcp/DhcpSrvLog-*.log]
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/docs/plugins/zookeeper_logs.md
+++ b/docs/plugins/zookeeper_logs.md
@@ -9,7 +9,7 @@ Log parser for Apache Zookeeper
 | file_path | The absolute path to the Zookeeper logs | []string | `[/home/kafka/kafka/logs/zookeeper.log]` | false |  |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:OIQ_OTEL_COLLECTOR_HOME}/storage` | false |  |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `${env:BINDPLANE_COLLECTOR_STORAGE}` | false |  |
 | save_log_record_original | Enable to preserve the original log message in a `log.record.original` key. | bool | `false` | false |  |
 | parse | When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field. | bool | `true` | false |  |
 
@@ -25,7 +25,7 @@ receivers:
       file_path: [/home/kafka/kafka/logs/zookeeper.log]
       timezone: UTC
       start_at: end
-      offset_storage_dir: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+      offset_storage_dir: ${env:BINDPLANE_COLLECTOR_STORAGE}
       save_log_record_original: false
       parse: true
 ```

--- a/plugins/bindplane_logs.yaml
+++ b/plugins/bindplane_logs.yaml
@@ -22,7 +22,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: parse
     description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
     type: bool

--- a/plugins/cockroachdb_logs.yaml
+++ b/plugins/cockroachdb_logs.yaml
@@ -94,7 +94,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: parse
     description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
     type: bool

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -54,7 +54,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: parse
     description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
     type: bool

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -72,7 +72,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: parse
     description: When enabled, parses the log fields into structured attributes. When disabled, sends the raw log message in the body field.
     type: bool

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -67,7 +67,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/jboss_logs.yaml
+++ b/plugins/jboss_logs.yaml
@@ -21,7 +21,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/kafka_logs.yaml
+++ b/plugins/kafka_logs.yaml
@@ -52,7 +52,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/macos_logs.yaml
+++ b/plugins/macos_logs.yaml
@@ -30,7 +30,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -29,7 +29,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/mysql_logs.yaml
+++ b/plugins/mysql_logs.yaml
@@ -63,7 +63,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -58,7 +58,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/oracle_database_logs.yaml
+++ b/plugins/oracle_database_logs.yaml
@@ -39,7 +39,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -17,7 +17,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/postgresql_logs.yaml
+++ b/plugins/postgresql_logs.yaml
@@ -30,7 +30,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/rabbitmq_logs.yaml
+++ b/plugins/rabbitmq_logs.yaml
@@ -16,7 +16,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/redis_logs.yaml
+++ b/plugins/redis_logs.yaml
@@ -26,7 +26,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/sap_hana_logs.yaml
+++ b/plugins/sap_hana_logs.yaml
@@ -29,7 +29,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/solr_logs.yaml
+++ b/plugins/solr_logs.yaml
@@ -18,7 +18,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -49,7 +49,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -94,7 +94,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/wildfly_logs.yaml
+++ b/plugins/wildfly_logs.yaml
@@ -39,7 +39,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -15,7 +15,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool

--- a/plugins/zookeeper_logs.yaml
+++ b/plugins/zookeeper_logs.yaml
@@ -21,7 +21,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: ${env:OIQ_OTEL_COLLECTOR_HOME}/storage
+    default: ${env:BINDPLANE_COLLECTOR_STORAGE}
   - name: save_log_record_original
     description: Enable to preserve the original log message in a `log.record.original` key.
     type: bool


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Replace the ${env:OIQ_OTEL_COLLECTOR_HOME}/storage offset_storage_dir default with ${env:BINDPLANE_COLLECTOR_STORAGE} in all plugin templates and regenerate the plugin docs.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
