### PR TITLE
chore(ci): retry external curl downloads (PIPE-1244)

### DIFF
--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -75,8 +75,8 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
           unzip wix314-binaries.zip
         working-directory: C:/build
       - name: Build MSI

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -56,8 +56,8 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
           unzip wix314-binaries.zip
         working-directory: C:/build
       - name: Build MSI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
           unzip wix314-binaries.zip
         working-directory: C:/build
       - name: Build MSI


### PR DESCRIPTION
### Proposed Change

The msi build-tool downloads (`go-msi.exe`, `wix314-binaries.zip`) used bare `curl`, so a
transient network blip failed the build. Each now retries transient failures, keeping `-f`
so a 404 still fails hard. Applies to the build-msi jobs across the release and manual-msi
workflows.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
