### PR TITLE
fix: Cap `observiq_collector.err` on Windows

### DIFF
--- a/internal/extension/opampconnectionextension/internal/service/service_windows.go
+++ b/internal/extension/opampconnectionextension/internal/service/service_windows.go
@@ -192,8 +192,15 @@ func redirectStderr() error {
 		return errors.New("OIQ_OTEL_COLLECTOR_HOME environment variable not set")
 	}
 
-	path := filepath.Join(homeDir, "log", "observiq_collector.err")
-	f, err := os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
+	path := filepath.Clean(filepath.Join(homeDir, "log", "observiq_collector.err"))
+
+	// Roll any previous contents to a backup so the file can't accumulate
+	// across service restarts. Must happen before the file is opened below.
+	if err := rollStderrFile(path); err != nil {
+		return fmt.Errorf("failed to roll stderr file: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
@@ -203,6 +210,9 @@ func redirectStderr() error {
 	} else {
 		os.Stderr = f
 	}
+
+	// Bound the file in-flight so a runaway error stream can't fill the disk.
+	go watchStderrFile(path)
 
 	return nil
 }

--- a/internal/extension/opampconnectionextension/internal/service/stderr_cap.go
+++ b/internal/extension/opampconnectionextension/internal/service/stderr_cap.go
@@ -1,0 +1,107 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// The stderr file (observiq_collector.err) captures output that does not go
+// through the zap logger (runtime panics, high-volume component error spew).
+// It historically had no size cap and has filled OS drives (10+ GB observed).
+// These constants bound it to cap + 1 backup.
+// ponytail: hardcoded cap/backups; expose via config if a customer ever needs to tune it.
+const (
+	stderrMaxBytes      = 10 * 1024 * 1024
+	stderrCheckInterval = 10 * time.Second
+)
+
+// rollStderrFile rolls an existing, non-empty stderr file to "<path>.1"
+// (replacing any previous backup) so it can't accumulate across service
+// restarts. It must be called before the file is opened as the stderr target:
+// on Windows, renaming a file our own stderr handle holds open fails with a
+// sharing violation (Go opens files without FILE_SHARE_DELETE).
+func rollStderrFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat stderr file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil
+	}
+	if err := os.Rename(path, path+".1"); err != nil {
+		return fmt.Errorf("roll stderr file: %w", err)
+	}
+	return nil
+}
+
+// capStderrFile bounds the stderr file while it is held open as the OS stderr
+// handle: if it has grown to at least threshold bytes, its contents are
+// copied aside to "<path>.1" and the file is truncated in place. Truncating
+// (rather than renaming) keeps the already-bound stderr handle valid: the
+// handle appends at EOF (O_APPEND / FILE_APPEND_DATA), so writes continue
+// correctly after truncation. Writes landing between the copy and the
+// truncate are lost — the goal is "bounded", not "exact".
+func capStderrFile(path string, threshold int64) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat stderr file: %w", err)
+	}
+	if info.Size() < threshold {
+		return nil
+	}
+
+	src, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("open stderr file: %w", err)
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(filepath.Clean(path+".1"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("open stderr backup file: %w", err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return fmt.Errorf("copy stderr file to backup: %w", err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("close stderr backup file: %w", err)
+	}
+
+	if err := os.Truncate(path, 0); err != nil {
+		return fmt.Errorf("truncate stderr file: %w", err)
+	}
+	return nil
+}
+
+// watchStderrFile periodically caps the stderr file for the life of the
+// process. Errors are best-effort: there is nowhere safe to report them
+// repeatedly (stderr is the file being managed), so ticks that fail are
+// simply retried on the next interval.
+func watchStderrFile(path string) {
+	ticker := time.NewTicker(stderrCheckInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		_ = capStderrFile(path, stderrMaxBytes)
+	}
+}

--- a/internal/extension/opampconnectionextension/internal/service/stderr_cap_test.go
+++ b/internal/extension/opampconnectionextension/internal/service/stderr_cap_test.go
@@ -1,0 +1,105 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollStderrFile(t *testing.T) {
+	t.Run("missing file is a no-op", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		require.NoError(t, rollStderrFile(path))
+		require.NoFileExists(t, path+".1")
+	})
+
+	t.Run("empty file is left in place", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		require.NoError(t, os.WriteFile(path, nil, 0660))
+		require.NoError(t, rollStderrFile(path))
+		require.FileExists(t, path)
+		require.NoFileExists(t, path+".1")
+	})
+
+	t.Run("non-empty file rolls to backup, replacing previous backup", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		require.NoError(t, os.WriteFile(path, []byte("current"), 0660))
+		require.NoError(t, os.WriteFile(path+".1", []byte("old backup"), 0660))
+
+		require.NoError(t, rollStderrFile(path))
+
+		require.NoFileExists(t, path)
+		backup, err := os.ReadFile(path + ".1")
+		require.NoError(t, err)
+		require.Equal(t, "current", string(backup))
+	})
+}
+
+func TestCapStderrFile(t *testing.T) {
+	t.Run("under cap is untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		require.NoError(t, os.WriteFile(path, []byte("small"), 0660))
+
+		require.NoError(t, capStderrFile(path, stderrMaxBytes))
+
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "small", string(content))
+		require.NoFileExists(t, path+".1")
+	})
+
+	t.Run("threshold 1 archives any non-empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		require.NoError(t, os.WriteFile(path, []byte("last run"), 0660))
+
+		require.NoError(t, capStderrFile(path, 1))
+
+		backup, err := os.ReadFile(path + ".1")
+		require.NoError(t, err)
+		require.Equal(t, "last run", string(backup))
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Empty(t, content)
+	})
+
+	t.Run("over cap copies to backup and truncates, appends continue", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "observiq_collector.err")
+		big := bytes.Repeat([]byte("x"), stderrMaxBytes)
+		require.NoError(t, os.WriteFile(path, big, 0660))
+
+		// Hold an O_APPEND handle across the cap, mirroring the stderr handle.
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0660)
+		require.NoError(t, err)
+		defer f.Close()
+
+		require.NoError(t, capStderrFile(path, stderrMaxBytes))
+
+		backup, err := os.ReadFile(path + ".1")
+		require.NoError(t, err)
+		require.Equal(t, big, backup)
+
+		// The held handle must keep working and write at the new EOF.
+		_, err = f.WriteString("after truncate")
+		require.NoError(t, err)
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "after truncate", string(content))
+	})
+}

