### PR TITLE
feat(opamp): Check for `RetryAfterNanoseconds` in error response

### DIFF
--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
@@ -1,0 +1,92 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observiq
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opamp-go/client"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+// gatedOpAMPClient wraps a client.OpAMPClient so that every call which
+// results in a message being sent to the Server first waits on a sendGate.
+// Start, Stop, and AgentDescription are passed straight through since they
+// don't send new outgoing data (or, in the case of Stop, must never be
+// delayed).
+type gatedOpAMPClient struct {
+	client.OpAMPClient
+	gate *sendGate
+}
+
+// newGatedOpAMPClient wraps underlying so that outgoing messages honor gate.
+func newGatedOpAMPClient(underlying client.OpAMPClient, gate *sendGate) client.OpAMPClient {
+	return &gatedOpAMPClient{OpAMPClient: underlying, gate: gate}
+}
+
+func (g *gatedOpAMPClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetAgentDescription(descr)
+}
+
+func (g *gatedOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetHealth(health)
+}
+
+func (g *gatedOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
+	g.gate.wait()
+	return g.OpAMPClient.UpdateEffectiveConfig(ctx)
+}
+
+func (g *gatedOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetRemoteConfigStatus(status)
+}
+
+func (g *gatedOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetPackageStatuses(statuses)
+}
+
+func (g *gatedOpAMPClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+	g.gate.wait()
+	return g.OpAMPClient.RequestConnectionSettings(request)
+}
+
+func (g *gatedOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetCustomCapabilities(customCapabilities)
+}
+
+func (g *gatedOpAMPClient) SetFlags(flags protobufs.AgentToServerFlags) {
+	g.gate.wait()
+	g.OpAMPClient.SetFlags(flags)
+}
+
+func (g *gatedOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
+	g.gate.wait()
+	return g.OpAMPClient.SendCustomMessage(message)
+}
+
+func (g *gatedOpAMPClient) SetAvailableComponents(components *protobufs.AvailableComponents) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetAvailableComponents(components)
+}
+
+func (g *gatedOpAMPClient) SetCapabilities(capabilities *protobufs.AgentCapabilities) error {
+	g.gate.wait()
+	return g.OpAMPClient.SetCapabilities(capabilities)
+}

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
@@ -39,42 +39,42 @@ func newGatedOpAMPClient(underlying client.OpAMPClient, gate *sendGate) client.O
 // SetAgentDescription calls [client.OpAMPClient.SetAgentDescription] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetAgentDescription(descr)
 }
 
 // SetHealth calls [client.OpAMPClient.SetHealth] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetHealth(health)
 }
 
 // UpdateEffectiveConfig calls [client.OpAMPClient.UpdateEffectiveConfig] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.UpdateEffectiveConfig(ctx)
 }
 
 // SetRemoteConfigStatus calls [client.OpAMPClient.SetRemoteConfigStatus] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetRemoteConfigStatus(status)
 }
 
 // SetPackageStatuses calls [client.OpAMPClient.SetPackageStatuses] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetPackageStatuses(statuses)
 }
 
 // RequestConnectionSettings calls [client.OpAMPClient.RequestConnectionSettings] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.RequestConnectionSettings(request)
 }
 
@@ -87,27 +87,27 @@ func (g *gatedOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.C
 // SetFlags calls [client.OpAMPClient.SetFlags] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetFlags(flags protobufs.AgentToServerFlags) {
-	g.gate.wait()
+	g.gate.wait(nil)
 	g.OpAMPClient.SetFlags(flags)
 }
 
 // SendCustomMessage calls [client.OpAMPClient.SendCustomMessage] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SendCustomMessage(message)
 }
 
 // SetAvailableComponents calls [client.OpAMPClient.SetAvailableComponents] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetAvailableComponents(components *protobufs.AvailableComponents) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetAvailableComponents(components)
 }
 
 // SetCapabilities calls [client.OpAMPClient.SetCapabilities] with its OpAMPClient after making sure
 // the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetCapabilities(capabilities *protobufs.AgentCapabilities) error {
-	g.gate.wait()
+	g.gate.wait(nil)
 	return g.OpAMPClient.SetCapabilities(capabilities)
 }

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
@@ -78,10 +78,9 @@ func (g *gatedOpAMPClient) RequestConnectionSettings(request *protobufs.Connecti
 	return g.OpAMPClient.RequestConnectionSettings(request)
 }
 
