### PR TITLE
chore(ci): retry cloud-CLI artifact upload/download (PIPE-1245)

### DIFF
--- a/.github/workflows/manual_gcs_release_test.yml
+++ b/.github/workflows/manual_gcs_release_test.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Install Gcloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Test Gsutil
-        run: gsutil ls gs://bdot-release
-      - run: gsutil cp LICENSE gs://bdot-release/LICENSE
-      - run: gsutil rm gs://bdot-release/LICENSE
+        run: |
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gsutil ls gs://bdot-release
+      - run: |
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gsutil cp LICENSE gs://bdot-release/LICENSE
+      - run: |
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gsutil rm gs://bdot-release/LICENSE

--- a/.github/workflows/release-containers-test.yml
+++ b/.github/workflows/release-containers-test.yml
@@ -26,11 +26,12 @@ jobs:
           credentials_json: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_CREDENTIALS }}
       - name: Download Linux Binaries from GCS
         run: |
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
           mkdir -p tmp
           VERSION=${{ github.event.inputs.version }}
           for ARCH in amd64 arm64 ppc64le; do
             ARCHIVE="observiq-otel-collector-${VERSION}-linux-${ARCH}.tar.gz"
-            gsutil cp "gs://bdot-release/${VERSION}/${ARCHIVE}" tmp/
+            retry gsutil cp "gs://bdot-release/${VERSION}/${ARCHIVE}" tmp/
             mkdir -p "tmp/${ARCH}"
             tar -xzf "tmp/${ARCHIVE}" -C "tmp/${ARCH}" observiq-otel-collector
             mv "tmp/${ARCH}/observiq-otel-collector" "tmp/collector_linux_${ARCH}"

--- a/.github/workflows/release-containers.yml
+++ b/.github/workflows/release-containers.yml
@@ -38,11 +38,12 @@ jobs:
           credentials_json: ${{ secrets.BDOT_GCS_RELEASE_BUCKET_CREDENTIALS }}
       - name: Download Linux Binaries from GCS
         run: |
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
           mkdir -p tmp
           VERSION=${{ github.event.inputs.version }}
           for ARCH in amd64 arm64 ppc64le; do
             ARCHIVE="observiq-otel-collector-${VERSION}-linux-${ARCH}.tar.gz"
-            gsutil cp "gs://bdot-release/${VERSION}/${ARCHIVE}" tmp/
+            retry gsutil cp "gs://bdot-release/${VERSION}/${ARCHIVE}" tmp/
             mkdir -p "tmp/${ARCH}"
             tar -xzf "tmp/${ARCHIVE}" -C "tmp/${ARCH}" observiq-otel-collector
             mv "tmp/${ARCH}/observiq-otel-collector" "tmp/collector_linux_${ARCH}"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -225,7 +225,8 @@ jobs:
 
       - name: Upload Bindplane Linux AMD64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
@@ -233,7 +234,8 @@ jobs:
 
       - name: Upload Bindplane Linux AMD64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
@@ -241,7 +243,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
@@ -249,7 +252,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
@@ -257,7 +261,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM32 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
@@ -265,7 +270,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM32 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
@@ -273,7 +279,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64LE Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
@@ -281,7 +288,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64LE RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \
@@ -289,7 +297,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload devel-deb \
             --location us-central1 \
@@ -297,7 +306,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload devel-rpm \
             --location us-central1 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,11 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.ORG_COSIGN_PWD }}
       - name: Upload Latest Install Scripts
         run: |
-          gsutil cp ./scripts/install/install_unix.sh gs://bdot-release/latest/install_unix.sh
-          gsutil cp ./scripts/install/install_macos.sh gs://bdot-release/latest/install_macos.sh
-          gsutil cp ./scripts/install/install_windows.ps1 gs://bdot-release/latest/install_windows.ps1
-          gsutil cp ./release_deps/gpg-keys.tar.gz gs://bdot-release/latest/gpg-keys.tar.gz
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gsutil cp ./scripts/install/install_unix.sh gs://bdot-release/latest/install_unix.sh
+          retry gsutil cp ./scripts/install/install_macos.sh gs://bdot-release/latest/install_macos.sh
+          retry gsutil cp ./scripts/install/install_windows.ps1 gs://bdot-release/latest/install_windows.ps1
+          retry gsutil cp ./release_deps/gpg-keys.tar.gz gs://bdot-release/latest/gpg-keys.tar.gz
       - name: Upload artifact bundle to release
         uses: AButler/upload-release-assets@v2.0
         with:
@@ -230,7 +231,8 @@ jobs:
 
       - name: Upload Bindplane Linux AMD64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload stable-deb \
             --location us-central1 \
@@ -238,7 +240,8 @@ jobs:
 
       - name: Upload Bindplane Linux AMD64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload stable-rpm \
             --location us-central1 \
@@ -246,7 +249,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload stable-deb \
             --location us-central1 \
@@ -254,7 +258,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload stable-rpm \
             --location us-central1 \
@@ -262,7 +267,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM32 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload stable-deb \
             --location us-central1 \
@@ -270,7 +276,8 @@ jobs:
 
       - name: Upload Bindplane Linux ARM32 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload stable-rpm \
             --location us-central1 \
@@ -278,7 +285,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64LE Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload stable-deb \
             --location us-central1 \
@@ -286,7 +294,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64LE RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload stable-rpm \
             --location us-central1 \
@@ -294,7 +303,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64 Deb Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts apt upload stable-deb \
             --location us-central1 \
@@ -302,7 +312,8 @@ jobs:
 
       - name: Upload Bindplane Linux PPC64 RPM Package
         run: |
-          gcloud \
+          retry(){ for i in 1 2 3; do "$@" && return 0; sleep $((i*10)); done; return 1; }
+          retry gcloud \
             --project bindplane-repository \
             artifacts yum upload stable-rpm \
             --location us-central1 \


### PR DESCRIPTION
### Proposed Change

Release and publish steps moved artifacts with `gsutil` and `gcloud artifacts` with no
retry, so a transient 5xx failed an expensive release job. Each call is now wrapped in
bounded retry with backoff. Destinations are fixed-path overwrites, so a retry is safe.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
