### PR TITLE
feat: add Datadog receiver (BPP-565)

### DIFF
--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -28,6 +28,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Cloudflare Receiver                        | [cloudflarereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/cloudflarereceiver/README.md)                         |
 | Cloud Foundry Receiver                     | [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/cloudfoundryreceiver/README.md)                     |
 | collectd write_http Plugin JSON Receiver   | [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/collectdreceiver/README.md)                             |
+| Datadog Receiver                           | [datadogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/datadogreceiver/README.md)                               |
 | Docker Stats Receiver                      | [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/dockerstatsreceiver/README.md)                       |
 | Elasticsearch Receiver                     | [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/elasticsearchreceiver/README.md)                   |
 | File Log Receiver                          | [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/receiver/filelogreceiver/README.md)                               |

--- a/manifests/observIQ/manifest.yaml
+++ b/manifests/observIQ/manifest.yaml
@@ -149,6 +149,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.157.0


### PR DESCRIPTION
### Proposed Change

Adds the upstream Datadog receiver, pinned to v0.157.0 to match the rest of the contrib components.

`make verify-manifest` passes. To validate locally, run `make agent` and confirm `datadogreceiver` appears in the generated `build/components.go`.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
