### PR TITLE
chore: add --timeout to local goreleaser snapshot targets (PIPE-1387)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ VERSION ?= $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG)-SNAPSHOT-$(SNAPSHO
 # template appends its own -SNAPSHOT-<sha> suffix, so passing VERSION here would double it.
 SNAPSHOT_TAG := $(if $(CURRENT_TAG),$(CURRENT_TAG),$(PREVIOUS_TAG))
 
+# Timeout for the local snapshot goreleaser targets. goreleaser defaults to 1h, which a
+# full cross-compile can exceed on a slower workstation, so the run gets killed partway
+# through. CI uses 120m on larger runners; local gets more headroom. Override on the
+# command line if your machine needs a different budget.
+GORELEASER_TIMEOUT ?= 180m
+
 # Build-info stamps. These get linked into the binary via -ldflags so
 # `collector --version` shows real values instead of "unknown".
 GIT_HASH ?= $(shell git rev-parse HEAD)
@@ -424,7 +430,7 @@ release-test:
 # If there are no MSIs in the root dir, we'll create dummy ones so that goreleaser can complete successfully
 	if [ ! -e "./observiq-otel-collector.msi" ]; then touch ./observiq-otel-collector.msi; fi
 	if [ ! -e "./observiq-otel-collector-arm64.msi" ]; then touch ./observiq-otel-collector-arm64.msi; fi
-	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
+	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --timeout $(GORELEASER_TIMEOUT) --skip=publish --skip=validate --skip=sign --clean --snapshot
 
 .PHONY: release-containers-test
 release-containers-test:
@@ -433,7 +439,7 @@ release-containers-test:
 	mv ./dist/collector_linux_amd64 ./tmp/collector_linux_amd64
 	mv ./dist/collector_linux_arm64 ./tmp/collector_linux_arm64
 	mv ./dist/collector_linux_ppc64le ./tmp/collector_linux_ppc64le
-	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot --config .goreleaser-docker.yml
+	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --parallelism 4 --timeout $(GORELEASER_TIMEOUT) --skip=publish --skip=validate --skip=sign --clean --snapshot --config .goreleaser-docker.yml
 
 .PHONY: agent-linux-amd64 agent-linux-arm64 agent-linux-ppc64le
 agent-linux-amd64:
@@ -459,11 +465,11 @@ agent-windows-arm64:
 
 build-single:
 	$(MAKE)
-	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --skip=publish --skip=sign --clean --skip=validate --snapshot --single-target
+	SIGNING_KEY_FILE="fake-file" GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release --timeout $(GORELEASER_TIMEOUT) --skip=publish --skip=sign --clean --skip=validate --snapshot --single-target
 
 .PHONY: release-test-single
 release-test-single:
-	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release -f .goreleaser.arm64.yml --skip=publish --clean --skip=validate --snapshot
+	GORELEASER_CURRENT_TAG=$(SNAPSHOT_TAG) goreleaser release -f .goreleaser.arm64.yml --timeout $(GORELEASER_TIMEOUT) --skip=publish --clean --skip=validate --snapshot
 
 .PHONY: for-all
 for-all:


### PR DESCRIPTION
### Proposed Change

`goreleaser release` defaults to a one-hour timeout, which none of our configs override. On a slower workstation a full cross-compile runs past that and gets killed partway through; a local `make release-test` died at roughly 1h1m.

This adds a `GORELEASER_TIMEOUT` variable, default `180m`, passed to the four local snapshot targets. It's `?=`, so a slower machine can override it per run without editing the file.

CI is untouched: the release workflows set their own `--timeout 120m` and don't call these targets.

To validate, `make -n release-test` and `make -n release-test-single` should both show `--timeout 180m`, and `make GORELEASER_TIMEOUT=45m -n release-test` should show `45m` instead.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