--- a/scripts/support/create-support-bundle.bat
+++ b/scripts/support/create-support-bundle.bat
@@ -44,6 +44,9 @@ if /I "%response%"=="n" (
     if exist "%collector_dir%\log\observiq_collector.err" (
         xcopy /Y "%collector_dir%\log\observiq_collector.err" "%output_dir%\"
     )
+    if exist "%collector_dir%\log\observiq_collector.err.1" (
+        xcopy /Y "%collector_dir%\log\observiq_collector.err.1" "%output_dir%\"
+    )
     xcopy /Y "%collector_dir%\log\collector.log" "%output_dir%\"
 )
 

--- a/scripts/support/create-support-bundle.ps1
+++ b/scripts/support/create-support-bundle.ps1
@@ -54,6 +54,10 @@ if ($response -eq "n") {
         Write-Host "Adding $collector_dir\log\observiq_collector.err"
         Copy-Item "$collector_dir\log\observiq_collector.err" -Destination "$output_dir\" -Force
     }
+    if (Test-Path "$collector_dir\log\observiq_collector.err.1") {
+        Write-Host "Adding $collector_dir\log\observiq_collector.err.1"
+        Copy-Item "$collector_dir\log\observiq_collector.err.1" -Destination "$output_dir\" -Force
+    }
     Write-Host "Adding $collector_dir\log\collector.log"
     Copy-Item "$collector_dir\log\collector.log" -Destination "$output_dir\" -Force
 }

--- a/scripts/support/create-support-bundle.sh
+++ b/scripts/support/create-support-bundle.sh
@@ -260,6 +260,11 @@ function bundle_files() {
             tar --append --file="$tar_filename" -C "$log_dir" observiq_collector.err
             info "Added file $(fg_cyan "$err_file")$(reset) to the tar file."
         fi
+        err_backup_file="$log_dir/observiq_collector.err.1"
+        if [ -f "$err_backup_file" ]; then
+            tar --append --file="$tar_filename" -C "$log_dir" observiq_collector.err.1
+            info "Added file $(fg_cyan "$err_backup_file")$(reset) to the tar file."
+        fi
     fi
 
     # Check if the files exist, if yes append them to the tar file


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Implement a custom handler to cap the size the `observer_collector.err` can grow to. This also includes a mechanism for rolling the file over when it gets too big. We only manage 1 roll over file to avoid the issue of unbounded growth.

Updates this functionality for the Windows service.

### Testing
Changes can be validated by installing an MSI built from this branch. Two behaviors can be verified: file watching and rollover. 
- After installing the service, turn it off and add some content to the file. On restart you'll see a new file `observiq_collector.err.1` is created containing the contents of the original.
- While the collector is running, put 10MB of content into the standard file. After ~10 seconds you'll see the file contents are moved to `observiq_collector.err.1`.

Run the support bundle script to verify the `observiq_collector.err.1` file is collected.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
