### PR TITLE
chore(linux): Set systemd unit file ownership to root:bdot

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -116,7 +116,9 @@ KillMode=process
 WantedBy=multi-user.target
 EOF
 
-  chown root:root "$config_file"
+  # Own the unit file by root:<runtime group> so the collector's runtime user
+  # (a member of BDOT_GROUP) can read it. Mode stays 0640 (group-readable only).
+  chown "root:${BDOT_GROUP}" "$config_file"
   chmod 0640 "$config_file"
 
   # Ensure the override dir exists.

--- a/updater/internal/service/service_linux.go
+++ b/updater/internal/service/service_linux.go
@@ -22,7 +22,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/observiq/bindplane-otel-collector/updater/internal/file"
 	"github.com/observiq/bindplane-otel-collector/updater/internal/path"
@@ -150,6 +153,56 @@ func (l linuxSystemdService) install() error {
 		return fmt.Errorf("enabling unit file failed: %w", err)
 	}
 
+	// Own the installed unit file root:<collector group> with 0640 so a non-root
+	// runtime user (member of the collector group) can read it. The group comes
+	// from the Group= directive in the service file we just installed.
+	group, err := collectorGroupFromServiceFile(l.newServiceFilePath)
+	if err != nil {
+		return fmt.Errorf("determine collector group: %w", err)
+	}
+	if err := setSystemdUnitOwnership(l.installedServiceFilePath, group); err != nil {
+		return fmt.Errorf("set unit file ownership: %w", err)
+	}
+
+	return nil
+}
+
+// collectorGroupFromServiceFile extracts the "Group=" value from a systemd unit
+// file. Returns an error if the directive is absent.
+func collectorGroupFromServiceFile(path string) (string, error) {
+	// #nosec G304 -- path is an internal service file path, not user input
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read service file: %w", err)
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Group=") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Group=")), nil
+		}
+	}
+	return "", fmt.Errorf("Group= not found in %s", path)
+}
+
+// setSystemdUnitOwnership sets the installed unit file to root:<group> with mode
+// 0640 so the collector's runtime user (a member of <group>) can read it.
+func setSystemdUnitOwnership(installedPath, group string) error {
+	g, err := user.LookupGroup(group)
+	if err != nil {
+		return fmt.Errorf("lookup group %q: %w", group, err)
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return fmt.Errorf("parse gid %q for group %q: %w", g.Gid, group, err)
+	}
+	if err := os.Chown(installedPath, 0, gid); err != nil {
+		return fmt.Errorf("chown %s to root:%s: %w", installedPath, group, err)
+	}
+	// #nosec G302 -- 0640 is intentional: group read is what lets the non-root
+	// runtime user (a member of the collector group) read the unit file.
+	if err := os.Chmod(installedPath, 0640); err != nil {
+		return fmt.Errorf("chmod %s to 0640: %w", installedPath, err)
+	}
 	return nil
 }
 

--- a/updater/internal/service/service_linux_systemd_test.go
+++ b/updater/internal/service/service_linux_systemd_test.go
@@ -20,7 +20,10 @@ package service
 import (
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/observiq/bindplane-otel-collector/updater/internal/path"
@@ -54,6 +57,46 @@ func TestLinuxSystemdServiceInstall(t *testing.T) {
 
 		//Make sure the service is no longer listed
 		requireSystemdServiceLoadedStatus(t, false)
+	})
+
+	t.Run("Test systemd install sets root:group 0640 ownership", func(t *testing.T) {
+		if os.Geteuid() != 0 {
+			t.Skip("requires root to chown to uid 0")
+		}
+
+		installedServicePath := "/usr/lib/systemd/system/linux-service.service"
+		uninstallSystemdService(t, installedServicePath, "linux-service")
+
+		l := &linuxSystemdService{
+			newServiceFilePath:       filepath.Join("testdata", "linux-service.service"),
+			serviceName:              "linux-service",
+			installedServiceFilePath: installedServicePath,
+			logger:                   zaptest.NewLogger(t),
+		}
+
+		err := l.install()
+		require.NoError(t, err)
+		require.FileExists(t, installedServicePath)
+
+		// The group comes from the Group= directive in testdata/linux-service.service.
+		group, err := collectorGroupFromServiceFile(l.newServiceFilePath)
+		require.NoError(t, err)
+		g, err := user.LookupGroup(group)
+		require.NoError(t, err)
+		wantGid, err := strconv.Atoi(g.Gid)
+		require.NoError(t, err)
+
+		info, err := os.Stat(installedServicePath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0640), info.Mode().Perm(), "unit file mode should be 0640")
+
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		require.True(t, ok, "expected *syscall.Stat_t")
+		require.Equal(t, uint32(0), stat.Uid, "unit file should be owned by root")
+		require.Equal(t, uint32(wantGid), stat.Gid, "unit file group should match Group= directive")
+
+		require.NoError(t, l.uninstall())
+		require.NoFileExists(t, installedServicePath)
 	})
 
 	t.Run("Test systemd stop + start", func(t *testing.T) {

--- a/updater/internal/service/service_linux_test.go
+++ b/updater/internal/service/service_linux_test.go
@@ -1,0 +1,75 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectorGroupFromServiceFile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		contents string
+		expected string
+		errSubst string
+	}{
+		{
+			name:     "default group",
+			contents: "[Service]\nUser=root\nGroup=bdot\nExecStart=sleep 1000\n",
+			expected: "bdot",
+		},
+		{
+			name:     "custom group",
+			contents: "[Service]\nUser=root\nGroup=collector\nExecStart=sleep 1000\n",
+			expected: "collector",
+		},
+		{
+			name:     "trims whitespace",
+			contents: "[Service]\nUser=root\n  Group=bdot  \nExecStart=sleep 1000\n",
+			expected: "bdot",
+		},
+		{
+			name:     "group absent",
+			contents: "[Service]\nUser=root\nExecStart=sleep 1000\n",
+			errSubst: "Group= not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "unit.service")
+			require.NoError(t, os.WriteFile(p, []byte(tc.contents), 0600))
+
+			group, err := collectorGroupFromServiceFile(p)
+			if tc.errSubst != "" {
+				require.ErrorContains(t, err, tc.errSubst)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, group)
+		})
+	}
+
+	t.Run("file does not exist", func(t *testing.T) {
+		_, err := collectorGroupFromServiceFile(filepath.Join(t.TempDir(), "does-not-exist.service"))
+		require.ErrorContains(t, err, "read service file")
+	})
+}

--- a/updater/internal/service/testdata/linux-service.service
+++ b/updater/internal/service/testdata/linux-service.service
@@ -4,6 +4,7 @@ After=network.target
 [Service]
 Type=simple
 User=root
+Group=root
 ExecStart=sleep 1000
 SuccessExitStatus=0
 [Install]


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
