### PR TITLE
fix: Suppress Active Directory plugin parse_logs error spam

### DIFF
--- a/plugins/active_directory_logs.yaml
+++ b/plugins/active_directory_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: Active Directory Logs
 description: Log parser for Active Directory
 parameters:
@@ -59,6 +59,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
           parse_from: body
+          on_error: send_quiet
         {{ end }}
     windows_event_log/web_services:
       channel: "Active Directory Web Services"
@@ -79,6 +80,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
           parse_from: body
+          on_error: send_quiet
         {{ end }}
     {{ if .enable_dns_server }}
     windows_event_log/dns:
@@ -100,6 +102,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
           parse_from: body
+          on_error: send_quiet
         {{ end }}
     {{ end }}
     {{ if .enable_dfs_replication }}
@@ -122,6 +125,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
           parse_from: body
+          on_error: send_quiet
         {{ end }}
     {{ end }}
     {{ if .enable_file_replication }}
@@ -144,6 +148,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>.*?)\s+(?P<level>.*?)\s+(?P<source>.*?)\s+(?P<event_id>.*?)\s+(?P<message>.*)$'
           parse_from: body
+          on_error: send_quiet
         {{ end }}
     {{ end }}
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
AD plugin logs were inducing the situation causing the collector's standard error file to grow uncontrolled. While the log shouldn't surpass a maximum size anymore, this change resolves the root issue with the AD plugin.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
