### PR TITLE
refactor(ci): extract reusable windows MSI build workflow (BPOP-5780)

### DIFF
--- a/.github/workflows/build-signed-windows.yml
+++ b/.github/workflows/build-signed-windows.yml
@@ -1,0 +1,139 @@
+name: build-signed-windows
+
+# Reusable workflow that builds the Windows collector + updater binaries, packages
+# them into an MSI, and code-signs the release artifacts with DigiCert KeyLocker.
+#
+# This job used to be copy-pasted into release.yml, release-test.yml and
+# manual_msi_build.yml. It lives here so the signing steps are defined once.
+#
+# Callers must pass `secrets: inherit` -- `secrets: inherit` is declared by the
+# caller, not by this workflow.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Collector version, with the leading v (e.g. v1.2.3)"
+        required: true
+        type: string
+      build_amd64:
+        description: "Build the amd64 MSI"
+        required: false
+        type: boolean
+        default: true
+      build_arm64:
+        description: "Build the arm64 MSI"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        shell: bash
+        run: |
+          matrix='{"include":[]}'
+          if [ "${{ inputs.build_amd64 }}" = "true" ]; then
+            matrix=$(echo "$matrix" | jq -c '.include += [{"arch":"amd64","msi_name":"observiq-otel-collector.msi","msi_arch":"x64"}]')
+          fi
+          if [ "${{ inputs.build_arm64 }}" = "true" ]; then
+            matrix=$(echo "$matrix" | jq -c '.include += [{"arch":"arm64","msi_name":"observiq-otel-collector-arm64.msi","msi_arch":"arm64"}]')
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build-msi:
+    needs: setup
+    runs-on: windows-2022
+    strategy:
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: internal/extension/opampconnectionextension/go.mod
+          cache-dependency-path: "**/go.sum"
+      - name: Install ocb
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          shell: bash
+          command: make install-ocb
+      - name: Prepare Release Dependencies
+        run: make release-prep "CURR_VERSION=${VERSION#v}"
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+      - name: Build Windows Binaries
+        run: make build-windows-${{ matrix.arch }}
+      - name: Copy Shared Files to MSI Build Directory
+        run: |
+          cp -r release_deps/plugins windows/
+          cp config/example.yaml windows/config.yaml
+          cp config/logging.yaml windows/logging.yaml
+          cp LICENSE windows/LICENSE
+          cp release_deps/VERSION.txt windows/VERSION.txt
+      - name: Copy Binaries
+        run: |
+          cp dist/collector_windows_${{ matrix.arch }}.exe windows/observiq-otel-collector.exe
+          cp dist/updater_windows_${{ matrix.arch }}.exe windows/updater.exe
+      # HACK: Copy build directory to C drive to avoid this error, since there must be a relative path from the tempdir that go-msi uses
+      # for the MSI to build properly
+      - name: Copy Build Dir
+        run: |
+          cp -r windows C:/build
+          echo "C:/build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      # Installs go-msi and wix.
+      - name: Install Build Tools
+        run: |
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
+          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
+          unzip wix314-binaries.zip
+        working-directory: C:/build
+      - name: Build MSI
+        run: go-msi.exe make -m ${{ matrix.msi_name }} --version ${{ inputs.version }} --arch ${{ matrix.msi_arch }}
+        working-directory: C:/build
+      - name: Install DigiCert Client tools from Github Custom Actions marketplace
+        uses: digicert/ssm-code-signing@v1.0.0
+      - name: Set up certificate
+        run: |
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+        shell: bash
+      - name: Set variables for signing
+        run: |
+          {
+            echo "SM_HOST=${{ secrets.SM_HOST }}"
+            echo "SM_API_KEY=${{ secrets.SM_API_KEY }}"
+            echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12"
+            echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}"
+          } >> "$GITHUB_ENV"
+        shell: bash
+      # The DigiCert action drops its PKCS#11 config under the runner user's temp
+      # directory. Resolve it once from LOCALAPPDATA instead of hardcoding the
+      # 8.3 short path, and fail loudly if the layout ever changes.
+      - name: Resolve smctl signing config
+        shell: pwsh
+        run: |
+          $cfg = Join-Path $env:LOCALAPPDATA 'Temp\smtools-windows-x64\pkcs11properties.cfg'
+          if (-not (Test-Path $cfg)) {
+            throw "smctl PKCS#11 config not found at $cfg"
+          }
+          "SMCTL_CONFIG=$cfg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Sign MSI
+        run: smctl sign --keypair-alias %KEYPAIR_ALIAS% --input C:/build/${{ matrix.msi_name }} --config-file %SMCTL_CONFIG%
+        shell: cmd
+        env:
+          KEYPAIR_ALIAS: ${{ secrets.BDOT_DIGICERT_KEYPAIR_ALIAS }}
+      - name: Upload MSI
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.msi_name }}
+          path: C:/build/${{ matrix.msi_name }}
+          # Short lived because Go Releaser will upload the msi to a release (github release, gcs, etc)
+          retention-days: 1

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -16,100 +16,10 @@ on:
         default: true
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        shell: bash
-        run: |
-          matrix='{"include":[]}'
-          if [ "${{ inputs.build_amd64 }}" = "true" ]; then
-            matrix=$(echo $matrix | jq -c '.include += [{"arch":"amd64","msi_name":"observiq-otel-collector.msi","msi_arch":"x64"}]')
-          fi
-          if [ "${{ inputs.build_arm64 }}" = "true" ]; then
-            matrix=$(echo $matrix | jq -c '.include += [{"arch":"arm64","msi_name":"observiq-otel-collector-arm64.msi","msi_arch":"arm64"}]')
-          fi
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
-
   build-msi:
