### PR TITLE
fix: Keep GOMAXPROCS at node core count under container CPU limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,13 @@ verify-manifest:
 	cd $(BUILD_DIR) && go mod tidy
 	# Compile with the same build tags as the release build ($(AGENT_BUILD_TAGS))
 	# so the gate exercises exactly what `make agent` ships.
-	cd $(BUILD_DIR) && CGO_ENABLED=0 go build -tags "$(AGENT_BUILD_TAGS)" -o /dev/null .
+	cd $(BUILD_DIR) && CGO_ENABLED=0 go build -tags "$(AGENT_BUILD_TAGS)" -o verify-binary .
+	# The GOMAXPROCS runtime default is carried by a //go:debug directive in
+	# $(AGENT_MAIN); it only takes effect if that file survives into the ocb
+	# main package. Assert it made it into the built binary.
+	cd $(BUILD_DIR) && go version -m verify-binary | grep -q 'containermaxprocs=0' || \
+		(echo "built binary is missing DefaultGODEBUG containermaxprocs=0 (lost $(AGENT_MAIN)?)"; exit 1)
+	rm -f $(BUILD_DIR)/verify-binary
 
 # Builds the collector for the current GOOS/GOARCH pair using ocb.
 .PHONY: agent

--- a/internal/extension/opampconnectionextension/cmd/main/main.go
+++ b/internal/extension/opampconnectionextension/cmd/main/main.go
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 // Go 1.25 made GOMAXPROCS container-aware: under a cgroup CPU limit it is
-// clamped to the limit (floor 2) instead of the node's core count. Every pod
+// clamped to max(2, ceil(limit)) instead of the node's core count. Every pod
 // on GKE Autopilot carries a CFS limit, so collectors there lost most of
 // their parallelism and Pub/Sub ingestion regressed (slow drains, expired
 // ack deadlines, redelivery storms). Keep the pre-1.25 behavior; operators
-// can still override with the GOMAXPROCS env var, which always wins over
-// these defaults.
+// can still override with the GOMAXPROCS env var (always wins) or opt the
+// clamp back in per deployment with GODEBUG=containermaxprocs=1.
+//
+// updatemaxprocs is deliberately left at its default: with the cgroup
+// consult disabled it only tracks CPU-affinity changes, and disabling it
+// would freeze GOMAXPROCS at startup for anyone who opts the clamp back
+// in via GODEBUG (stale under in-place pod resize).
 //
 //go:debug containermaxprocs=0
-//go:debug updatemaxprocs=0
 
 // Package main is the entry point for the ocb-built BDOT Collector. The
 // `agent` Make target copies this file over ocb's generated main.go after
@@ -43,6 +47,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	goruntime "runtime"
 	"strings"
 	_ "time/tzdata"
 
@@ -75,6 +80,11 @@ func main() {
 		fmt.Println("built at:", version.Date())
 		return
 	}
+
+	// Support triage for CPU-limited containers: makes the effective
+	// parallelism visible without GODEBUG=schedtrace.
+	log.Printf("go runtime: GOMAXPROCS=%d NumCPU=%d GOMAXPROCS_env=%q GODEBUG_env=%q",
+		goruntime.GOMAXPROCS(0), goruntime.NumCPU(), os.Getenv("GOMAXPROCS"), os.Getenv("GODEBUG"))
 
 	factories, err := components()
 	if err != nil {

--- a/internal/extension/opampconnectionextension/cmd/main/main.go
+++ b/internal/extension/opampconnectionextension/cmd/main/main.go
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Go 1.25 made GOMAXPROCS container-aware: under a cgroup CPU limit it is
+// clamped to the limit (floor 2) instead of the node's core count. Every pod
+// on GKE Autopilot carries a CFS limit, so collectors there lost most of
+// their parallelism and Pub/Sub ingestion regressed (slow drains, expired
+// ack deadlines, redelivery storms). Keep the pre-1.25 behavior; operators
+// can still override with the GOMAXPROCS env var, which always wins over
+// these defaults.
+//
+//go:debug containermaxprocs=0
+//go:debug updatemaxprocs=0
+
 // Package main is the entry point for the ocb-built BDOT Collector. The
 // `agent` Make target copies this file over ocb's generated main.go after
 // `builder --skip-compilation` runs; `go build` then compiles it together


### PR DESCRIPTION
### Proposed Change

Go 1.25 made GOMAXPROCS container-aware: under a cgroup CPU limit it defaults to `max(2, ceil(limit))` instead of the node's logical core count ([release notes](https://go.dev/doc/go1.25), [blog](https://go.dev/blog/container-aware-gomaxprocs), [golang/go#73193](https://github.com/golang/go/issues/73193)). BDOT picked this up when the toolchain moved from Go 1.24 to 1.25 in v1.94.0, an unreviewed runtime-behavior change for every CPU-limited container.

On GKE Autopilot every pod carries a CFS CPU limit, so collectors there silently lost most of their parallelism. Observed impact on a large Pub/Sub ingestion fleet upgrading v1.92.2 → v1.96.0/v1.100.0: throughput regression, sustained expired ack deadlines (300–999/s), redelivery storms, and an unbounded backlog (275M undelivered) — restored on rollback to v1.92.2 (clean A/B/A). Verified on shipped images under `--cpus=2` (via `GODEBUG=schedtrace`): `bindplane-agent:1.92.2` → `gomaxprocs=14` (node cores), `1.100.0` through `1.104.0` → `gomaxprocs=2`.

**Both directions stay available per deployment, no rebuild:**
- `GOMAXPROCS=<n>` env — pin an explicit value (always wins).
- `GODEBUG=containermaxprocs=1` env opt the container-aware clamp back in. `updatemaxprocs` is deliberately left at its default so this opt-in keeps tracking limit changes (Kubernetes in-place pod resize); pinning it would freeze GOMAXPROCS at startup for those users while buying nothing for the default case (with the cgroup consult disabled, the updater only tracks CPU affinity).
- The `cgroup_runtime` extension (already compiled into BDOT, wraps uber-go/automaxprocs) remains the config-driven opt-in for limit-aware GOMAXPROCS + GOMEMLIMIT.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

---
Supersedes #3594 (same commits; moved off the `bpop-5001` branch, which is being repurposed for the Pub/Sub receiver hardening work the ticket actually covers). Review context: see #3594.