-// SetCustomCapabilities calls [client.OpAMPClient.SetCustomCapabilities] with its OpAMPClient after making sure
-// the sendGate isn't blocking
+// SetCustomCapabilities calls [client.OpAMPClient.SetCustomCapabilities] with its OpAMPClient.
+// It does not wait for the sendGate
 func (g *gatedOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
-	g.gate.wait()
 	return g.OpAMPClient.SetCustomCapabilities(customCapabilities)
 }
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client.go
@@ -36,56 +36,78 @@ func newGatedOpAMPClient(underlying client.OpAMPClient, gate *sendGate) client.O
 	return &gatedOpAMPClient{OpAMPClient: underlying, gate: gate}
 }
 
+// SetAgentDescription calls [client.OpAMPClient.SetAgentDescription] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetAgentDescription(descr)
 }
 
+// SetHealth calls [client.OpAMPClient.SetHealth] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetHealth(health)
 }
 
+// UpdateEffectiveConfig calls [client.OpAMPClient.UpdateEffectiveConfig] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
 	g.gate.wait()
 	return g.OpAMPClient.UpdateEffectiveConfig(ctx)
 }
 
+// SetRemoteConfigStatus calls [client.OpAMPClient.SetRemoteConfigStatus] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetRemoteConfigStatus(status)
 }
 
+// SetPackageStatuses calls [client.OpAMPClient.SetPackageStatuses] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetPackageStatuses(statuses)
 }
 
+// RequestConnectionSettings calls [client.OpAMPClient.RequestConnectionSettings] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
 	g.gate.wait()
 	return g.OpAMPClient.RequestConnectionSettings(request)
 }
 
+// SetCustomCapabilities calls [client.OpAMPClient.SetCustomCapabilities] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetCustomCapabilities(customCapabilities)
 }
 
+// SetFlags calls [client.OpAMPClient.SetFlags] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetFlags(flags protobufs.AgentToServerFlags) {
 	g.gate.wait()
 	g.OpAMPClient.SetFlags(flags)
 }
 
+// SendCustomMessage calls [client.OpAMPClient.SendCustomMessage] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
 	g.gate.wait()
 	return g.OpAMPClient.SendCustomMessage(message)
 }
 
+// SetAvailableComponents calls [client.OpAMPClient.SetAvailableComponents] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetAvailableComponents(components *protobufs.AvailableComponents) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetAvailableComponents(components)
 }
 
+// SetCapabilities calls [client.OpAMPClient.SetCapabilities] with its OpAMPClient after making sure
+// the sendGate isn't blocking
 func (g *gatedOpAMPClient) SetCapabilities(capabilities *protobufs.AgentCapabilities) error {
 	g.gate.wait()
 	return g.OpAMPClient.SetCapabilities(capabilities)

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client_test.go
@@ -1,0 +1,80 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observiq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/observiq/bindplane-otel-collector/internal/extension/opampconnectionextension/internal/opamp/mocks"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGatedOpAMPClient_WaitsForGateBeforeDelegating(t *testing.T) {
+	gate := newSendGate()
+	wait := 100 * time.Millisecond
+	gate.block(wait)
+
+	mockClient := new(mocks.MockOpAMPClient)
+	var calledAt time.Time
+	mockClient.On("SetHealth", mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
+		calledAt = time.Now()
+	})
+
+	gated := newGatedOpAMPClient(mockClient, gate)
+
+	start := time.Now()
+	err := gated.SetHealth(&protobufs.ComponentHealth{})
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, calledAt.Sub(start), wait)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestGatedOpAMPClient_NoDelayWhenGateOpen(t *testing.T) {
+	gate := newSendGate()
+
+	mockClient := new(mocks.MockOpAMPClient)
+	mockClient.On("SendCustomMessage", mock.Anything).Return((chan struct{})(nil), nil)
+
+	gated := newGatedOpAMPClient(mockClient, gate)
+
+	start := time.Now()
+	_, err := gated.SendCustomMessage(&protobufs.CustomMessage{})
+	assert.NoError(t, err)
+	assert.Less(t, time.Since(start), 50*time.Millisecond)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestGatedOpAMPClient_StopIsNotGated(t *testing.T) {
+	gate := newSendGate()
+	gate.block(10 * time.Second)
+
+	mockClient := new(mocks.MockOpAMPClient)
+	mockClient.On("Stop", mock.Anything).Return(nil)
+
+	gated := newGatedOpAMPClient(mockClient, gate)
+
+	start := time.Now()
+	err := gated.Stop(context.Background())
+	assert.NoError(t, err)
+	assert.Less(t, time.Since(start), 50*time.Millisecond)
+
+	mockClient.AssertExpectations(t)
+}

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/gated_opamp_client_test.go
@@ -17,6 +17,7 @@ package observiq
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/observiq/bindplane-otel-collector/internal/extension/opampconnectionextension/internal/opamp/mocks"
@@ -26,55 +27,61 @@ import (
 )
 
 func TestGatedOpAMPClient_WaitsForGateBeforeDelegating(t *testing.T) {
-	gate := newSendGate()
-	wait := 100 * time.Millisecond
-	gate.block(wait)
+	synctest.Test(t, func(t *testing.T) {
+		gate := newSendGate()
+		wait := 100 * time.Millisecond
+		gate.block(wait)
 
-	mockClient := new(mocks.MockOpAMPClient)
-	var calledAt time.Time
-	mockClient.On("SetHealth", mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
-		calledAt = time.Now()
+		mockClient := new(mocks.MockOpAMPClient)
+		var calledAt time.Time
+		mockClient.On("SetHealth", mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
+			calledAt = time.Now()
+		})
+
+		gated := newGatedOpAMPClient(mockClient, gate)
+
+		start := time.Now()
+		err := gated.SetHealth(&protobufs.ComponentHealth{})
+		assert.NoError(t, err)
+		assert.Equal(t, wait, calledAt.Sub(start))
+
+		mockClient.AssertExpectations(t)
 	})
-
-	gated := newGatedOpAMPClient(mockClient, gate)
-
-	start := time.Now()
-	err := gated.SetHealth(&protobufs.ComponentHealth{})
-	assert.NoError(t, err)
-	assert.GreaterOrEqual(t, calledAt.Sub(start), wait)
-
-	mockClient.AssertExpectations(t)
 }
 
 func TestGatedOpAMPClient_NoDelayWhenGateOpen(t *testing.T) {
-	gate := newSendGate()
+	synctest.Test(t, func(t *testing.T) {
+		gate := newSendGate()
 
-	mockClient := new(mocks.MockOpAMPClient)
-	mockClient.On("SendCustomMessage", mock.Anything).Return((chan struct{})(nil), nil)
+		mockClient := new(mocks.MockOpAMPClient)
+		mockClient.On("SendCustomMessage", mock.Anything).Return((chan struct{})(nil), nil)
 
-	gated := newGatedOpAMPClient(mockClient, gate)
+		gated := newGatedOpAMPClient(mockClient, gate)
 
-	start := time.Now()
-	_, err := gated.SendCustomMessage(&protobufs.CustomMessage{})
-	assert.NoError(t, err)
-	assert.Less(t, time.Since(start), 50*time.Millisecond)
+		start := time.Now()
+		_, err := gated.SendCustomMessage(&protobufs.CustomMessage{})
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), time.Since(start))
 
-	mockClient.AssertExpectations(t)
+		mockClient.AssertExpectations(t)
+	})
 }
 
 func TestGatedOpAMPClient_StopIsNotGated(t *testing.T) {
-	gate := newSendGate()
-	gate.block(10 * time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		gate := newSendGate()
+		gate.block(10 * time.Second)
 
-	mockClient := new(mocks.MockOpAMPClient)
-	mockClient.On("Stop", mock.Anything).Return(nil)
+		mockClient := new(mocks.MockOpAMPClient)
+		mockClient.On("Stop", mock.Anything).Return(nil)
 
-	gated := newGatedOpAMPClient(mockClient, gate)
+		gated := newGatedOpAMPClient(mockClient, gate)
 
-	start := time.Now()
-	err := gated.Stop(context.Background())
-	assert.NoError(t, err)
-	assert.Less(t, time.Since(start), 50*time.Millisecond)
+		start := time.Now()
+		err := gated.Stop(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), time.Since(start))
 
-	mockClient.AssertExpectations(t)
+		mockClient.AssertExpectations(t)
+	})
 }

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/measurements.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/measurements.go
@@ -41,6 +41,7 @@ type measurementsSender struct {
 	logger          *zap.Logger
 	reporter        MeasurementsReporter
 	opampClient     client.OpAMPClient
+	gate            *sendGate
 	interval        time.Duration
 	extraAttributes map[string]string
 
@@ -56,11 +57,12 @@ type measurementsSender struct {
 	lastSendMux          *sync.RWMutex
 }
 
-func newMeasurementsSender(l *zap.Logger, reporter MeasurementsReporter, opampClient client.OpAMPClient, interval time.Duration, extraAttributes map[string]string) *measurementsSender {
+func newMeasurementsSender(l *zap.Logger, reporter MeasurementsReporter, opampClient client.OpAMPClient, gate *sendGate, interval time.Duration, extraAttributes map[string]string) *measurementsSender {
 	return &measurementsSender{
 		logger:          l,
 		reporter:        reporter,
 		opampClient:     opampClient,
+		gate:            gate,
 		interval:        interval,
 		extraAttributes: extraAttributes,
 
@@ -177,6 +179,14 @@ func (m *measurementsSender) loop() {
 
 			success := false
 			for i := 0; i < maxSendRetries; i++ {
+				// Check the gate ourselves, with a cancellation path tied to this sender's done channel,
+				// rather than relying solely on the gated client's own (uncancelable) wait:
+				// otherwise [measurementsSender.Stop] could block for the remainder of a server-requested retry delay
+				// if the server withdraws this capability mid-session.
+				if !m.gate.wait(m.done) {
+					return
+				}
+
 				sendingChannel, err := m.opampClient.SendCustomMessage(cm)
 				switch {
 				case err == nil: // OK

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/measurements_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/measurements_test.go
@@ -62,7 +62,7 @@ func TestMeasurementsSender(t *testing.T) {
 		reg := measurements.NewResettableThroughputMeasurementsRegistry(false)
 		require.NoError(t, reg.RegisterThroughputMeasurements(processorID, tm))
 
-		ms := newMeasurementsSender(zap.NewNop(), reg, client, 1*time.Millisecond, nil)
+		ms := newMeasurementsSender(zap.NewNop(), reg, client, nil, 1*time.Millisecond, nil)
 		ms.Start()
 
 		select {
@@ -112,7 +112,7 @@ func TestMeasurementsSender(t *testing.T) {
 		reg := measurements.NewResettableThroughputMeasurementsRegistry(false)
 		reg.RegisterThroughputMeasurements(processorID, tm)
 
-		ms := newMeasurementsSender(zap.NewNop(), reg, client, 5*time.Hour, nil)
+		ms := newMeasurementsSender(zap.NewNop(), reg, client, nil, 5*time.Hour, nil)
 		ms.Start()
 
 		// With a 5-hour interval, no data should be emitted yet; confirm the channel

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
@@ -186,6 +186,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		clientLogger,
 		args.MeasurementsReporter,
 		observiqClient.opampClient,
+		observiqClient.sendGate,
 		args.Config.MeasurementsInterval,
 		args.Config.ExtraMeasurementsAttributes,
 	)
@@ -195,6 +196,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		clientLogger,
 		args.TopologyReporter,
 		observiqClient.opampClient,
+		observiqClient.sendGate,
 		args.Config.TopologyInterval,
 	)
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
@@ -336,13 +336,13 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	// Ensure we're no longer monitoring the collector as we shutdown to avoid error messages due to shutdown
 	c.stopCollectorMonitoring()
 
-	c.safeSetDisconnecting(true)
-	c.collector.Stop(ctx)
-
 	// Release anything blocked waiting on a server-requested retry delay so shutdown isn't held up.
 	if c.sendGate != nil {
 		c.sendGate.close()
 	}
+
+	c.safeSetDisconnecting(true)
+	c.collector.Stop(ctx)
 
 	// Reset the measurements registry to prevent resending old metrics on reconnect
 	if c.measurementsSender != nil {

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -447,9 +448,12 @@ func (c *Client) onErrorHandler(_ context.Context, errResp *protobufs.ServerErro
 	c.logger.Error("Server returned an error response", zap.String("Error", errResp.GetErrorMessage()))
 
 	if retryInfo := errResp.GetRetryInfo(); retryInfo != nil {
-		wait := time.Duration(retryInfo.GetRetryAfterNanoseconds())
-		c.logger.Info("Server requested a retry delay, blocking outgoing messages", zap.Stringer("wait", wait))
-		c.sendGate.block(wait)
+		if c.sendGate != nil {
+			retryAfterNanoseconds := min(retryInfo.GetRetryAfterNanoseconds(), math.MaxInt64)
+			wait := time.Duration(retryAfterNanoseconds)
+			c.logger.Warn("Server requested a retry delay, blocking outgoing messages", zap.Stringer("wait", wait))
+			c.sendGate.block(wait)
+		}
 	}
 }
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client.go
@@ -86,6 +86,7 @@ type Client struct {
 	reportManager           *report.Manager
 	measurementsSender      *measurementsSender
 	topologySender          *topologySender
+	sendGate                *sendGate
 
 	// To signal if we are disconnecting already and not take any actions on connection failures
 	disconnecting bool
@@ -147,6 +148,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		updaterManager:          updaterManger,
 		reportManager:           reportManager,
 		managerConfigPath:       args.ManagerConfigPath,
+		sendGate:                newSendGate(),
 	}
 
 	// Parse URL to determin scheme
@@ -164,7 +166,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 	switch opampURL.Scheme {
 	case "ws", "wss":
 		logger := newZapOpAMPLoggerAdapter(clientLogger)
-		observiqClient.opampClient = client.NewWebSocket(logger)
+		observiqClient.opampClient = newGatedOpAMPClient(client.NewWebSocket(logger), observiqClient.sendGate)
 	default:
 		return nil, ErrUnsupportedURL
 	}
@@ -336,6 +338,11 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	c.safeSetDisconnecting(true)
 	c.collector.Stop(ctx)
 
+	// Release anything blocked waiting on a server-requested retry delay so shutdown isn't held up.
+	if c.sendGate != nil {
+		c.sendGate.close()
+	}
+
 	// Reset the measurements registry to prevent resending old metrics on reconnect
 	if c.measurementsSender != nil {
 		c.measurementsSender.Stop()
@@ -438,6 +445,12 @@ func (c *Client) onConnectFailedHandler(_ context.Context, err error) {
 
 func (c *Client) onErrorHandler(_ context.Context, errResp *protobufs.ServerErrorResponse) {
 	c.logger.Error("Server returned an error response", zap.String("Error", errResp.GetErrorMessage()))
+
+	if retryInfo := errResp.GetRetryInfo(); retryInfo != nil {
+		wait := time.Duration(retryInfo.GetRetryAfterNanoseconds())
+		c.logger.Info("Server requested a retry delay, blocking outgoing messages", zap.Stringer("wait", wait))
+		c.sendGate.block(wait)
+	}
 }
 
 func (c *Client) onGetEffectiveConfigHandler(_ context.Context) (*protobufs.EffectiveConfig, error) {

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client_test.go
@@ -864,7 +864,7 @@ func TestClient_onErrorHandler(t *testing.T) {
 		c.onErrorHandler(context.Background(), errResp)
 
 		start := time.Now()
-		gate.wait()
+		gate.wait(nil)
 		assert.Less(t, time.Since(start), 50*time.Millisecond)
 	})
 
@@ -892,7 +892,7 @@ func TestClient_onErrorHandler(t *testing.T) {
 
 		// A subsequent send should be held back for roughly the requested duration.
 		start = time.Now()
-		gate.wait()
+		gate.wait(nil)
 		assert.GreaterOrEqual(t, time.Since(start), wait)
 	})
 }

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/observiq_client_test.go
@@ -849,6 +849,54 @@ func TestClient_onConnectFailedHandler(t *testing.T) {
 	}
 }
 
+func TestClient_onErrorHandler(t *testing.T) {
+	t.Run("No retry info does not block sends", func(t *testing.T) {
+		gate := newSendGate()
+		c := &Client{
+			logger:   zap.NewNop(),
+			sendGate: gate,
+		}
+
+		errResp := &protobufs.ServerErrorResponse{
+			ErrorMessage: "oops",
+		}
+
+		c.onErrorHandler(context.Background(), errResp)
+
+		start := time.Now()
+		gate.wait()
+		assert.Less(t, time.Since(start), 50*time.Millisecond)
+	})
+
+	t.Run("Retry info blocks sends for the requested duration", func(t *testing.T) {
+		gate := newSendGate()
+		c := &Client{
+			logger:   zap.NewNop(),
+			sendGate: gate,
+		}
+
+		wait := 100 * time.Millisecond
+		errResp := &protobufs.ServerErrorResponse{
+			ErrorMessage: "unavailable",
+			Details: &protobufs.ServerErrorResponse_RetryInfo{
+				RetryInfo: &protobufs.RetryInfo{
+					RetryAfterNanoseconds: uint64(wait.Nanoseconds()),
+				},
+			},
+		}
+
+		// onErrorHandler only arms the gate - it must return immediately itself.
+		start := time.Now()
+		c.onErrorHandler(context.Background(), errResp)
+		assert.Less(t, time.Since(start), 50*time.Millisecond)
+
+		// A subsequent send should be held back for roughly the requested duration.
+		start = time.Now()
+		gate.wait()
+		assert.GreaterOrEqual(t, time.Since(start), wait)
+	})
+}
+
 func TestClient_onGetEffectiveConfigHandler(t *testing.T) {
 	mockManager := mocks.NewMockConfigManager(t)
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/reload_funcs_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/reload_funcs_test.go
@@ -101,8 +101,8 @@ func Test_managerReload(t *testing.T) {
 					opampClient:        mockOpAmpClient,
 					ident:              newIdentity(zap.NewNop(), *currConfig, "0.0.0"),
 					currentConfig:      *currConfig,
-					measurementsSender: newMeasurementsSender(zap.NewNop(), nil, mockOpAmpClient, 0, nil),
-					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, nil),
+					measurementsSender: newMeasurementsSender(zap.NewNop(), nil, mockOpAmpClient, nil, 0, nil),
+					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, nil, nil),
 				}
 				reloadFunc := managerReload(client, managerFilePath)
 
@@ -236,8 +236,8 @@ labels: env=prod
 					opampClient:        mockOpAmpClient,
 					ident:              newIdentity(zap.NewNop(), *currConfig, "0.0.0"),
 					currentConfig:      *currConfig,
-					measurementsSender: newMeasurementsSender(zap.NewNop(), nil, mockOpAmpClient, 0, nil),
-					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, nil),
+					measurementsSender: newMeasurementsSender(zap.NewNop(), nil, mockOpAmpClient, nil, 0, nil),
+					topologySender:     newTopologySender(zap.NewNop(), nil, mockOpAmpClient, nil, nil),
 				}
 				reloadFunc := managerReload(client, managerFilePath)
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate.go
@@ -53,20 +53,29 @@ func (g *sendGate) block(d time.Duration) {
 }
 
 // wait blocks until any delay set by block has elapsed, or the gate is closed.
-func (g *sendGate) wait() {
+// If cancel fires first, wait returns false to indicate that the caller should abandon whatever send it was waiting to make;
+// a nil cancel behaves as if it never fires. A nil *sendGate always returns true immediately,
+// so callers that only get a gate when it's needed (e.g. in tests) don't need to guard against it.
+func (g *sendGate) wait(cancel <-chan struct{}) bool {
+	if g == nil {
+		return true
+	}
+
 	for {
 		g.mu.Lock()
 		remaining := time.Until(g.notBefore)
 		g.mu.Unlock()
 
 		if remaining <= 0 {
-			return
+			return true
 		}
 
 		select {
 		case <-time.After(remaining):
 		case <-g.closed:
-			return
+			return true
+		case <-cancel:
+			return false
 		}
 	}
 }

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate.go
@@ -1,0 +1,78 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observiq
+
+import (
+	"sync"
+	"time"
+)
+
+// sendGate blocks outgoing OpAMP messages until a server-requested retry
+// delay (see ServerErrorResponse.RetryInfo) has elapsed. It is shared between
+// the Client and its gatedOpAMPClient so that a delay observed in
+// onErrorHandler is enforced on every subsequent send attempt, rather than
+// just delaying receipt of the next server message.
+type sendGate struct {
+	mu        sync.Mutex
+	notBefore time.Time
+
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newSendGate() *sendGate {
+	return &sendGate{closed: make(chan struct{})}
+}
+
+// block delays outgoing messages until d has elapsed. If a longer delay is
+// already in effect, the longer one wins.
+func (g *sendGate) block(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+
+	notBefore := time.Now().Add(d)
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if notBefore.After(g.notBefore) {
+		g.notBefore = notBefore
+	}
+}
+
+// wait blocks until any delay set by block has elapsed, or the gate is closed.
+func (g *sendGate) wait() {
+	for {
+		g.mu.Lock()
+		remaining := time.Until(g.notBefore)
+		g.mu.Unlock()
+
+		if remaining <= 0 {
+			return
+		}
+
+		select {
+		case <-time.After(remaining):
+		case <-g.closed:
+			return
+		}
+	}
+}
+
+// close releases any goroutines currently blocked in wait. Safe to call
+// multiple times.
+func (g *sendGate) close() {
+	g.closeOnce.Do(func() { close(g.closed) })
+}

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
@@ -72,7 +72,7 @@ func TestSendGate_ShorterBlockDoesNotShortenExistingDelay(t *testing.T) {
 }
 
 func TestSendGate_CloseUnblocksWait(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
+	synctest.Test(t, func(_ *testing.T) {
 		g := newSendGate()
 		g.block(10 * time.Second)
 

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
@@ -27,7 +27,7 @@ func TestSendGate_WaitWithoutBlockReturnsImmediately(t *testing.T) {
 		g := newSendGate()
 
 		start := time.Now()
-		g.wait()
+		g.wait(nil)
 		assert.Equal(t, time.Duration(0), time.Since(start))
 	})
 }
@@ -40,7 +40,7 @@ func TestSendGate_BlockDelaysWait(t *testing.T) {
 		g.block(wait)
 
 		start := time.Now()
-		g.wait()
+		g.wait(nil)
 		assert.Equal(t, wait, time.Since(start))
 	})
 }
@@ -53,7 +53,7 @@ func TestSendGate_LongerBlockWins(t *testing.T) {
 		g.block(200 * time.Millisecond)
 
 		start := time.Now()
-		g.wait()
+		g.wait(nil)
 		assert.Equal(t, 200*time.Millisecond, time.Since(start))
 	})
 }
@@ -66,7 +66,7 @@ func TestSendGate_ShorterBlockDoesNotShortenExistingDelay(t *testing.T) {
 		g.block(50 * time.Millisecond)
 
 		start := time.Now()
-		g.wait()
+		g.wait(nil)
 		assert.Equal(t, 200*time.Millisecond, time.Since(start))
 	})
 }
@@ -78,12 +78,47 @@ func TestSendGate_CloseUnblocksWait(t *testing.T) {
 
 		done := make(chan struct{})
 		go func() {
-			g.wait()
+			g.wait(nil)
 			close(done)
 		}()
 
 		g.close()
 		<-done
+	})
+}
+
+func TestSendGate_CancelUnblocksWaitAndReturnsFalse(t *testing.T) {
+	synctest.Test(t, func(_ *testing.T) {
+		g := newSendGate()
+		g.block(10 * time.Second)
+
+		cancel := make(chan struct{})
+		result := make(chan bool, 1)
+		go func() {
+			result <- g.wait(cancel)
+		}()
+
+		close(cancel)
+		assert.False(t, <-result)
+	})
+}
+
+func TestSendGate_WaitReturnsTrueWhenDelayElapsesBeforeCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+		g.block(50 * time.Millisecond)
+
+		assert.True(t, g.wait(make(chan struct{})))
+	})
+}
+
+func TestSendGate_NilGateWaitReturnsTrueImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var g *sendGate
+
+		start := time.Now()
+		assert.True(t, g.wait(nil))
+		assert.Equal(t, time.Duration(0), time.Since(start))
 	})
 }
 