-    needs: setup
-    runs-on: windows-2022
-    strategy:
-      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: internal/extension/opampconnectionextension/go.mod
-      - name: Install ocb
-        uses: nick-fields/retry@v4
-        with:
-          max_attempts: 3
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          shell: bash
-          command: make install-ocb
-      - name: Prepare Release Dependencies
-        run: make release-prep CURR_VERSION=${VERSION#v}
-        shell: bash
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-      - name: Build Windows Binaries
-        run: make build-windows-${{ matrix.arch }}
-      - name: Copy Shared Files to MSI Build Directory
-        run: |
-          cp -r release_deps/plugins windows/
-          cp config/example.yaml windows/config.yaml
-          cp config/logging.yaml windows/logging.yaml
-          cp LICENSE windows/LICENSE
-          cp release_deps/VERSION.txt windows/VERSION.txt
-      - name: Copy Binaries
-        run: |
-          cp dist/collector_windows_${{ matrix.arch }}.exe windows/observiq-otel-collector.exe
-          cp dist/updater_windows_${{ matrix.arch }}.exe windows/updater.exe
-      # HACK: Copy build directory to C drive to avoid this error, since there must be a relative path from the tempdir that go-msi uses
-      # for the MSI to build properly
-      - name: Copy Build Dir
-        run: |
-          cp -r windows C:/build
-          echo "C:/build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      # Installs go-msi and wix.
-      - name: Install Build Tools
-        run: |
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
-          unzip wix314-binaries.zip
-        working-directory: C:/build
-      - name: Build MSI
-        run: go-msi.exe make -m ${{ matrix.msi_name }} --version ${{ github.event.inputs.version }} --arch ${{ matrix.msi_arch }}
-        working-directory: C:/build
-      - name: Install DigiCert Client tools from Github Custom Actions marketplace
-        uses: digicert/ssm-code-signing@v1.0.0
-      - name: Set up certificate
-        run: |
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-        shell: bash
-      - name: Set variables for signing
-        id: variables
-        run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-        shell: bash
-      - name: Sign MSI
-        run: |
-          smctl sign --keypair-alias ${{ secrets.BDOT_DIGICERT_KEYPAIR_ALIAS }} --input C:/build/${{ matrix.msi_name }} --config-file C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg
-        shell: cmd
-      - name: Upload MSI
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.msi_name }}
-          path: C:/build/${{ matrix.msi_name }}
-          # Short lived because this is meant as an action for developers
-          retention-days: 1
+    uses: ./.github/workflows/build-signed-windows.yml
+    with:
+      version: ${{ inputs.version }}
+      build_amd64: ${{ inputs.build_amd64 }}
+      build_arm64: ${{ inputs.build_arm64 }}
+    secrets: inherit

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,90 +9,10 @@ on:
 
 jobs:
   build-msi:
