### PR TITLE
chore(ci): retry go install @version and make install-ocb (PIPE-1246)

### DIFF
--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -46,8 +46,13 @@ jobs:
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
       - name: Install ocb
-        run: make install-ocb
-        shell: bash
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          shell: bash
+          command: make install-ocb
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash

--- a/.github/workflows/manual_multi_build.yml
+++ b/.github/workflows/manual_multi_build.yml
@@ -20,13 +20,23 @@ jobs:
             go.sum
             **/go.sum
       - name: Install ocb
-        run: make install-ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: make install-ocb
       - name: Build
         run: make build-linux
+      - name: Install lichen
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: go install github.com/uw-labs/lichen@v0.1.7
       - name: Scan Third Party Dependency Licenses
-        run: |
-          go install github.com/uw-labs/lichen@v0.1.7
-          lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
+        run: lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_darwin:
     if: github.actor != 'dependabot[bot]'
     runs-on: macos-14
@@ -41,13 +51,23 @@ jobs:
             go.sum
             **/go.sum
       - name: Install ocb
-        run: make install-ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: make install-ocb
       - name: Build
         run: make build-darwin
+      - name: Install lichen
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: go install github.com/uw-labs/lichen@v0.1.7
       - name: Scan Third Party Dependency Licenses
-        run: |
-          go install github.com/uw-labs/lichen@v0.1.7
-          lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
+        run: lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest-4-cores
@@ -62,10 +82,20 @@ jobs:
             go.sum
             **/go.sum
       - name: Install ocb
-        run: make install-ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: make install-ocb
       - name: Build
         run: make build-windows
+      - name: Install lichen
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: go install github.com/uw-labs/lichen@v0.1.7
       - name: Scan Third Party Dependency Licenses
-        run: |
-          go install github.com/uw-labs/lichen@v0.1.7
-          lichen --config=./license.yaml dist/collector_windows_amd64.exe dist/updater_windows_amd64.exe dist/collector_windows_arm64.exe dist/updater_windows_arm64.exe
+        run: lichen --config=./license.yaml dist/collector_windows_amd64.exe dist/updater_windows_amd64.exe dist/collector_windows_arm64.exe dist/updater_windows_arm64.exe

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -27,8 +27,13 @@ jobs:
         with:
           go-version-file: internal/extension/opampconnectionextension/go.mod
       - name: Install ocb
-        run: make install-ocb
-        shell: bash
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          shell: bash
+          command: make install-ocb
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash
@@ -113,7 +118,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install ocb
-        run: make install-ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: make install-ocb
 
       - name: Retrieve Windows AMD64 MSI Installer
         uses: actions/download-artifact@v8
@@ -126,7 +136,12 @@ jobs:
           name: observiq-otel-collector-arm64.msi
 
       - name: Install cosign
-        run: go install github.com/sigstore/cosign/cmd/cosign@v1.13.1
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: go install github.com/sigstore/cosign/cmd/cosign@v1.13.1
       - name: Build cosign key file
         run: 'echo "$COSIGN_PRIVATE_KEY" >> cosign.key'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,13 @@ jobs:
           go-version-file: internal/extension/opampconnectionextension/go.mod
           cache-dependency-path: "**/go.sum"
       - name: Install ocb
-        run: make install-ocb
-        shell: bash
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          shell: bash
+          command: make install-ocb
       - name: Prepare Release Dependencies
         run: make release-prep CURR_VERSION=${VERSION#v}
         shell: bash
@@ -125,7 +130,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install ocb
-        run: make install-ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: make install-ocb
       - name: Retrieve Windows AMD64 MSI Installer
         uses: actions/download-artifact@v4
         with:
@@ -135,7 +145,12 @@ jobs:
         with:
           name: observiq-otel-collector-arm64.msi
       - name: Install cosign
-        run: go install github.com/sigstore/cosign/cmd/cosign@v1.13.1
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: go install github.com/sigstore/cosign/cmd/cosign@v1.13.1
       - name: Build cosign key file
         run: 'echo "$COSIGN_PRIVATE_KEY" >> cosign.key'
         shell: bash


### PR DESCRIPTION
### Proposed Change

Standalone `go install pkg@version` (cosign, lichen) and `make install-ocb` fetch over the
module proxy and GitHub with no retry. Each step is now wrapped in `nick-fields/retry`. The
lichen step is split so only the install retries, leaving the license scan to fail hard on a
real violation.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