@@ -104,7 +139,7 @@ func TestSendGate_NonPositiveBlockIsNoop(t *testing.T) {
 		g.block(-1 * time.Second)
 
 		start := time.Now()
-		g.wait()
+		g.wait(nil)
 		assert.Equal(t, time.Duration(0), time.Since(start))
 	})
 }

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/send_gate_test.go
@@ -1,0 +1,110 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observiq
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSendGate_WaitWithoutBlockReturnsImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+
+		start := time.Now()
+		g.wait()
+		assert.Equal(t, time.Duration(0), time.Since(start))
+	})
+}
+
+func TestSendGate_BlockDelaysWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+
+		wait := 100 * time.Millisecond
+		g.block(wait)
+
+		start := time.Now()
+		g.wait()
+		assert.Equal(t, wait, time.Since(start))
+	})
+}
+
+func TestSendGate_LongerBlockWins(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+
+		g.block(50 * time.Millisecond)
+		g.block(200 * time.Millisecond)
+
+		start := time.Now()
+		g.wait()
+		assert.Equal(t, 200*time.Millisecond, time.Since(start))
+	})
+}
+
+func TestSendGate_ShorterBlockDoesNotShortenExistingDelay(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+
+		g.block(200 * time.Millisecond)
+		g.block(50 * time.Millisecond)
+
+		start := time.Now()
+		g.wait()
+		assert.Equal(t, 200*time.Millisecond, time.Since(start))
+	})
+}
+
+func TestSendGate_CloseUnblocksWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+		g.block(10 * time.Second)
+
+		done := make(chan struct{})
+		go func() {
+			g.wait()
+			close(done)
+		}()
+
+		g.close()
+		<-done
+	})
+}
+
+func TestSendGate_CloseIsIdempotent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+		assert.NotPanics(t, func() {
+			g.close()
+			g.close()
+		})
+	})
+}
+
+func TestSendGate_NonPositiveBlockIsNoop(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := newSendGate()
+		g.block(0)
+		g.block(-1 * time.Second)
+
+		start := time.Now()
+		g.wait()
+		assert.Equal(t, time.Duration(0), time.Since(start))
+	})
+}