-    runs-on: windows-2022
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-            msi_name: observiq-otel-collector.msi
-            msi_arch: x64
-          - arch: arm64
-            msi_name: observiq-otel-collector-arm64.msi
-            msi_arch: arm64
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: internal/extension/opampconnectionextension/go.mod
-      - name: Install ocb
-        uses: nick-fields/retry@v4
-        with:
-          max_attempts: 3
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          shell: bash
-          command: make install-ocb
-      - name: Prepare Release Dependencies
-        run: make release-prep CURR_VERSION=${VERSION#v}
-        shell: bash
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-      - name: Build Windows Binaries
-        run: make build-windows-${{ matrix.arch }}
-      - name: Copy Shared Files to MSI Build Directory
-        run: |
-          cp -r release_deps/plugins windows/
-          cp config/example.yaml windows/config.yaml
-          cp config/logging.yaml windows/logging.yaml
-          cp LICENSE windows/LICENSE
-          cp release_deps/VERSION.txt windows/VERSION.txt
-      - name: Copy Binaries
-        run: |
-          cp dist/collector_windows_${{ matrix.arch }}.exe windows/observiq-otel-collector.exe
-          cp dist/updater_windows_${{ matrix.arch }}.exe windows/updater.exe
-      # HACK: Copy build directory to C drive to avoid this error, since there must be a relative path from the tempdir that go-msi uses
-      # for the MSI to build properly
-      - name: Copy Build Dir
-        run: |
-          cp -r windows C:/build
-          echo "C:/build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      # Installs go-msi and wix.
-      - name: Install Build Tools
-        run: |
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
-          unzip wix314-binaries.zip
-        working-directory: C:/build
-      - name: Build MSI
-        run: go-msi.exe make -m ${{ matrix.msi_name }} --version ${{ github.event.inputs.version }} --arch ${{ matrix.msi_arch }}
-        working-directory: C:/build
-      - name: Install DigiCert Client tools from Github Custom Actions marketplace
-        uses: digicert/ssm-code-signing@v1.0.0
-      - name: Set up certificate
-        run: |
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-        shell: bash
-      - name: Set variables for signing
-        id: variables
-        run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-        shell: bash
-      - name: Sign MSI
-        run: |
-          smctl sign --keypair-alias ${{ secrets.BDOT_DIGICERT_KEYPAIR_ALIAS }} --input C:/build/${{ matrix.msi_name }} --config-file C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg
-        shell: cmd
-      - name: Upload MSI
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.msi_name }}
-          path: C:/build/${{ matrix.msi_name }}
-          retention-days: 1
+    uses: ./.github/workflows/build-signed-windows.yml
+    with:
+      version: ${{ inputs.version }}
+    secrets: inherit
 
   release-test:
     runs-on: ubuntu-latest-32-cores

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,92 +6,10 @@ on:
 
 jobs:
   build-msi:
-    runs-on: windows-2022
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-            msi_name: observiq-otel-collector.msi
-            msi_arch: x64
-          - arch: arm64
-            msi_name: observiq-otel-collector-arm64.msi
-            msi_arch: arm64
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: internal/extension/opampconnectionextension/go.mod
-          cache-dependency-path: "**/go.sum"
-      - name: Install ocb
-        uses: nick-fields/retry@v4
-        with:
-          max_attempts: 3
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          shell: bash
-          command: make install-ocb
-      - name: Prepare Release Dependencies
-        run: make release-prep CURR_VERSION=${VERSION#v}
-        shell: bash
-        env:
-          VERSION: ${{ github.ref_name }}
-      - name: Build Windows Binaries
-        run: make build-windows-${{ matrix.arch }}
-      - name: Copy Shared Files to MSI Build Directory
-        run: |
-          cp -r release_deps/plugins windows/
-          cp config/example.yaml windows/config.yaml
-          cp config/logging.yaml windows/logging.yaml
-          cp LICENSE windows/LICENSE
-          cp release_deps/VERSION.txt windows/VERSION.txt
-      - name: Copy Binaries
-        run: |
-          cp dist/collector_windows_${{ matrix.arch }}.exe windows/observiq-otel-collector.exe
-          cp dist/updater_windows_${{ matrix.arch }}.exe windows/updater.exe
-      # HACK: Copy build directory to C drive to avoid this error, since there must be a relative path from the tempdir that go-msi uses
-      # for the MSI to build properly
-      - name: Copy Build Dir
-        run: |
-          cp -r windows C:/build
-          echo "C:/build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      # Installs go-msi and wix.
-      - name: Install Build Tools
-        run: |
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
-          curl -f -L --retry 3 --retry-delay 5 --retry-connrefused -o wix314-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip
-          unzip wix314-binaries.zip
-        working-directory: C:/build
-      - name: Build MSI
-        run: go-msi.exe make -m ${{ matrix.msi_name }} --version ${{ github.ref_name }} --arch ${{ matrix.msi_arch }}
-        working-directory: C:/build
-      - name: Install DigiCert Client tools from Github Custom Actions marketplace
-        uses: digicert/ssm-code-signing@v1.0.0
-      - name: Set up certificate
-        run: |
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-        shell: bash
-      - name: Set variables for signing
-        id: variables
-        run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-        shell: bash
-      - name: Sign MSI
-        run: |
-          smctl sign --keypair-alias ${{ secrets.BDOT_DIGICERT_KEYPAIR_ALIAS }} --input C:/build/${{ matrix.msi_name }} --config-file C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg
-        shell: cmd
-      - name: Upload MSI
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.msi_name }}
-          path: C:/build/${{ matrix.msi_name }}
-          # Short lived because Go Releaser will upload the msi to a release (github release, gcs, etc)
-          retention-days: 1
+    uses: ./.github/workflows/build-signed-windows.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
 
   release:
     needs: [build-msi]


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Pure refactor, no behavior change. The ~15-step build-msi job was copy-pasted into release.yml, release-test.yml and manual_msi_build.yml and had already drifted. Moves it to .github/workflows/build-signed-windows.yml as a workflow_call target. Two incidental cleanups: the smctl PKCS#11 config path is resolved from LOCALAPPDATA instead of the hardcoded RUNNER~1 short path, and the keypair alias goes through step env instead of being interpolated into a cmd line.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed