### PR TITLE
chore: stop publishing goreleaser default archives from the docker config (PIPE-1388)

### DIFF
--- a/.goreleaser-docker.yml
+++ b/.goreleaser-docker.yml
@@ -36,6 +36,21 @@ builds:
       - arm64
       - ppc64le
 
+# Container images and manifests are the only intended output of this config.
+# Without the three stanzas below, goreleaser applies its defaults: a tar.gz per
+# linux arch, a checksums file over them, and an upload of all of it to the GitHub
+# release for the tag. Those archives hold just the binaries and goreleaser's default
+# doc files, so they duplicate (less completely) the archives .goreleaser.yml already
+# publishes, and they ship unsigned.
+archives:
+  - formats: [binary]
+
+checksum:
+  disable: true
+
+release:
+  disable: true
+
 # Build container images with docker buildx (mutli arch builds).
 dockers:
   - id: scratch-amd64


### PR DESCRIPTION
### Proposed Change

In the absence of `archives:`, `checksum:`, or `release:` blocks, goreleaser applies its defaults. Alongside the container images, it uploads a tar.gz per linux arch plus a checksums file to the GitHub release. Those tarballs are an unsigned, thinner duplicate of what `.goreleaser.yml` already ships.

The container images and manifests are unaffected: they consume the `collector` and `container-init` binaries by build id, which the change leaves in place.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