--- a/internal/extension/opampconnectionextension/internal/opamp/observiq/topology.go
+++ b/internal/extension/opampconnectionextension/internal/opamp/observiq/topology.go
@@ -40,6 +40,7 @@ type topologySender struct {
 	logger      *zap.Logger
 	reporter    TopologyReporter
 	opampClient client.OpAMPClient
+	gate        *sendGate
 
 	interval           time.Duration
 	changeIntervalChan chan time.Duration
@@ -50,7 +51,7 @@ type topologySender struct {
 	wg        *sync.WaitGroup
 }
 
-func newTopologySender(l *zap.Logger, reporter TopologyReporter, opampClient client.OpAMPClient, interval *time.Duration) *topologySender {
+func newTopologySender(l *zap.Logger, reporter TopologyReporter, opampClient client.OpAMPClient, gate *sendGate, interval *time.Duration) *topologySender {
 	var topologyInterval time.Duration
 	if interval == nil {
 		topologyInterval = defaultTopologyInterval
@@ -62,6 +63,7 @@ func newTopologySender(l *zap.Logger, reporter TopologyReporter, opampClient cli
 		logger:      l,
 		reporter:    reporter,
 		opampClient: opampClient,
+		gate:        gate,
 		interval:    topologyInterval,
 
 		changeIntervalChan: make(chan time.Duration, 1),
@@ -166,6 +168,15 @@ func (ts *topologySender) loop() {
 
 			success := false
 			for i := 0; i < maxSendRetries; i++ {
+				// Check the gate ourselves, with a cancellation path tied to
+				// this sender's done channel, rather than relying solely on
+				// the gated client's own (uncancelable) wait: otherwise Stop
+				// could block for the remainder of a server-requested retry
+				// delay if the server withdraws this capability mid-session.
+				if !ts.gate.wait(ts.done) {
+					return
+				}
+
 				sendingChannel, err := ts.opampClient.SendCustomMessage(cm)
 				switch {
 				case err == nil: // OK


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change

Update the OpAMP client to look for `RetryInfo.RetryAfterNanoseconds` in `onErrorHandler`. When it receives an error response with that field, stop sending messages for the duration of that period.

- Add a new `sendGate` struct that can be set to block messages for a duration, and wait until that duration has passed
- Add `gatedOpAMPClient` which wraps the current OpAMP client, and use `sendGate` to wait until sending isn't blocked before sending messages

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
